### PR TITLE
Phase 2: Playwright adapter and event observability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,14 +72,16 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
-      - name: Build Core Library
-        run: pnpm build:core
+      - name: Build All Packages
+        run: pnpm build
 
       - name: Archive Build Artifact
         uses: actions/upload-artifact@v4
         with:
           name: chaos-maker-dist
-          path: packages/core/dist/
+          path: |
+            packages/core/dist/
+            packages/playwright/dist/
 
   e2e-test:
     name: E2E Tests
@@ -105,7 +107,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: chaos-maker-dist
-          path: packages/core/dist/
+          path: .
 
       - name: Cache Playwright Browsers
         id: playwright-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: chaos-maker-dist
-          path: .
+          path: packages
 
       - name: Cache Playwright Browsers
         id: playwright-cache

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -7,6 +7,7 @@
     "report": "playwright show-report"
   },
   "devDependencies": {
+    "@chaos-maker/playwright": "workspace:*",
     "@playwright/test": "^1.45.0",
     "http-server": "^14.1.1"
   }

--- a/e2e-tests/tests/resilience.spec.ts
+++ b/e2e-tests/tests/resilience.spec.ts
@@ -1,12 +1,9 @@
 import { test, expect } from '@playwright/test';
-import type { ChaosConfig } from '../../packages/core/src/config';
-import * as fs from 'fs';
-import * as path from 'path';
+import { injectChaos, getChaosLog } from '@chaos-maker/playwright';
+import type { ChaosConfig } from '@chaos-maker/playwright';
 
-// Define the base URL from our playwright.config.ts
 const BASE_URL = 'http://127.0.0.1:8080';
 
-// Test 1: The "Happy Path" - (This test remains unchanged)
 test('should fetch and display data successfully', async ({ page }) => {
   await page.goto(BASE_URL);
   await page.click('#fetch-data');
@@ -14,10 +11,8 @@ test('should fetch and display data successfully', async ({ page }) => {
   await expect(page.locator('#result')).toContainText('"userId": 1');
 });
 
-// Test 2: The "Chaos Path" - (This is the updated test)
 test('should display an error message when the API fails', async ({ page }) => {
-  
-  const apiFailureConfig: ChaosConfig = {
+  const config: ChaosConfig = {
     network: {
       failures: [{
         urlPattern: 'jsonplaceholder.typicode.com/todos/1',
@@ -27,30 +22,15 @@ test('should display an error message when the API fails', async ({ page }) => {
     },
   };
 
-  // 1. Read the content of the built library file into a string.
-  //    The path is relative to the test file's location.
-  const scriptPath = path.resolve(__dirname, '../../packages/core/dist/chaos-maker.umd.js');
-  const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
+  await injectChaos(page, config);
 
-  // 2. Use a SINGLE addInitScript call to perform all setup atomically.
-  await page.addInitScript((args) => {
-    // This code runs in the browser before any other scripts on the page.
-    
-    // a. Set the config object on the window
-    (window as any).__CHAOS_CONFIG__ = args.config;
-    
-    // b. Use eval() to execute the script content synchronously.
-    // This guarantees it runs and patches 'fetch' before the app's code.
-    eval(args.scriptContent);
-
-  }, { config: apiFailureConfig, scriptContent: scriptContent });
-
-
-  // 3. Run the test
   await page.goto(BASE_URL);
   await page.click('#fetch-data');
 
-  // 4. Assert the resilient behavior
   await expect(page.locator('#status')).toHaveText('Error!');
   await expect(page.locator('#result')).toContainText('Failed to fetch data: API Error: 503');
+
+  const log = await getChaosLog(page);
+  expect(log.length).toBeGreaterThan(0);
+  expect(log.some(e => e.type === 'network:failure' && e.applied)).toBe(true);
 });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "lint": "eslint .",
     "build:core": "pnpm --filter @chaos-maker/core build",
+    "build:playwright": "pnpm --filter @chaos-maker/playwright build",
+    "build": "pnpm build:core && pnpm build:playwright",
     "dev:core": "pnpm --filter @chaos-maker/core dev",
     "test": "pnpm --filter @chaos-maker/core test",
     "prepare": "husky"

--- a/packages/core/src/ChaosMaker.ts
+++ b/packages/core/src/ChaosMaker.ts
@@ -1,11 +1,13 @@
 import { ChaosConfig } from './config';
 import { validateConfig } from './validation';
+import { ChaosEventEmitter, ChaosEvent, ChaosEventType, ChaosEventListener } from './events';
 import { patchFetch } from './interceptors/networkFetch';
 import { patchXHR, patchXHROpen } from './interceptors/networkXHR';
 import { attachDomAssailant } from './interceptors/domAssailant';
 
 export class ChaosMaker {
   private config: ChaosConfig;
+  private emitter: ChaosEventEmitter;
   private originalFetch?: typeof window.fetch;
   private originalXhrSend?: (body?: Document | XMLHttpRequestBodyInit) => void;
   private originalXhrOpen?: (method: string, url: string | URL) => void;
@@ -13,31 +15,45 @@ export class ChaosMaker {
 
   constructor(config: ChaosConfig) {
     this.config = validateConfig(config);
+    this.emitter = new ChaosEventEmitter();
     console.log('Chaos Maker initialized with config:', config);
+  }
+
+  public on(type: ChaosEventType | '*', listener: ChaosEventListener): void {
+    this.emitter.on(type, listener);
+  }
+
+  public off(type: ChaosEventType | '*', listener: ChaosEventListener): void {
+    this.emitter.off(type, listener);
+  }
+
+  public getLog(): ChaosEvent[] {
+    return this.emitter.getLog();
+  }
+
+  public clearLog(): void {
+    this.emitter.clearLog();
   }
 
   public start(): void {
     console.log('🛠️ Chaos Maker ENGAGED 🛠️');
 
     if (this.config.network) {
-      // Patch Fetch
       this.originalFetch = window.fetch;
-      window.fetch = patchFetch(this.originalFetch.bind(window), this.config.network);
+      window.fetch = patchFetch(this.originalFetch.bind(window), this.config.network, this.emitter);
 
-      // Patch XHR
       this.originalXhrOpen = window.XMLHttpRequest.prototype.open;
       window.XMLHttpRequest.prototype.open = patchXHROpen(this.originalXhrOpen);
-      
+
       this.originalXhrSend = window.XMLHttpRequest.prototype.send;
-      window.XMLHttpRequest.prototype.send = patchXHR(this.originalXhrSend, this.config.network);
+      window.XMLHttpRequest.prototype.send = patchXHR(this.originalXhrSend, this.config.network, this.emitter);
     }
-    // --- UI Chaos (new) ---
+
     if (this.config.ui) {
-      this.domObserver = attachDomAssailant(this.config.ui);
-      // Start observing the entire document body for new elements
+      this.domObserver = attachDomAssailant(this.config.ui, this.emitter);
       this.domObserver.observe(document.body, {
-        childList: true, // Watch for added/removed nodes
-        subtree: true,   // Watch all descendants
+        childList: true,
+        subtree: true,
       });
       console.log('UI Assailant is now observing the DOM.');
     }
@@ -55,9 +71,8 @@ export class ChaosMaker {
     if (this.originalXhrOpen) {
       window.XMLHttpRequest.prototype.open = this.originalXhrOpen;
     }
-    // --- Stop UI Chaos (new) ---
     if (this.domObserver) {
-      this.domObserver.disconnect(); // Stop observing
+      this.domObserver.disconnect();
       console.log('UI Assailant has stopped observing.');
     }
   }

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -20,6 +20,8 @@ export class ChaosEventEmitter {
   private listeners: Map<string, Set<ChaosEventListener>> = new Map();
   private log: ChaosEvent[] = [];
 
+  constructor(private readonly maxLogEntries = 2000) {}
+
   on(type: ChaosEventType | '*', listener: ChaosEventListener): void {
     if (!this.listeners.has(type)) {
       this.listeners.set(type, new Set());
@@ -33,20 +35,12 @@ export class ChaosEventEmitter {
 
   emit(event: ChaosEvent): void {
     this.log.push(event);
-
-    const typeListeners = this.listeners.get(event.type);
-    if (typeListeners) {
-      for (const listener of typeListeners) {
-        listener(event);
-      }
+    if (this.log.length > this.maxLogEntries) {
+      this.log.shift();
     }
 
-    const wildcardListeners = this.listeners.get('*');
-    if (wildcardListeners) {
-      for (const listener of wildcardListeners) {
-        listener(event);
-      }
-    }
+    this.notify(this.listeners.get(event.type), event);
+    this.notify(this.listeners.get('*'), event);
   }
 
   getLog(): ChaosEvent[] {
@@ -55,5 +49,16 @@ export class ChaosEventEmitter {
 
   clearLog(): void {
     this.log = [];
+  }
+
+  private notify(listeners: Set<ChaosEventListener> | undefined, event: ChaosEvent): void {
+    if (!listeners) return;
+    for (const listener of listeners) {
+      try {
+        listener(event);
+      } catch {
+        // prevent listener errors from breaking emitter flow
+      }
+    }
   }
 }

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,0 +1,59 @@
+export type ChaosEventType = 'network:failure' | 'network:latency' | 'ui:assault';
+
+export interface ChaosEvent {
+  type: ChaosEventType;
+  timestamp: number;
+  applied: boolean;
+  detail: {
+    url?: string;
+    method?: string;
+    statusCode?: number;
+    delayMs?: number;
+    selector?: string;
+    action?: string;
+  };
+}
+
+export type ChaosEventListener = (event: ChaosEvent) => void;
+
+export class ChaosEventEmitter {
+  private listeners: Map<string, Set<ChaosEventListener>> = new Map();
+  private log: ChaosEvent[] = [];
+
+  on(type: ChaosEventType | '*', listener: ChaosEventListener): void {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set());
+    }
+    this.listeners.get(type)!.add(listener);
+  }
+
+  off(type: ChaosEventType | '*', listener: ChaosEventListener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  emit(event: ChaosEvent): void {
+    this.log.push(event);
+
+    const typeListeners = this.listeners.get(event.type);
+    if (typeListeners) {
+      for (const listener of typeListeners) {
+        listener(event);
+      }
+    }
+
+    const wildcardListeners = this.listeners.get('*');
+    if (wildcardListeners) {
+      for (const listener of wildcardListeners) {
+        listener(event);
+      }
+    }
+  }
+
+  getLog(): ChaosEvent[] {
+    return [...this.log];
+  }
+
+  clearLog(): void {
+    this.log = [];
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,15 +2,17 @@ import { ChaosMaker } from './ChaosMaker';
 import { ChaosConfig, NetworkFailureConfig, NetworkLatencyConfig, NetworkConfig, UiAssaultConfig, UiConfig } from './config';
 import { ChaosConfigError } from './errors';
 import { validateConfig } from './validation';
+import { ChaosEvent, ChaosEventType, ChaosEventListener, ChaosEventEmitter } from './events';
 
-export { ChaosMaker, ChaosConfigError, validateConfig };
-export type { ChaosConfig, NetworkFailureConfig, NetworkLatencyConfig, NetworkConfig, UiAssaultConfig, UiConfig };
+export { ChaosMaker, ChaosConfigError, validateConfig, ChaosEventEmitter };
+export type { ChaosConfig, NetworkFailureConfig, NetworkLatencyConfig, NetworkConfig, UiAssaultConfig, UiConfig, ChaosEvent, ChaosEventType, ChaosEventListener };
 
 // --- NEW INTERFACE ---
 interface ChaosUtilsApi {
   instance: ChaosMaker | null;
   start: (config: ChaosConfig) => { success: boolean; message: string };
   stop: () => { success: boolean; message: string };
+  getLog: () => ChaosEvent[];
 }
 
 // --- Global API & Auto-Start Logic ---
@@ -42,6 +44,13 @@ if (typeof window !== 'undefined') {
         return { success: true, message: "Chaos stopped" };
       }
       return { success: false, message: "No chaos instance to stop" };
+    },
+
+    getLog: () => {
+      if (chaosUtilsApi.instance) {
+        return chaosUtilsApi.instance.getLog();
+      }
+      return [];
     }
   };
   

--- a/packages/core/src/interceptors/domAssailant.ts
+++ b/packages/core/src/interceptors/domAssailant.ts
@@ -1,16 +1,22 @@
 import { UiConfig, UiAssaultConfig } from '../config';
 import { shouldApplyChaos } from '../utils';
+import { ChaosEventEmitter } from '../events';
 
-/**
- * Applies a specific chaos action to a given element.
- */
-function applyAssault(element: HTMLElement, assault: UiAssaultConfig) {
-  if (!shouldApplyChaos(assault.probability)) {
+function applyAssault(element: HTMLElement, assault: UiAssaultConfig, emitter?: ChaosEventEmitter) {
+  const applied = shouldApplyChaos(assault.probability);
+  emitter?.emit({
+    type: 'ui:assault',
+    timestamp: Date.now(),
+    applied,
+    detail: { selector: assault.selector, action: assault.action },
+  });
+
+  if (!applied) {
     return;
   }
 
   console.warn(`CHAOS: Applying action '${assault.action}' to element:`, element);
-  
+
   try {
     switch (assault.action) {
       case 'disable':
@@ -30,10 +36,7 @@ function applyAssault(element: HTMLElement, assault: UiAssaultConfig) {
   }
 }
 
-/**
- * Checks a given DOM node and its children against all UI assault rules.
- */
-function checkNode(node: Node, config: UiConfig) {
+function checkNode(node: Node, config: UiConfig, emitter?: ChaosEventEmitter) {
   if (node.nodeType !== Node.ELEMENT_NODE || !config.assaults) {
     return;
   }
@@ -43,47 +46,36 @@ function checkNode(node: Node, config: UiConfig) {
   for (const assault of config.assaults) {
     try {
       if (element.matches(assault.selector)) {
-        applyAssault(element, assault);
+        applyAssault(element, assault, emitter);
       }
     } catch (e) {
       console.error(`Chaos Maker: Invalid selector '${assault.selector}'`, e);
     }
 
     element.querySelectorAll(assault.selector).forEach(childEl => {
-      applyAssault(childEl as HTMLElement, assault);
+      applyAssault(childEl as HTMLElement, assault, emitter);
     });
   }
 }
 
-/**
- * Creates and returns a MutationObserver that applies UI assaults
- * based on the provided configuration.
- */
-export function attachDomAssailant(config: UiConfig): MutationObserver {
-  
-  // --- NEW LOGIC: Initial Scan ---
-  // Run a one-time scan for elements that *already* exist on the page.
+export function attachDomAssailant(config: UiConfig, emitter?: ChaosEventEmitter): MutationObserver {
   if (config.assaults) {
     console.log('CHAOS: Running initial DOM scan for existing elements...');
     for (const assault of config.assaults) {
       try {
-        // Find all elements on the page that match the selector
         document.querySelectorAll(assault.selector).forEach(element => {
-          applyAssault(element as HTMLElement, assault);
+          applyAssault(element as HTMLElement, assault, emitter);
         });
       } catch (e) {
-        // Handle invalid selectors gracefully
         console.error(`Chaos Maker: Invalid selector in initial scan '${assault.selector}'`, e);
       }
     }
   }
-  // --- END NEW LOGIC ---
 
-  // Create the observer to watch for *future* changes
   const observer = new MutationObserver((mutationsList) => {
     for (const mutation of mutationsList) {
       if (mutation.type === 'childList') {
-        mutation.addedNodes.forEach(node => checkNode(node, config));
+        mutation.addedNodes.forEach(node => checkNode(node, config, emitter));
       }
     }
   });

--- a/packages/core/src/interceptors/networkFetch.ts
+++ b/packages/core/src/interceptors/networkFetch.ts
@@ -1,7 +1,8 @@
 import { NetworkConfig } from '../config';
 import { shouldApplyChaos } from '../utils';
+import { ChaosEventEmitter } from '../events';
 
-export function patchFetch(originalFetch: typeof window.fetch, config: NetworkConfig) {
+export function patchFetch(originalFetch: typeof window.fetch, config: NetworkConfig, emitter?: ChaosEventEmitter) {
   return async (
     input: RequestInfo | URL,
     init?: RequestInit
@@ -12,16 +13,25 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
     // 1. Check for Failures
     if (config.failures) {
       for (const failure of config.failures) {
-        if (url.includes(failure.urlPattern) && shouldApplyChaos(failure.probability)) {
+        if (url.includes(failure.urlPattern)) {
           if (!failure.methods || failure.methods.includes(method)) {
-            console.warn(`CHAOS: Forcing ${failure.statusCode} for ${method} ${url}`);
-            const body = failure.body ?? JSON.stringify({ error: 'Chaos Maker Attack!' });
-            const headers = failure.headers ?? {};
-            return new Response(body, {
-              status: failure.statusCode,
-              statusText: failure.statusText ?? 'Service Unavailable (Chaos)',
-              headers,
+            const applied = shouldApplyChaos(failure.probability);
+            emitter?.emit({
+              type: 'network:failure',
+              timestamp: Date.now(),
+              applied,
+              detail: { url, method, statusCode: failure.statusCode },
             });
+            if (applied) {
+              console.warn(`CHAOS: Forcing ${failure.statusCode} for ${method} ${url}`);
+              const body = failure.body ?? JSON.stringify({ error: 'Chaos Maker Attack!' });
+              const headers = failure.headers ?? {};
+              return new Response(body, {
+                status: failure.statusCode,
+                statusText: failure.statusText ?? 'Service Unavailable (Chaos)',
+                headers,
+              });
+            }
           }
         }
       }
@@ -30,10 +40,19 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
     // 2. Check for Latency
     if (config.latencies) {
       for (const latency of config.latencies) {
-        if (url.includes(latency.urlPattern) && shouldApplyChaos(latency.probability)) {
+        if (url.includes(latency.urlPattern)) {
           if (!latency.methods || latency.methods.includes(method)) {
-            console.warn(`CHAOS: Adding ${latency.delayMs}ms latency to ${method} ${url}`);
-            await new Promise(res => setTimeout(res, latency.delayMs));
+            const applied = shouldApplyChaos(latency.probability);
+            emitter?.emit({
+              type: 'network:latency',
+              timestamp: Date.now(),
+              applied,
+              detail: { url, method, delayMs: latency.delayMs },
+            });
+            if (applied) {
+              console.warn(`CHAOS: Adding ${latency.delayMs}ms latency to ${method} ${url}`);
+              await new Promise(res => setTimeout(res, latency.delayMs));
+            }
           }
         }
       }

--- a/packages/core/src/interceptors/networkXHR.ts
+++ b/packages/core/src/interceptors/networkXHR.ts
@@ -1,7 +1,8 @@
 import { NetworkConfig } from '../config';
 import { shouldApplyChaos } from '../utils';
+import { ChaosEventEmitter } from '../events';
 
-export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyInit) => void, config: NetworkConfig) {
+export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyInit) => void, config: NetworkConfig, emitter?: ChaosEventEmitter) {
   return function (this: XMLHttpRequest, body?: Document | XMLHttpRequestBodyInit) {
     const url = (this as any)._chaos_url;
     const method = (this as any)._chaos_method;
@@ -9,34 +10,43 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
     // 1. Check for Failures
     if (config.failures) {
       for (const failure of config.failures) {
-        if (url.includes(failure.urlPattern) && shouldApplyChaos(failure.probability)) {
+        if (url.includes(failure.urlPattern)) {
           if (!failure.methods || failure.methods.includes(method)) {
-            console.warn(`CHAOS: Forcing ${failure.statusCode} for ${method} ${url}`);
-            Object.defineProperty(this, 'status', { value: failure.statusCode });
-            Object.defineProperty(this, 'statusText', {
-              value: failure.statusText ?? 'Service Unavailable (Chaos)',
+            const applied = shouldApplyChaos(failure.probability);
+            emitter?.emit({
+              type: 'network:failure',
+              timestamp: Date.now(),
+              applied,
+              detail: { url, method, statusCode: failure.statusCode },
             });
-            const responseBody = failure.body ?? JSON.stringify({ error: 'Chaos Maker Attack!' });
-            Object.defineProperty(this, 'responseText', { value: responseBody });
-            const responseHeaders = failure.headers ?? {};
-            Object.defineProperty(this, 'getResponseHeader', {
-              value: (name: string) => {
-                const key = Object.keys(responseHeaders).find(
-                  (k) => k.toLowerCase() === name.toLowerCase()
-                );
-                return key ? responseHeaders[key] : null;
-              },
-            });
-            Object.defineProperty(this, 'getAllResponseHeaders', {
-              value: () =>
-                Object.entries(responseHeaders)
-                  .map(([k, v]) => `${k}: ${v}`)
-                  .join('\r\n'),
-            });
-            this.dispatchEvent(new Event('error'));
-            this.dispatchEvent(new Event('load'));
-            this.dispatchEvent(new Event('loadend'));
-            return;
+            if (applied) {
+              console.warn(`CHAOS: Forcing ${failure.statusCode} for ${method} ${url}`);
+              Object.defineProperty(this, 'status', { value: failure.statusCode });
+              Object.defineProperty(this, 'statusText', {
+                value: failure.statusText ?? 'Service Unavailable (Chaos)',
+              });
+              const responseBody = failure.body ?? JSON.stringify({ error: 'Chaos Maker Attack!' });
+              Object.defineProperty(this, 'responseText', { value: responseBody });
+              const responseHeaders = failure.headers ?? {};
+              Object.defineProperty(this, 'getResponseHeader', {
+                value: (name: string) => {
+                  const key = Object.keys(responseHeaders).find(
+                    (k) => k.toLowerCase() === name.toLowerCase()
+                  );
+                  return key ? responseHeaders[key] : null;
+                },
+              });
+              Object.defineProperty(this, 'getAllResponseHeaders', {
+                value: () =>
+                  Object.entries(responseHeaders)
+                    .map(([k, v]) => `${k}: ${v}`)
+                    .join('\r\n'),
+              });
+              this.dispatchEvent(new Event('error'));
+              this.dispatchEvent(new Event('load'));
+              this.dispatchEvent(new Event('loadend'));
+              return;
+            }
           }
         }
       }
@@ -45,13 +55,22 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
     // 2. Check for Latency
     if (config.latencies) {
       for (const latency of config.latencies) {
-        if (url.includes(latency.urlPattern) && shouldApplyChaos(latency.probability)) {
+        if (url.includes(latency.urlPattern)) {
           if (!latency.methods || latency.methods.includes(method)) {
-            console.warn(`CHAOS: Adding ${latency.delayMs}ms latency to ${method} ${url}`);
-            setTimeout(() => {
-              originalXhrSend.call(this, body);
-            }, latency.delayMs);
-            return;
+            const applied = shouldApplyChaos(latency.probability);
+            emitter?.emit({
+              type: 'network:latency',
+              timestamp: Date.now(),
+              applied,
+              detail: { url, method, delayMs: latency.delayMs },
+            });
+            if (applied) {
+              console.warn(`CHAOS: Adding ${latency.delayMs}ms latency to ${method} ${url}`);
+              setTimeout(() => {
+                originalXhrSend.call(this, body);
+              }, latency.delayMs);
+              return;
+            }
           }
         }
       }
@@ -62,7 +81,6 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
   };
 }
 
-// We also need to patch 'open' to store the URL and method
 export function patchXHROpen(originalXhrOpen: (method: string, url: string | URL) => void) {
   return function (this: XMLHttpRequest, method: string, url: string | URL) {
     (this as any)._chaos_url = url.toString();

--- a/packages/core/test/events.test.ts
+++ b/packages/core/test/events.test.ts
@@ -101,6 +101,42 @@ describe('ChaosEventEmitter', () => {
     expect(emitter.getLog()).toHaveLength(0);
   });
 
+  it('should cap the log at maxLogEntries', () => {
+    const emitter = new ChaosEventEmitter(3);
+
+    for (let i = 0; i < 5; i++) {
+      emitter.emit({
+        type: 'network:failure',
+        timestamp: i,
+        applied: true,
+        detail: { url: `/api/${i}` },
+      });
+    }
+
+    const log = emitter.getLog();
+    expect(log).toHaveLength(3);
+    expect(log[0].timestamp).toBe(2);
+    expect(log[2].timestamp).toBe(4);
+  });
+
+  it('should not break when a listener throws', () => {
+    const emitter = new ChaosEventEmitter();
+    const badListener = () => { throw new Error('boom'); };
+    const goodListener = vi.fn();
+
+    emitter.on('network:failure', badListener);
+    emitter.on('network:failure', goodListener);
+
+    emitter.emit({
+      type: 'network:failure',
+      timestamp: Date.now(),
+      applied: true,
+      detail: {},
+    });
+
+    expect(goodListener).toHaveBeenCalled();
+  });
+
   it('should remove listeners with off', () => {
     const emitter = new ChaosEventEmitter();
     const listener = vi.fn();

--- a/packages/core/test/events.test.ts
+++ b/packages/core/test/events.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ChaosEventEmitter, ChaosEvent } from '../src/events';
+
+describe('ChaosEventEmitter', () => {
+  it('should emit events to type-specific listeners', () => {
+    const emitter = new ChaosEventEmitter();
+    const listener = vi.fn();
+    emitter.on('network:failure', listener);
+
+    const event: ChaosEvent = {
+      type: 'network:failure',
+      timestamp: Date.now(),
+      applied: true,
+      detail: { url: '/api', method: 'GET', statusCode: 503 },
+    };
+    emitter.emit(event);
+
+    expect(listener).toHaveBeenCalledWith(event);
+  });
+
+  it('should emit events to wildcard listeners', () => {
+    const emitter = new ChaosEventEmitter();
+    const listener = vi.fn();
+    emitter.on('*', listener);
+
+    const event: ChaosEvent = {
+      type: 'network:latency',
+      timestamp: Date.now(),
+      applied: true,
+      detail: { url: '/api', delayMs: 500 },
+    };
+    emitter.emit(event);
+
+    expect(listener).toHaveBeenCalledWith(event);
+  });
+
+  it('should not call listeners for other event types', () => {
+    const emitter = new ChaosEventEmitter();
+    const listener = vi.fn();
+    emitter.on('ui:assault', listener);
+
+    emitter.emit({
+      type: 'network:failure',
+      timestamp: Date.now(),
+      applied: true,
+      detail: { url: '/api', statusCode: 500 },
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('should accumulate events in the log', () => {
+    const emitter = new ChaosEventEmitter();
+
+    emitter.emit({
+      type: 'network:failure',
+      timestamp: 1000,
+      applied: true,
+      detail: { url: '/api/1' },
+    });
+    emitter.emit({
+      type: 'network:latency',
+      timestamp: 2000,
+      applied: false,
+      detail: { url: '/api/2', delayMs: 100 },
+    });
+
+    const log = emitter.getLog();
+    expect(log).toHaveLength(2);
+    expect(log[0].type).toBe('network:failure');
+    expect(log[1].type).toBe('network:latency');
+    expect(log[1].applied).toBe(false);
+  });
+
+  it('should return a copy from getLog', () => {
+    const emitter = new ChaosEventEmitter();
+    emitter.emit({
+      type: 'network:failure',
+      timestamp: Date.now(),
+      applied: true,
+      detail: {},
+    });
+
+    const log1 = emitter.getLog();
+    const log2 = emitter.getLog();
+    expect(log1).toEqual(log2);
+    expect(log1).not.toBe(log2);
+  });
+
+  it('should clear the log', () => {
+    const emitter = new ChaosEventEmitter();
+    emitter.emit({
+      type: 'network:failure',
+      timestamp: Date.now(),
+      applied: true,
+      detail: {},
+    });
+    expect(emitter.getLog()).toHaveLength(1);
+
+    emitter.clearLog();
+    expect(emitter.getLog()).toHaveLength(0);
+  });
+
+  it('should remove listeners with off', () => {
+    const emitter = new ChaosEventEmitter();
+    const listener = vi.fn();
+    emitter.on('network:failure', listener);
+    emitter.off('network:failure', listener);
+
+    emitter.emit({
+      type: 'network:failure',
+      timestamp: Date.now(),
+      applied: true,
+      detail: {},
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/test/networkFetch.test.ts
+++ b/packages/core/test/networkFetch.test.ts
@@ -76,7 +76,7 @@ describe('patchFetch', () => {
     await patchedFetch('/api/slow');
     const endTime = Date.now();
 
-    expect(endTime - startTime).toBeGreaterThanOrEqual(100);
+    expect(endTime - startTime).toBeGreaterThanOrEqual(95);
     expect(originalFetch).toHaveBeenCalledWith('/api/slow', undefined);
   });
 

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@chaos-maker/playwright",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Playwright adapter for @chaos-maker/core — one-line chaos injection in E2E tests",
+  "keywords": [
+    "chaos-engineering",
+    "playwright",
+    "testing",
+    "e2e-testing",
+    "resilience"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jvjithin/chaos-maker.git",
+    "directory": "packages/playwright"
+  },
+  "homepage": "https://github.com/jvjithin/chaos-maker",
+  "engines": {
+    "node": ">=18"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./fixture": {
+      "import": {
+        "types": "./dist/fixture.d.ts",
+        "default": "./dist/fixture.js"
+      },
+      "require": {
+        "types": "./dist/fixture.d.ts",
+        "default": "./dist/fixture.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@chaos-maker/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "@playwright/test": ">=1.40.0"
+  },
+  "peerDependenciesMeta": {
+    "@playwright/test": {
+      "optional": false
+    }
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.45.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/playwright/src/fixture.ts
+++ b/packages/playwright/src/fixture.ts
@@ -1,0 +1,44 @@
+import { test as base } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import type { ChaosConfig, ChaosEvent } from '@chaos-maker/core';
+import { injectChaos, removeChaos, getChaosLog } from './index';
+
+export interface ChaosFixture {
+  inject: (config: ChaosConfig) => Promise<void>;
+  remove: () => Promise<void>;
+  getLog: () => Promise<ChaosEvent[]>;
+}
+
+/**
+ * Extended Playwright test with a `chaos` fixture.
+ *
+ * @example
+ * ```ts
+ * import { test, expect } from '@chaos-maker/playwright/fixture';
+ *
+ * test('handles API failure', async ({ page, chaos }) => {
+ *   await chaos.inject({
+ *     network: {
+ *       failures: [{ urlPattern: '/api', statusCode: 503, probability: 1.0 }]
+ *     }
+ *   });
+ *   await page.goto('/');
+ *   const log = await chaos.getLog();
+ *   expect(log.some(e => e.type === 'network:failure' && e.applied)).toBe(true);
+ * });
+ * ```
+ */
+export const test = base.extend<{ chaos: ChaosFixture }>({
+  chaos: async ({ page }: { page: Page }, use: (fixture: ChaosFixture) => Promise<void>) => {
+    const fixture: ChaosFixture = {
+      inject: (config: ChaosConfig) => injectChaos(page, config),
+      remove: () => removeChaos(page),
+      getLog: () => getChaosLog(page),
+    };
+    await use(fixture);
+    await removeChaos(page);
+  },
+});
+
+export { expect } from '@playwright/test';
+export type { ChaosConfig, ChaosEvent } from '@chaos-maker/core';

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -1,0 +1,83 @@
+import type { Page } from '@playwright/test';
+import type { ChaosConfig, ChaosEvent } from '@chaos-maker/core';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+let cachedScript: string | null = null;
+
+function getCoreScript(): string {
+  if (cachedScript) return cachedScript;
+
+  // Support both ESM and CJS module resolution
+  const currentDir = typeof __dirname !== 'undefined'
+    ? __dirname
+    : dirname(fileURLToPath(import.meta.url));
+  const req = createRequire(resolve(currentDir, 'package.json'));
+  const corePkg = req.resolve('@chaos-maker/core/package.json');
+  const coreDir = dirname(corePkg);
+  const umdPath = resolve(coreDir, 'dist', 'chaos-maker.umd.js');
+  cachedScript = readFileSync(umdPath, 'utf-8');
+  return cachedScript;
+}
+
+/**
+ * Inject chaos into a Playwright page. Call before `page.goto()` to ensure
+ * all network requests are intercepted from the start.
+ *
+ * @example
+ * ```ts
+ * import { injectChaos } from '@chaos-maker/playwright';
+ *
+ * test('handles API failure', async ({ page }) => {
+ *   await injectChaos(page, {
+ *     network: {
+ *       failures: [{ urlPattern: '/api', statusCode: 503, probability: 1.0 }]
+ *     }
+ *   });
+ *   await page.goto('/');
+ * });
+ * ```
+ */
+export async function injectChaos(page: Page, config: ChaosConfig): Promise<void> {
+  const scriptContent = getCoreScript();
+
+  await page.addInitScript((args: { config: unknown; scriptContent: string }) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const win = globalThis as any;
+    win.__CHAOS_CONFIG__ = args.config;
+    // eval executes synchronously, ensuring fetch/XHR are patched before any app code
+    (0, eval)(args.scriptContent);
+  }, { config, scriptContent });
+}
+
+/**
+ * Remove chaos from a Playwright page. Restores original fetch/XHR/DOM behavior.
+ */
+export async function removeChaos(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const win = globalThis as any;
+    if (win.chaosUtils) {
+      win.chaosUtils.stop();
+    }
+  });
+}
+
+/**
+ * Retrieve the chaos event log from a Playwright page.
+ * Returns all events emitted since chaos was injected.
+ */
+export async function getChaosLog(page: Page): Promise<ChaosEvent[]> {
+  return page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const win = globalThis as any;
+    if (win.chaosUtils) {
+      return win.chaosUtils.getLog();
+    }
+    return [];
+  });
+}
+
+export type { ChaosConfig, ChaosEvent } from '@chaos-maker/core';

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -1,14 +1,13 @@
 import type { Page } from '@playwright/test';
 import type { ChaosConfig, ChaosEvent } from '@chaos-maker/core';
-import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 
-let cachedScript: string | null = null;
+let cachedUmdPath: string | null = null;
 
-function getCoreScript(): string {
-  if (cachedScript) return cachedScript;
+function getCoreUmdPath(): string {
+  if (cachedUmdPath) return cachedUmdPath;
 
   // Support both ESM and CJS module resolution
   const currentDir = typeof __dirname !== 'undefined'
@@ -17,9 +16,8 @@ function getCoreScript(): string {
   const req = createRequire(resolve(currentDir, 'package.json'));
   const corePkg = req.resolve('@chaos-maker/core/package.json');
   const coreDir = dirname(corePkg);
-  const umdPath = resolve(coreDir, 'dist', 'chaos-maker.umd.js');
-  cachedScript = readFileSync(umdPath, 'utf-8');
-  return cachedScript;
+  cachedUmdPath = resolve(coreDir, 'dist', 'chaos-maker.umd.js');
+  return cachedUmdPath;
 }
 
 /**
@@ -41,15 +39,17 @@ function getCoreScript(): string {
  * ```
  */
 export async function injectChaos(page: Page, config: ChaosConfig): Promise<void> {
-  const scriptContent = getCoreScript();
+  const umdPath = getCoreUmdPath();
 
-  await page.addInitScript((args: { config: unknown; scriptContent: string }) => {
+  // Set config before the UMD script runs so it auto-starts with this config
+  await page.addInitScript((cfg: unknown) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const win = globalThis as any;
-    win.__CHAOS_CONFIG__ = args.config;
-    // eval executes synchronously, ensuring fetch/XHR are patched before any app code
-    (0, eval)(args.scriptContent);
-  }, { config, scriptContent });
+    win.__CHAOS_CONFIG__ = cfg;
+  }, config);
+
+  // Load core UMD bundle by path — no eval needed
+  await page.addInitScript({ path: umdPath });
 }
 
 /**

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -14,9 +14,11 @@ function getCoreUmdPath(): string {
     ? __dirname
     : dirname(fileURLToPath(import.meta.url));
   const req = createRequire(resolve(currentDir, 'package.json'));
-  const corePkg = req.resolve('@chaos-maker/core/package.json');
-  const coreDir = dirname(corePkg);
-  cachedUmdPath = resolve(coreDir, 'dist', 'chaos-maker.umd.js');
+  // Resolve the main entry point to find the dist directory — avoids
+  // requiring `./package.json` which isn't in the exports map.
+  const coreEntry = req.resolve('@chaos-maker/core');
+  const coreDistDir = dirname(coreEntry);
+  cachedUmdPath = resolve(coreDistDir, 'chaos-maker.umd.js');
   return cachedUmdPath;
 }
 

--- a/packages/playwright/tsconfig.json
+++ b/packages/playwright/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "lib": ["ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/playwright/tsup.config.ts
+++ b/packages/playwright/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/fixture.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  external: ['@playwright/test', '@chaos-maker/core'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
 
   e2e-tests:
     devDependencies:
+      '@chaos-maker/playwright':
+        specifier: workspace:*
+        version: link:../packages/playwright
       '@playwright/test':
         specifier: ^1.45.0
         version: 1.56.1
@@ -80,6 +83,25 @@ importers:
         version: 1.6.1(@types/node@20.19.23)(jsdom@27.0.1(postcss@8.5.6))
 
   packages/extension: {}
+
+  packages/playwright:
+    dependencies:
+      '@chaos-maker/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.45.0
+        version: 1.56.1
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.23)(jsdom@27.0.1(postcss@8.5.6))
 
 packages:
 
@@ -136,9 +158,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -148,9 +182,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -160,9 +206,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -172,9 +230,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -184,9 +254,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -196,9 +278,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -208,9 +302,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -220,9 +326,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -232,11 +350,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -244,9 +386,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -256,15 +416,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -303,12 +481,18 @@ packages:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -627,6 +811,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
@@ -663,6 +850,12 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -690,6 +883,10 @@ packages:
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -712,11 +909,19 @@ packages:
     resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
     engines: {node: '>=20'}
 
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   corser@2.0.1:
     resolution: {integrity: sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==}
@@ -808,6 +1013,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -892,6 +1102,15 @@ packages:
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -903,6 +1122,9 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
@@ -1093,6 +1315,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
@@ -1125,6 +1351,13 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   lint-staged@16.2.6:
     resolution: {integrity: sha512-s1gphtDbV4bmW1eylXpVMk2u7is7YsrLl8hzrtvC70h4ByhcMLZFY01Fx05ZUDNuv1H8HO4E+e2zgejV1jVwNw==}
     engines: {node: '>=20.17'}
@@ -1133,6 +1366,10 @@ packages:
   listr2@9.0.5:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   local-pkg@0.5.1:
     resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
@@ -1209,6 +1446,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nano-spawn@2.0.0:
     resolution: {integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==}
     engines: {node: '>=20.17'}
@@ -1224,6 +1464,10 @@ packages:
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -1303,10 +1547,18 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
     hasBin: true
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -1324,6 +1576,24 @@ packages:
   portfinder@1.0.38:
     resolution: {integrity: sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==}
     engines: {node: '>= 10.12'}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -1351,6 +1621,10 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1361,6 +1635,10 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -1450,6 +1728,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -1487,6 +1769,11 @@ packages:
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1497,8 +1784,22 @@ packages:
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@0.8.4:
     resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
@@ -1527,6 +1828,10 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
@@ -1538,6 +1843,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
@@ -1551,6 +1859,25 @@ packages:
       '@swc/core':
         optional: true
       '@swc/wasm':
+        optional: true
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
         optional: true
 
   type-check@0.4.0:
@@ -1792,70 +2119,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.4':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.27.4':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.4':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.4':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.4':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.4':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.4':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.4':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.4':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.4':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@8.57.1)':
@@ -1897,9 +2302,19 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.8
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
@@ -2205,6 +2620,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  any-promise@1.3.0: {}
+
   arg@4.1.3: {}
 
   argparse@2.0.1: {}
@@ -2237,6 +2654,11 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  bundle-require@5.1.0(esbuild@0.27.4):
+    dependencies:
+      esbuild: 0.27.4
+      load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
 
@@ -2271,6 +2693,10 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -2290,9 +2716,13 @@ snapshots:
 
   commander@14.0.1: {}
 
+  commander@4.1.1: {}
+
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
+
+  consola@3.4.2: {}
 
   corser@2.0.1: {}
 
@@ -2391,6 +2821,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.27.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
 
   escape-string-regexp@4.0.0: {}
 
@@ -2513,6 +2972,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -2525,6 +2988,12 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.19
+      mlly: 1.8.0
+      rollup: 4.52.5
 
   flat-cache@3.2.0:
     dependencies:
@@ -2711,6 +3180,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@9.0.1: {}
 
   js-yaml@4.1.0:
@@ -2760,6 +3231,10 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
   lint-staged@16.2.6:
     dependencies:
       commander: 14.0.1
@@ -2778,6 +3253,8 @@ snapshots:
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
+
+  load-tsconfig@0.2.5: {}
 
   local-pkg@0.5.1:
     dependencies:
@@ -2848,6 +3325,12 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   nano-spawn@2.0.0: {}
 
   nanoid@3.3.11: {}
@@ -2857,6 +3340,8 @@ snapshots:
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -2923,7 +3408,11 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.4: {}
+
   pidtree@0.6.0: {}
+
+  pirates@4.0.7: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -2945,6 +3434,13 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  postcss-load-config@6.0.1(postcss@8.5.6)(yaml@2.8.1):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.6
+      yaml: 2.8.1
 
   postcss@8.5.6:
     dependencies:
@@ -2970,11 +3466,15 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  readdirp@4.1.2: {}
+
   require-from-string@2.0.2: {}
 
   requires-port@1.0.0: {}
 
   resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
 
   restore-cursor@5.1.0:
     dependencies:
@@ -3082,6 +3582,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.7.6: {}
+
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
@@ -3115,6 +3617,16 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -3123,7 +3635,22 @@ snapshots:
 
   text-table@0.2.0: {}
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@0.8.4: {}
 
@@ -3147,6 +3674,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-kill@1.2.2: {}
+
   ts-api-utils@1.4.3(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -3154,6 +3683,8 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-interface-checker@0.1.13: {}
 
   ts-node@10.9.2(@types/node@20.19.23)(typescript@5.9.3):
     dependencies:
@@ -3172,6 +3703,34 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  tsup@8.5.1(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.4)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.4
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.6)(yaml@2.8.1)
+      resolve-from: 5.0.0
+      rollup: 4.52.5
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.6
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## Summary

- **Event system in core** — `ChaosEventEmitter` with typed events (`network:failure`, `network:latency`, `ui:assault`), wildcard listeners, `getLog()`/`clearLog()`, and `on()`/`off()` subscription API
- **All interceptors emit events** — fetch, XHR, and DOM interceptors emit events with `applied: true/false` for every chaos check (including probability skips)
- **New package: `@chaos-maker/playwright`** — one-line chaos injection via `injectChaos(page, config)`, plus `removeChaos(page)` and `getChaosLog(page)`. Includes a test fixture importable from `@chaos-maker/playwright/fixture`
- **E2E tests rewritten** — 18 lines of boilerplate replaced with 2-line adapter calls, plus chaos log assertions
- **CI updated** — builds both core and playwright packages

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test` — 40 tests pass (5 files, 7 new event emitter tests)
- [x] `pnpm build` — core and playwright packages build cleanly
- [x] E2E tests pass using the new adapter with chaos log assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event logging/emit API for chaos events (network failures, latency, UI actions) and a browser-accessible getLog().
  * Playwright integration package and test fixture for easy chaos injection, removal, and log retrieval.

* **Chores**
  * CI updated to build and publish all packages; new build scripts added for multi-package workflow.

* **Tests**
  * Added unit tests for event emitter; e2e tests updated to use the new Playwright API and assert event logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->