### PR TITLE
Phase 3: Presets, builder API, and new chaos types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
-# Claude Code project files
+# Claude Code & agents project files
 CLAUDE.md
 PROJECT_STATUS.md
+LEARNINGS.md
 .claude/skills/
+AGENTS.md
+GEMINI.md
 
 # Node
 node_modules

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -1,0 +1,55 @@
+import { ChaosConfig, CorruptionStrategy } from './config';
+
+function cloneConfig(config: ChaosConfig): ChaosConfig {
+  return JSON.parse(JSON.stringify(config));
+}
+
+export class ChaosConfigBuilder {
+  private config: ChaosConfig;
+
+  constructor(initialConfig?: ChaosConfig) {
+    this.config = initialConfig ? cloneConfig(initialConfig) : { network: {}, ui: {} };
+    if (!this.config.network) this.config.network = {};
+    if (!this.config.ui) this.config.ui = {};
+  }
+
+  failRequests(urlPattern: string, statusCode: number, probability: number, methods?: string[], body?: string, headers?: Record<string, string>) {
+    if (!this.config.network!.failures) this.config.network!.failures = [];
+    this.config.network!.failures.push({ urlPattern, statusCode, probability, methods, body, headers });
+    return this;
+  }
+
+  addLatency(urlPattern: string, delayMs: number, probability: number, methods?: string[]) {
+    if (!this.config.network!.latencies) this.config.network!.latencies = [];
+    this.config.network!.latencies.push({ urlPattern, delayMs, probability, methods });
+    return this;
+  }
+
+  abortRequests(urlPattern: string, probability: number, timeout?: number, methods?: string[]) {
+    if (!this.config.network!.aborts) this.config.network!.aborts = [];
+    this.config.network!.aborts.push({ urlPattern, probability, timeout, methods });
+    return this;
+  }
+
+  corruptResponses(urlPattern: string, strategy: CorruptionStrategy, probability: number, methods?: string[]) {
+    if (!this.config.network!.corruptions) this.config.network!.corruptions = [];
+    this.config.network!.corruptions.push({ urlPattern, strategy, probability, methods });
+    return this;
+  }
+
+  simulateCors(urlPattern: string, probability: number, methods?: string[]) {
+    if (!this.config.network!.cors) this.config.network!.cors = [];
+    this.config.network!.cors.push({ urlPattern, probability, methods });
+    return this;
+  }
+
+  assaultUi(selector: string, action: 'disable' | 'hide' | 'remove', probability: number) {
+    if (!this.config.ui!.assaults) this.config.ui!.assaults = [];
+    this.config.ui!.assaults.push({ selector, action, probability });
+    return this;
+  }
+
+  build(): ChaosConfig {
+    return cloneConfig(this.config);
+  }
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -15,9 +15,34 @@ export interface NetworkLatencyConfig {
   probability: number;
 }
 
+export interface NetworkAbortConfig {
+  urlPattern: string;
+  methods?: string[];
+  probability: number;
+  timeout?: number; // ms before abort; 0 or omitted = immediate
+}
+
+export type CorruptionStrategy = 'truncate' | 'malformed-json' | 'empty' | 'wrong-type';
+
+export interface NetworkCorruptionConfig {
+  urlPattern: string;
+  methods?: string[];
+  probability: number;
+  strategy: CorruptionStrategy;
+}
+
+export interface NetworkCorsConfig {
+  urlPattern: string;
+  methods?: string[];
+  probability: number;
+}
+
 export interface NetworkConfig {
   failures?: NetworkFailureConfig[];
   latencies?: NetworkLatencyConfig[];
+  aborts?: NetworkAbortConfig[];
+  corruptions?: NetworkCorruptionConfig[];
+  cors?: NetworkCorsConfig[];
 }
 
 export interface UiAssaultConfig {

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,4 +1,4 @@
-export type ChaosEventType = 'network:failure' | 'network:latency' | 'ui:assault';
+export type ChaosEventType = 'network:failure' | 'network:latency' | 'network:abort' | 'network:corruption' | 'network:cors' | 'ui:assault';
 
 export interface ChaosEvent {
   type: ChaosEventType;
@@ -9,6 +9,8 @@ export interface ChaosEvent {
     method?: string;
     statusCode?: number;
     delayMs?: number;
+    timeoutMs?: number;
+    strategy?: string;
     selector?: string;
     action?: string;
   };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,11 +1,13 @@
 import { ChaosMaker } from './ChaosMaker';
-import { ChaosConfig, NetworkFailureConfig, NetworkLatencyConfig, NetworkConfig, UiAssaultConfig, UiConfig } from './config';
+import { ChaosConfig, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig } from './config';
 import { ChaosConfigError } from './errors';
 import { validateConfig } from './validation';
 import { ChaosEvent, ChaosEventType, ChaosEventListener, ChaosEventEmitter } from './events';
+import { ChaosConfigBuilder } from './builder';
+import { presets } from './presets';
 
-export { ChaosMaker, ChaosConfigError, validateConfig, ChaosEventEmitter };
-export type { ChaosConfig, NetworkFailureConfig, NetworkLatencyConfig, NetworkConfig, UiAssaultConfig, UiConfig, ChaosEvent, ChaosEventType, ChaosEventListener };
+export { ChaosMaker, ChaosConfigError, validateConfig, ChaosEventEmitter, ChaosConfigBuilder, presets };
+export type { ChaosConfig, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig, ChaosEvent, ChaosEventType, ChaosEventListener };
 
 // --- NEW INTERFACE ---
 interface ChaosUtilsApi {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 import { ChaosMaker } from './ChaosMaker';
-import { ChaosConfig, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig } from './config';
+import { ChaosConfig, CorruptionStrategy, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig } from './config';
 import { ChaosConfigError } from './errors';
 import { validateConfig } from './validation';
 import { ChaosEvent, ChaosEventType, ChaosEventListener, ChaosEventEmitter } from './events';
@@ -7,7 +7,7 @@ import { ChaosConfigBuilder } from './builder';
 import { presets } from './presets';
 
 export { ChaosMaker, ChaosConfigError, validateConfig, ChaosEventEmitter, ChaosConfigBuilder, presets };
-export type { ChaosConfig, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig, ChaosEvent, ChaosEventType, ChaosEventListener };
+export type { ChaosConfig, CorruptionStrategy, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig, ChaosEvent, ChaosEventType, ChaosEventListener };
 
 // --- NEW INTERFACE ---
 interface ChaosUtilsApi {

--- a/packages/core/src/interceptors/networkFetch.ts
+++ b/packages/core/src/interceptors/networkFetch.ts
@@ -1,16 +1,218 @@
-import { NetworkConfig } from '../config';
-import { shouldApplyChaos } from '../utils';
+import { NetworkAbortConfig, NetworkConfig, NetworkCorruptionConfig } from '../config';
+import { shouldApplyChaos, corruptText } from '../utils';
 import { ChaosEventEmitter } from '../events';
+
+function isRequest(input: RequestInfo | URL): input is Request {
+  return typeof Request !== 'undefined' && input instanceof Request;
+}
+
+function getFetchUrl(input: RequestInfo | URL): string {
+  return isRequest(input) ? input.url : input.toString();
+}
+
+function getFetchMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  if (init?.method) {
+    return init.method.toUpperCase();
+  }
+  if (isRequest(input)) {
+    return input.method.toUpperCase();
+  }
+  return 'GET';
+}
+
+function getFetchSignal(input: RequestInfo | URL, init?: RequestInit): AbortSignal | undefined {
+  if (init?.signal) {
+    return init.signal;
+  }
+  if (isRequest(input)) {
+    return input.signal;
+  }
+  return undefined;
+}
+
+function createAbortError(): Error {
+  if (typeof DOMException !== 'undefined') {
+    return new DOMException('The user aborted a request.', 'AbortError');
+  }
+
+  const error = new Error('The user aborted a request.');
+  error.name = 'AbortError';
+  return error;
+}
+
+function mergeAbortSignals(primary: AbortSignal, secondary?: AbortSignal): AbortSignal {
+  if (!secondary) {
+    return primary;
+  }
+
+  const controller = new AbortController();
+
+  const abortFrom = (signal: AbortSignal) => {
+    cleanup();
+    if (!controller.signal.aborted) {
+      controller.abort(signal.reason);
+    }
+  };
+
+  const onPrimaryAbort = () => abortFrom(primary);
+  const onSecondaryAbort = () => abortFrom(secondary);
+
+  const cleanup = () => {
+    primary.removeEventListener('abort', onPrimaryAbort);
+    secondary.removeEventListener('abort', onSecondaryAbort);
+  };
+
+  if (primary.aborted) {
+    abortFrom(primary);
+    return controller.signal;
+  }
+
+  if (secondary.aborted) {
+    abortFrom(secondary);
+    return controller.signal;
+  }
+
+  primary.addEventListener('abort', onPrimaryAbort, { once: true });
+  secondary.addEventListener('abort', onSecondaryAbort, { once: true });
+  return controller.signal;
+}
+
+function withSignal(init: RequestInit | undefined, signal: AbortSignal | undefined): RequestInit | undefined {
+  if (!signal) {
+    return init;
+  }
+
+  return {
+    ...(init ?? {}),
+    signal,
+  };
+}
+
+function emitAbortEvent(
+  emitter: ChaosEventEmitter | undefined,
+  abort: NetworkAbortConfig,
+  url: string,
+  method: string,
+  applied: boolean
+): void {
+  emitter?.emit({
+    type: 'network:abort',
+    timestamp: Date.now(),
+    applied,
+    detail: { url, method, timeoutMs: abort.timeout },
+  });
+}
+
+function emitCorruptionEvent(
+  emitter: ChaosEventEmitter | undefined,
+  corruption: NetworkCorruptionConfig,
+  url: string,
+  method: string,
+  applied: boolean
+): void {
+  emitter?.emit({
+    type: 'network:corruption',
+    timestamp: Date.now(),
+    applied,
+    detail: { url, method, strategy: corruption.strategy },
+  });
+}
 
 export function patchFetch(originalFetch: typeof window.fetch, config: NetworkConfig, emitter?: ChaosEventEmitter) {
   return async (
     input: RequestInfo | URL,
     init?: RequestInit
   ): Promise<Response> => {
-    const url = input.toString();
-    const method = init?.method?.toUpperCase() || 'GET';
+    const url = getFetchUrl(input);
+    const method = getFetchMethod(input, init);
+    const existingSignal = getFetchSignal(input, init);
 
-    // 1. Check for Failures
+    // 1. Check for CORS
+    if (config.cors) {
+      for (const cors of config.cors) {
+        if (url.includes(cors.urlPattern)) {
+          if (!cors.methods || cors.methods.includes(method)) {
+            const applied = shouldApplyChaos(cors.probability);
+            emitter?.emit({
+              type: 'network:cors',
+              timestamp: Date.now(),
+              applied,
+              detail: { url, method },
+            });
+            if (applied) {
+              console.warn(`CHAOS: Forcing CORS error for ${method} ${url}`);
+              throw new TypeError('Failed to fetch');
+            }
+          }
+        }
+      }
+    }
+
+    // 2. Check for Abort
+    let selectedAbort: NetworkAbortConfig | null = null;
+    let abortSignal: AbortSignal | undefined;
+    let abortTimer: ReturnType<typeof setTimeout> | undefined;
+    let abortEventSettled = false;
+
+    const settleAbortEvent = (applied: boolean) => {
+      if (!selectedAbort || abortEventSettled) {
+        return;
+      }
+      abortEventSettled = true;
+      if (abortTimer) {
+        clearTimeout(abortTimer);
+        abortTimer = undefined;
+      }
+      emitAbortEvent(emitter, selectedAbort, url, method, applied);
+    };
+
+    if (config.aborts) {
+      for (const abort of config.aborts) {
+        if (url.includes(abort.urlPattern)) {
+          if (!abort.methods || abort.methods.includes(method)) {
+            const applied = shouldApplyChaos(abort.probability);
+            if (!applied) {
+              emitAbortEvent(emitter, abort, url, method, false);
+              continue;
+            }
+
+            console.warn(`CHAOS: Aborting ${method} ${url} after ${abort.timeout || 0}ms`);
+            selectedAbort = abort;
+
+            const chaosController = new AbortController();
+            abortSignal = mergeAbortSignals(chaosController.signal, existingSignal);
+
+            const applyAbort = () => {
+              if (abortEventSettled) {
+                return;
+              }
+              settleAbortEvent(true);
+              chaosController.abort(createAbortError());
+            };
+
+            if (abort.timeout) {
+              abortTimer = setTimeout(applyAbort, abort.timeout);
+            } else {
+              applyAbort();
+            }
+            break;
+          }
+        }
+      }
+    }
+
+    if (selectedAbort) {
+      try {
+        const response = await originalFetch(input, withSignal(init, abortSignal));
+        settleAbortEvent(false);
+        return response;
+      } catch (error) {
+        settleAbortEvent(false);
+        throw error;
+      }
+    }
+
+    // 3. Check for Failures
     if (config.failures) {
       for (const failure of config.failures) {
         if (url.includes(failure.urlPattern)) {
@@ -37,7 +239,7 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
       }
     }
 
-    // 2. Check for Latency
+    // 4. Check for Latency
     if (config.latencies) {
       for (const latency of config.latencies) {
         if (url.includes(latency.urlPattern)) {
@@ -58,7 +260,51 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
       }
     }
 
-    // 3. If no chaos, proceed as normal
-    return originalFetch(input, init);
+    // 5. Determine Corruption (applied after fetch)
+    let selectedCorruption: NetworkCorruptionConfig | null = null;
+    if (config.corruptions) {
+      for (const corruption of config.corruptions) {
+        if (url.includes(corruption.urlPattern)) {
+          if (!corruption.methods || corruption.methods.includes(method)) {
+            const applied = shouldApplyChaos(corruption.probability);
+            if (!applied) {
+              emitCorruptionEvent(emitter, corruption, url, method, false);
+              continue;
+            }
+            selectedCorruption = corruption;
+            break; // Apply only one corruption
+          }
+        }
+      }
+    }
+
+    let response: Response;
+    try {
+      response = await originalFetch(input, init);
+    } catch (error) {
+      if (selectedCorruption) {
+        emitCorruptionEvent(emitter, selectedCorruption, url, method, false);
+      }
+      throw error;
+    }
+
+    if (!selectedCorruption) {
+      return response;
+    }
+
+    try {
+      console.warn(`CHAOS: Corrupting response for ${method} ${url} with strategy: ${selectedCorruption.strategy}`);
+      const text = await response.text();
+      const corruptedText = corruptText(text, selectedCorruption.strategy);
+      emitCorruptionEvent(emitter, selectedCorruption, url, method, true);
+      return new Response(corruptedText, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    } catch (error) {
+      emitCorruptionEvent(emitter, selectedCorruption, url, method, false);
+      throw error;
+    }
   };
 }

--- a/packages/core/src/interceptors/networkXHR.ts
+++ b/packages/core/src/interceptors/networkXHR.ts
@@ -1,13 +1,141 @@
-import { NetworkConfig } from '../config';
-import { shouldApplyChaos } from '../utils';
+import { NetworkAbortConfig, NetworkConfig, NetworkCorruptionConfig } from '../config';
+import { shouldApplyChaos, corruptText } from '../utils';
 import { ChaosEventEmitter } from '../events';
+
+function emitAbortEvent(
+  emitter: ChaosEventEmitter | undefined,
+  abort: NetworkAbortConfig,
+  url: string,
+  method: string,
+  applied: boolean
+): void {
+  emitter?.emit({
+    type: 'network:abort',
+    timestamp: Date.now(),
+    applied,
+    detail: { url, method, timeoutMs: abort.timeout },
+  });
+}
+
+function emitCorruptionEvent(
+  emitter: ChaosEventEmitter | undefined,
+  corruption: NetworkCorruptionConfig,
+  url: string,
+  method: string,
+  applied: boolean
+): void {
+  emitter?.emit({
+    type: 'network:corruption',
+    timestamp: Date.now(),
+    applied,
+    detail: { url, method, strategy: corruption.strategy },
+  });
+}
 
 export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyInit) => void, config: NetworkConfig, emitter?: ChaosEventEmitter) {
   return function (this: XMLHttpRequest, body?: Document | XMLHttpRequestBodyInit) {
     const url = (this as any)._chaos_url;
     const method = (this as any)._chaos_method;
 
-    // 1. Check for Failures
+    // 1. Check for CORS
+    if (config.cors) {
+      for (const cors of config.cors) {
+        if (url.includes(cors.urlPattern)) {
+          if (!cors.methods || cors.methods.includes(method)) {
+            const applied = shouldApplyChaos(cors.probability);
+            emitter?.emit({
+              type: 'network:cors',
+              timestamp: Date.now(),
+              applied,
+              detail: { url, method },
+            });
+            if (applied) {
+              console.warn(`CHAOS: Forcing CORS error for ${method} ${url}`);
+              Object.defineProperty(this, 'status', { value: 0 });
+              Object.defineProperty(this, 'statusText', { value: '' });
+              this.dispatchEvent(new Event('error'));
+              this.dispatchEvent(new Event('loadend'));
+              return;
+            }
+          }
+        }
+      }
+    }
+
+    // 2. Check for Abort
+    if (config.aborts) {
+      for (const abort of config.aborts) {
+        if (url.includes(abort.urlPattern)) {
+          if (!abort.methods || abort.methods.includes(method)) {
+            const applied = shouldApplyChaos(abort.probability);
+            if (!applied) {
+              emitAbortEvent(emitter, abort, url, method, false);
+              continue;
+            }
+
+            console.warn(`CHAOS: Aborting ${method} ${url} after ${abort.timeout || 0}ms`);
+
+            let abortSettled = false;
+            let abortTimer: ReturnType<typeof setTimeout> | undefined;
+
+            const cleanup = () => {
+              if (abortTimer) {
+                clearTimeout(abortTimer);
+                abortTimer = undefined;
+              }
+              if (typeof this.removeEventListener === 'function') {
+                this.removeEventListener('loadend', handleLoadEnd);
+              }
+            };
+
+            const finalizeAbort = (didAbort: boolean) => {
+              if (abortSettled) {
+                return;
+              }
+              abortSettled = true;
+              cleanup();
+              emitAbortEvent(emitter, abort, url, method, didAbort);
+            };
+
+            const handleLoadEnd = () => {
+              finalizeAbort(false);
+            };
+
+            const applyAbort = () => {
+              if (abortSettled) {
+                return;
+              }
+              finalizeAbort(true);
+              this.abort();
+            };
+
+            if (typeof this.addEventListener === 'function') {
+              this.addEventListener('loadend', handleLoadEnd);
+            }
+
+            try {
+              originalXhrSend.call(this, body);
+            } catch (error) {
+              finalizeAbort(false);
+              throw error;
+            }
+
+            if (abortSettled) {
+              return;
+            }
+
+            if (abort.timeout) {
+              abortTimer = setTimeout(applyAbort, abort.timeout);
+            } else {
+              applyAbort();
+            }
+            return;
+          }
+        }
+      }
+    }
+
+    // 3. Check for Failures
     if (config.failures) {
       for (const failure of config.failures) {
         if (url.includes(failure.urlPattern)) {
@@ -26,7 +154,7 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
                 value: failure.statusText ?? 'Service Unavailable (Chaos)',
               });
               const responseBody = failure.body ?? JSON.stringify({ error: 'Chaos Maker Attack!' });
-              Object.defineProperty(this, 'responseText', { value: responseBody });
+              Object.defineProperty(this, 'responseText', { value: responseBody, configurable: true });
               const responseHeaders = failure.headers ?? {};
               Object.defineProperty(this, 'getResponseHeader', {
                 value: (name: string) => {
@@ -35,12 +163,14 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
                   );
                   return key ? responseHeaders[key] : null;
                 },
+                configurable: true
               });
               Object.defineProperty(this, 'getAllResponseHeaders', {
                 value: () =>
                   Object.entries(responseHeaders)
                     .map(([k, v]) => `${k}: ${v}`)
                     .join('\r\n'),
+                configurable: true
               });
               this.dispatchEvent(new Event('error'));
               this.dispatchEvent(new Event('load'));
@@ -52,7 +182,95 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
       }
     }
 
-    // 2. Check for Latency
+    // 4. Check for Corruption
+    let selectedCorruption: NetworkCorruptionConfig | null = null;
+    if (config.corruptions) {
+      for (const corruption of config.corruptions) {
+        if (url.includes(corruption.urlPattern)) {
+          if (!corruption.methods || corruption.methods.includes(method)) {
+            const applied = shouldApplyChaos(corruption.probability);
+            if (!applied) {
+              emitCorruptionEvent(emitter, corruption, url, method, false);
+              continue;
+            }
+            selectedCorruption = corruption;
+            break;
+          }
+        }
+      }
+    }
+
+    if (selectedCorruption) {
+      let settled = false;
+      let corruptedText: string | null = null;
+
+      const cleanup = () => {
+        if (typeof this.removeEventListener !== 'function') return;
+        this.removeEventListener('error', handleFailure);
+        this.removeEventListener('abort', handleFailure);
+        this.removeEventListener('loadend', handleLoadEnd);
+      };
+
+      const finalize = (applied: boolean) => {
+        if (settled) return;
+        settled = true;
+        emitCorruptionEvent(emitter, selectedCorruption!, url, method, applied);
+        cleanup();
+      };
+
+      const applyCorruption = () => {
+        if (corruptedText !== null) {
+          return corruptedText;
+        }
+
+        delete (this as any).responseText;
+
+        try {
+          const originalText = this.responseText;
+          if (typeof originalText !== 'string') {
+            Object.defineProperty(this, 'responseText', { value: originalText, configurable: true });
+            finalize(false);
+            return originalText;
+          }
+
+          corruptedText = corruptText(originalText, selectedCorruption.strategy);
+          Object.defineProperty(this, 'responseText', { value: corruptedText, configurable: true });
+          finalize(true);
+          return corruptedText;
+        } catch (error) {
+          finalize(false);
+          throw error;
+        }
+      };
+
+      const handleFailure = () => {
+        finalize(false);
+      };
+
+      const handleLoadEnd = () => {
+        if (settled) return;
+        try {
+          applyCorruption();
+        } catch {
+          // applyCorruption already finalizes the event and preserves the throw path for direct access
+        }
+      };
+
+      if (typeof this.addEventListener === 'function') {
+        this.addEventListener('error', handleFailure);
+        this.addEventListener('abort', handleFailure);
+        this.addEventListener('loadend', handleLoadEnd);
+      }
+
+      Object.defineProperty(this, 'responseText', {
+        get() {
+          return applyCorruption();
+        },
+        configurable: true,
+      });
+    }
+
+    // 5. Check for Latency
     if (config.latencies) {
       for (const latency of config.latencies) {
         if (url.includes(latency.urlPattern)) {
@@ -76,7 +294,7 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
       }
     }
 
-    // 3. If no chaos, proceed as normal
+    // 6. If no chaos, proceed as normal
     originalXhrSend.call(this, body);
   };
 }

--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -1,0 +1,36 @@
+import { ChaosConfig } from './config';
+
+const MATCH_ALL_URLS = '/';
+
+export const presets: Record<string, ChaosConfig> = {
+  unstableApi: {
+    network: {
+      failures: [{ urlPattern: '/api/', statusCode: 500, probability: 0.1 }],
+      latencies: [{ urlPattern: '/api/', delayMs: 1000, probability: 0.2 }],
+    },
+  },
+  slowNetwork: {
+    network: {
+      latencies: [{ urlPattern: MATCH_ALL_URLS, delayMs: 2000, probability: 1.0 }],
+    },
+  },
+  offlineMode: {
+    network: {
+      cors: [{ urlPattern: MATCH_ALL_URLS, probability: 1.0 }],
+    },
+  },
+  flakyConnection: {
+    network: {
+      aborts: [{ urlPattern: MATCH_ALL_URLS, probability: 0.05 }],
+      latencies: [{ urlPattern: MATCH_ALL_URLS, delayMs: 3000, probability: 0.1 }],
+    },
+  },
+  degradedUi: {
+    ui: {
+      assaults: [
+        { selector: 'button', action: 'disable', probability: 0.2 },
+        { selector: 'a', action: 'hide', probability: 0.1 },
+      ],
+    },
+  },
+};

--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -2,7 +2,17 @@ import { ChaosConfig } from './config';
 
 const MATCH_ALL_URLS = '/';
 
-export const presets: Record<string, ChaosConfig> = {
+function deepFreeze<T>(obj: T): Readonly<T> {
+  if (obj && typeof obj === 'object' && !Object.isFrozen(obj)) {
+    Object.freeze(obj);
+    for (const val of Object.values(obj as Record<string, unknown>)) {
+      deepFreeze(val);
+    }
+  }
+  return obj;
+}
+
+export const presets: Readonly<Record<string, ChaosConfig>> = deepFreeze({
   unstableApi: {
     network: {
       failures: [{ urlPattern: '/api/', statusCode: 500, probability: 0.1 }],
@@ -33,4 +43,4 @@ export const presets: Record<string, ChaosConfig> = {
       ],
     },
   },
-};
+});

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,3 +1,18 @@
+import type { CorruptionStrategy } from './config';
+
 export function shouldApplyChaos(probability: number): boolean {
   return Math.random() < probability;
+}
+
+export function corruptText(text: string, strategy: CorruptionStrategy): string {
+  switch (strategy) {
+    case 'truncate':
+      return text.slice(0, Math.max(0, Math.floor(text.length / 2)));
+    case 'malformed-json':
+      return `${text}"}`;
+    case 'empty':
+      return '';
+    case 'wrong-type':
+      return '<html><body>Unexpected HTML</body></html>';
+  }
 }

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -21,9 +21,32 @@ const networkLatencySchema = z.object({
   probability,
 }).strict();
 
+const networkAbortSchema = z.object({
+  urlPattern: z.string().min(1, 'urlPattern must not be empty'),
+  methods: z.array(z.string()).optional(),
+  probability,
+  timeout: z.number().min(0, 'timeout must be >= 0').optional(),
+}).strict();
+
+const networkCorruptionSchema = z.object({
+  urlPattern: z.string().min(1, 'urlPattern must not be empty'),
+  methods: z.array(z.string()).optional(),
+  probability,
+  strategy: z.enum(['truncate', 'malformed-json', 'empty', 'wrong-type']),
+}).strict();
+
+const networkCorsSchema = z.object({
+  urlPattern: z.string().min(1, 'urlPattern must not be empty'),
+  methods: z.array(z.string()).optional(),
+  probability,
+}).strict();
+
 const networkConfigSchema = z.object({
   failures: z.array(networkFailureSchema).optional(),
   latencies: z.array(networkLatencySchema).optional(),
+  aborts: z.array(networkAbortSchema).optional(),
+  corruptions: z.array(networkCorruptionSchema).optional(),
+  cors: z.array(networkCorsSchema).optional(),
 }).strict();
 
 const uiAssaultSchema = z.object({

--- a/packages/core/test/builder-presets.test.ts
+++ b/packages/core/test/builder-presets.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { ChaosConfigBuilder } from '../src/builder';
+import { presets } from '../src/presets';
+import { validateConfig } from '../src/validation';
+
+describe('ChaosConfigBuilder', () => {
+  it('should build an empty config by default', () => {
+    const builder = new ChaosConfigBuilder();
+    const config = builder.build();
+    expect(config.network).toEqual({});
+    expect(config.ui).toEqual({});
+  });
+
+  it('should add failure requests', () => {
+    const builder = new ChaosConfigBuilder();
+    builder.failRequests('/api/', 500, 0.5, ['GET']);
+    const config = builder.build();
+    expect(config.network?.failures).toHaveLength(1);
+    expect(config.network?.failures?.[0]).toEqual({
+      urlPattern: '/api/',
+      statusCode: 500,
+      probability: 0.5,
+      methods: ['GET'],
+      body: undefined,
+      headers: undefined
+    });
+  });
+
+  it('should add latency', () => {
+    const builder = new ChaosConfigBuilder();
+    builder.addLatency('/api/', 1000, 1.0);
+    const config = builder.build();
+    expect(config.network?.latencies).toHaveLength(1);
+    expect(config.network?.latencies?.[0].delayMs).toBe(1000);
+  });
+
+  it('should add abort requests', () => {
+    const builder = new ChaosConfigBuilder();
+    builder.abortRequests('/api/', 1.0, 100);
+    const config = builder.build();
+    expect(config.network?.aborts).toHaveLength(1);
+    expect(config.network?.aborts?.[0].timeout).toBe(100);
+  });
+
+  it('should add corruptions', () => {
+    const builder = new ChaosConfigBuilder();
+    builder.corruptResponses('/api/', 'truncate', 1.0);
+    const config = builder.build();
+    expect(config.network?.corruptions).toHaveLength(1);
+    expect(config.network?.corruptions?.[0].strategy).toBe('truncate');
+  });
+
+  it('should add cors simulation', () => {
+    const builder = new ChaosConfigBuilder();
+    builder.simulateCors('/api/', 1.0);
+    const config = builder.build();
+    expect(config.network?.cors).toHaveLength(1);
+    expect(config.network?.cors?.[0].probability).toBe(1.0);
+  });
+
+  it('should add UI assaults', () => {
+    const builder = new ChaosConfigBuilder();
+    builder.assaultUi('button', 'disable', 1.0);
+    const config = builder.build();
+    expect(config.ui?.assaults).toHaveLength(1);
+    expect(config.ui?.assaults?.[0].action).toBe('disable');
+  });
+
+  it('should chain methods', () => {
+    const config = new ChaosConfigBuilder()
+      .failRequests('/api/1', 500, 1.0)
+      .addLatency('/api/2', 500, 1.0)
+      .build();
+    
+    expect(config.network?.failures).toHaveLength(1);
+    expect(config.network?.latencies).toHaveLength(1);
+  });
+
+  it('should return a snapshot from build()', () => {
+    const builder = new ChaosConfigBuilder();
+    const firstConfig = builder.build();
+
+    builder.addLatency('/api/', 1000, 1.0);
+
+    expect(firstConfig).toEqual({ network: {}, ui: {} });
+  });
+});
+
+describe('Presets', () => {
+  it('should have predefined presets', () => {
+    expect(presets.unstableApi).toBeDefined();
+    expect(presets.slowNetwork).toBeDefined();
+    expect(presets.offlineMode).toBeDefined();
+    expect(presets.flakyConnection).toBeDefined();
+    expect(presets.degradedUi).toBeDefined();
+  });
+
+  it('unstableApi should have failures and latencies', () => {
+    const config = presets.unstableApi;
+    expect(config.network?.failures).toBeDefined();
+    expect(config.network?.latencies).toBeDefined();
+  });
+
+  it('all presets should pass config validation', () => {
+    for (const config of Object.values(presets)) {
+      expect(() => validateConfig(config)).not.toThrow();
+    }
+  });
+});

--- a/packages/core/test/builder-presets.test.ts
+++ b/packages/core/test/builder-presets.test.ts
@@ -66,23 +66,38 @@ describe('ChaosConfigBuilder', () => {
     expect(config.ui?.assaults?.[0].action).toBe('disable');
   });
 
-  it('should chain methods', () => {
+  it('should chain all methods', () => {
     const config = new ChaosConfigBuilder()
       .failRequests('/api/1', 500, 1.0)
       .addLatency('/api/2', 500, 1.0)
+      .abortRequests('/api/3', 1.0, 50)
+      .corruptResponses('/api/4', 'truncate', 1.0)
+      .simulateCors('/api/5', 1.0)
+      .assaultUi('button', 'disable', 1.0)
       .build();
-    
+
     expect(config.network?.failures).toHaveLength(1);
     expect(config.network?.latencies).toHaveLength(1);
+    expect(config.network?.aborts).toHaveLength(1);
+    expect(config.network?.corruptions).toHaveLength(1);
+    expect(config.network?.cors).toHaveLength(1);
+    expect(config.ui?.assaults).toHaveLength(1);
   });
 
-  it('should return a snapshot from build()', () => {
-    const builder = new ChaosConfigBuilder();
+  it('should return a snapshot from build() that is unaffected by later mutations', () => {
+    const builder = new ChaosConfigBuilder()
+      .failRequests('/api/1', 500, 1.0);
+
     const firstConfig = builder.build();
 
-    builder.addLatency('/api/', 1000, 1.0);
+    builder.addLatency('/api/2', 1000, 1.0);
+    builder.abortRequests('/api/3', 1.0);
+    builder.corruptResponses('/api/4', 'empty', 1.0);
 
-    expect(firstConfig).toEqual({ network: {}, ui: {} });
+    expect(firstConfig.network?.failures).toHaveLength(1);
+    expect(firstConfig.network?.latencies).toBeUndefined();
+    expect(firstConfig.network?.aborts).toBeUndefined();
+    expect(firstConfig.network?.corruptions).toBeUndefined();
   });
 });
 

--- a/packages/core/test/networkFetch.test.ts
+++ b/packages/core/test/networkFetch.test.ts
@@ -1,11 +1,33 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { patchFetch } from '../src/interceptors/networkFetch';
 import { NetworkConfig } from '../src/config';
+import { ChaosEventEmitter } from '../src/events';
 // Import the mock from setup.ts
 import { mockFetch } from './setup';
 
 // Get the mock fetch from our setup file
 const originalFetch = mockFetch;
+
+function createAbortAwareFetch() {
+  return vi.fn((_input: RequestInfo | URL, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+    const signal = init?.signal;
+    if (!signal) {
+      reject(new Error('Missing signal'));
+      return;
+    }
+
+    const rejectWithAbort = () => {
+      reject(signal.reason ?? new DOMException('The user aborted a request.', 'AbortError'));
+    };
+
+    if (signal.aborted) {
+      rejectWithAbort();
+      return;
+    }
+
+    signal.addEventListener('abort', rejectWithAbort, { once: true });
+  }));
+}
 
 beforeEach(() => {
   // Reset mock call history before each test
@@ -89,5 +111,155 @@ describe('patchFetch', () => {
     // With 0 probability, should always call original
     await patchedFetch('/api/flaky');
     expect(originalFetch).toHaveBeenCalled();
+  });
+
+  it('should force a CORS error for a matching URL', async () => {
+    const config: NetworkConfig = {
+      cors: [{ urlPattern: '/api/cors', probability: 1.0 }]
+    };
+    const patchedFetch = patchFetch(originalFetch, config);
+
+    await expect(patchedFetch('/api/cors')).rejects.toThrow('Failed to fetch');
+    expect(originalFetch).not.toHaveBeenCalled();
+  });
+
+  it('should throw an AbortError for a matching URL immediately without timeout', async () => {
+    const config: NetworkConfig = {
+      aborts: [{ urlPattern: '/api/abort', probability: 1.0 }]
+    };
+    const abortAwareFetch = createAbortAwareFetch();
+    const patchedFetch = patchFetch(abortAwareFetch as typeof global.fetch, config);
+
+    await expect(patchedFetch('/api/abort')).rejects.toThrow('The user aborted a request.');
+    expect(abortAwareFetch).toHaveBeenCalledTimes(1);
+    const [, requestInit] = abortAwareFetch.mock.calls[0];
+    expect(requestInit?.signal).toBeDefined();
+    expect(requestInit?.signal?.aborted).toBe(true);
+  });
+
+  it('should throw an AbortError for a matching URL after a delay if timeout is set', async () => {
+    vi.useFakeTimers();
+    const config: NetworkConfig = {
+      aborts: [{ urlPattern: '/api/abort-delay', timeout: 100, probability: 1.0 }]
+    };
+    const abortAwareFetch = createAbortAwareFetch();
+    const patchedFetch = patchFetch(abortAwareFetch as typeof global.fetch, config);
+
+    const requestPromise = patchedFetch('/api/abort-delay');
+    expect(abortAwareFetch).toHaveBeenCalledTimes(1);
+
+    const [, requestInit] = abortAwareFetch.mock.calls[0];
+    expect(requestInit?.signal?.aborted).toBe(false);
+
+    const rejectionAssertion = requestPromise.then(
+      () => {
+        throw new Error('Expected request to abort');
+      },
+      (error) => {
+        expect(error).toMatchObject({
+          name: 'AbortError',
+          message: 'The user aborted a request.',
+        });
+      }
+    );
+    await vi.advanceTimersByTimeAsync(100);
+
+    await rejectionAssertion;
+    expect(requestInit?.signal?.aborted).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('should corrupt response text according to truncate strategy', async () => {
+    const config: NetworkConfig = {
+      corruptions: [{ urlPattern: '/api/corrupt', strategy: 'truncate', probability: 1.0 }]
+    };
+    const patchedFetch = patchFetch(originalFetch, config);
+    originalFetch.mockResolvedValueOnce(new global.Response('HelloWorld', { status: 200 }));
+
+    const response = await patchedFetch('/api/corrupt');
+    const text = await response.text();
+    expect(text).toBe('Hello');
+  });
+
+  it('should corrupt response text according to malformed-json strategy', async () => {
+    const config: NetworkConfig = {
+      corruptions: [{ urlPattern: '/api/corrupt', strategy: 'malformed-json', probability: 1.0 }]
+    };
+    const patchedFetch = patchFetch(originalFetch, config);
+    originalFetch.mockResolvedValueOnce(new global.Response('{"key":"value"}', { status: 200 }));
+
+    const response = await patchedFetch('/api/corrupt');
+    const text = await response.text();
+    expect(text).toBe('{"key":"value"}"}');
+  });
+
+  it('should corrupt response text according to empty strategy', async () => {
+    const config: NetworkConfig = {
+      corruptions: [{ urlPattern: '/api/corrupt', strategy: 'empty', probability: 1.0 }]
+    };
+    const patchedFetch = patchFetch(originalFetch, config);
+    originalFetch.mockResolvedValueOnce(new global.Response('HelloWorld', { status: 200 }));
+
+    const response = await patchedFetch('/api/corrupt');
+    const text = await response.text();
+    expect(text).toBe('');
+  });
+
+  it('should corrupt response text according to wrong-type strategy', async () => {
+    const config: NetworkConfig = {
+      corruptions: [{ urlPattern: '/api/corrupt', strategy: 'wrong-type', probability: 1.0 }]
+    };
+    const patchedFetch = patchFetch(originalFetch, config);
+    originalFetch.mockResolvedValueOnce(new global.Response('HelloWorld', { status: 200 }));
+
+    const response = await patchedFetch('/api/corrupt');
+    const text = await response.text();
+    expect(text).toBe('<html><body>Unexpected HTML</body></html>');
+  });
+
+  it('should log corruption as not applied when fetch fails before a response is available', async () => {
+    const emitter = new ChaosEventEmitter();
+    const failingFetch = vi.fn().mockRejectedValue(new Error('boom'));
+    const config: NetworkConfig = {
+      corruptions: [{ urlPattern: '/api/corrupt', strategy: 'truncate', probability: 1.0 }]
+    };
+    const patchedFetch = patchFetch(failingFetch as typeof global.fetch, config, emitter);
+
+    await expect(patchedFetch('/api/corrupt')).rejects.toThrow('boom');
+    expect(emitter.getLog()).toEqual([
+      expect.objectContaining({
+        type: 'network:corruption',
+        applied: false,
+        detail: expect.objectContaining({
+          url: '/api/corrupt',
+          method: 'GET',
+          strategy: 'truncate',
+        }),
+      }),
+    ]);
+  });
+
+  it('should log abort as not applied when the request completes before the timeout fires', async () => {
+    const emitter = new ChaosEventEmitter();
+    const fastFetch = vi.fn().mockResolvedValue(new global.Response('{}', { status: 200 }));
+    const config: NetworkConfig = {
+      aborts: [{ urlPattern: '/api/fast', timeout: 100, probability: 1.0 }]
+    };
+    const patchedFetch = patchFetch(fastFetch as typeof global.fetch, config, emitter);
+
+    const response = await patchedFetch('/api/fast');
+
+    expect(response.status).toBe(200);
+    expect(emitter.getLog()).toEqual([
+      expect.objectContaining({
+        type: 'network:abort',
+        applied: false,
+        detail: expect.objectContaining({
+          url: '/api/fast',
+          method: 'GET',
+          timeoutMs: 100,
+        }),
+      }),
+    ]);
   });
 });

--- a/packages/core/test/networkFetch.test.ts
+++ b/packages/core/test/networkFetch.test.ts
@@ -240,6 +240,7 @@ describe('patchFetch', () => {
   });
 
   it('should log abort as not applied when the request completes before the timeout fires', async () => {
+    vi.useFakeTimers();
     const emitter = new ChaosEventEmitter();
     const fastFetch = vi.fn().mockResolvedValue(new global.Response('{}', { status: 200 }));
     const config: NetworkConfig = {
@@ -248,8 +249,12 @@ describe('patchFetch', () => {
     const patchedFetch = patchFetch(fastFetch as typeof global.fetch, config, emitter);
 
     const response = await patchedFetch('/api/fast');
-
     expect(response.status).toBe(200);
+
+    // Advance past the timeout to prove the timer was cancelled
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(emitter.getLog()).toHaveLength(1);
     expect(emitter.getLog()).toEqual([
       expect.objectContaining({
         type: 'network:abort',
@@ -261,5 +266,6 @@ describe('patchFetch', () => {
         }),
       }),
     ]);
+    vi.useRealTimers();
   });
 });

--- a/packages/core/test/networkXHR.test.ts
+++ b/packages/core/test/networkXHR.test.ts
@@ -297,6 +297,7 @@ describe('patchXHR (send)', () => {
   });
 
   it('should log abort as not applied when XHR completes before the timeout fires', () => {
+    vi.useFakeTimers();
     const emitter = new ChaosEventEmitter();
     const config: NetworkConfig = {
       aborts: [{ urlPattern: '/api/fast', timeout: 100, probability: 1.0 }]
@@ -314,7 +315,11 @@ describe('patchXHR (send)', () => {
 
     xhr.send();
 
+    // Advance past the timeout to prove the timer was cancelled
+    vi.advanceTimersByTime(200);
+
     expect(mockXhrAbort).not.toHaveBeenCalled();
+    expect(emitter.getLog()).toHaveLength(1);
     expect(emitter.getLog()).toEqual([
       expect.objectContaining({
         type: 'network:abort',
@@ -326,5 +331,6 @@ describe('patchXHR (send)', () => {
         }),
       }),
     ]);
+    vi.useRealTimers();
   });
 });

--- a/packages/core/test/networkXHR.test.ts
+++ b/packages/core/test/networkXHR.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { patchXHR, patchXHROpen } from '../src/interceptors/networkXHR';
 import { NetworkConfig } from '../src/config';
+import { ChaosEventEmitter } from '../src/events';
 // Import the mocks from setup.ts
-import { mockXhrOpen, mockXhrSend } from './setup';
+import { mockXhrAbort, mockXhrOpen, mockXhrSend } from './setup';
 
 // Get the original implementations
 const originalXhrOpen = global.XMLHttpRequest.prototype.open;
@@ -13,6 +14,7 @@ beforeEach(() => {
   // Now these are the correct vi.fn() objects
   mockXhrOpen.mockClear();
   mockXhrSend.mockClear();
+  mockXhrAbort.mockClear();
   
   // Restore originals before each test
   global.XMLHttpRequest.prototype.open = originalXhrOpen;
@@ -122,5 +124,207 @@ describe('patchXHR (send)', () => {
     expect(mockXhrSend).toHaveBeenCalled();
 
     vi.useRealTimers(); // Restore real timers
+  });
+
+  it('should force a CORS error for a matching URL', () => {
+    const config: NetworkConfig = {
+      cors: [{ urlPattern: '/api/cors', probability: 1.0 }]
+    };
+    const patchedSend = patchXHR(originalXhrSend, config);
+    global.XMLHttpRequest.prototype.send = patchedSend;
+
+    const xhr = new global.XMLHttpRequest();
+    const errorSpy = vi.spyOn(xhr, 'dispatchEvent');
+    (xhr as any)._chaos_url = '/api/cors';
+    (xhr as any)._chaos_method = 'GET';
+
+    xhr.send();
+
+    expect(mockXhrSend).not.toHaveBeenCalled();
+    expect(xhr.status).toBe(0);
+    expect(errorSpy).toHaveBeenCalledWith(new Event('error'));
+  });
+
+  it('should force an abort for a matching URL immediately', () => {
+    const config: NetworkConfig = {
+      aborts: [{ urlPattern: '/api/abort', probability: 1.0 }]
+    };
+    const patchedSend = patchXHR(originalXhrSend, config);
+    global.XMLHttpRequest.prototype.send = patchedSend;
+
+    const xhr = new global.XMLHttpRequest();
+    const abortSpy = vi.spyOn(xhr, 'dispatchEvent');
+    (xhr as any)._chaos_url = '/api/abort';
+    (xhr as any)._chaos_method = 'GET';
+
+    xhr.send();
+
+    expect(mockXhrSend).toHaveBeenCalled();
+    expect(mockXhrAbort).toHaveBeenCalledTimes(1);
+    expect(xhr.status).toBe(0);
+    expect(abortSpy).toHaveBeenCalledWith(new Event('abort'));
+  });
+
+  it('should force an abort for a matching URL after timeout', () => {
+    vi.useFakeTimers();
+    const config: NetworkConfig = {
+      aborts: [{ urlPattern: '/api/abort', probability: 1.0, timeout: 100 }]
+    };
+    const patchedSend = patchXHR(originalXhrSend, config);
+    global.XMLHttpRequest.prototype.send = patchedSend;
+
+    const xhr = new global.XMLHttpRequest();
+    const abortSpy = vi.spyOn(xhr, 'dispatchEvent');
+    (xhr as any)._chaos_url = '/api/abort';
+    (xhr as any)._chaos_method = 'GET';
+
+    xhr.send();
+
+    expect(mockXhrSend).toHaveBeenCalled();
+    expect(mockXhrAbort).not.toHaveBeenCalled();
+    expect(abortSpy).not.toHaveBeenCalledWith(new Event('abort'));
+
+    vi.advanceTimersByTime(100);
+
+    expect(mockXhrAbort).toHaveBeenCalledTimes(1);
+    expect(xhr.status).toBe(0);
+    expect(abortSpy).toHaveBeenCalledWith(new Event('abort'));
+    vi.useRealTimers();
+  });
+
+  it('should corrupt response text according to truncate strategy', () => {
+    const config: NetworkConfig = {
+      corruptions: [{ urlPattern: '/api/corrupt', strategy: 'truncate', probability: 1.0 }]
+    };
+    const patchedSend = patchXHR(originalXhrSend, config);
+    global.XMLHttpRequest.prototype.send = patchedSend;
+
+    const xhr = new global.XMLHttpRequest();
+    (xhr as any)._chaos_url = '/api/corrupt';
+    (xhr as any)._chaos_method = 'GET';
+
+    // Original property (simulate it loading)
+    (xhr as any)._responseText = 'HelloWorld';
+
+    xhr.send();
+
+    expect(xhr.responseText).toBe('Hello');
+  });
+
+  it('should corrupt response text according to malformed-json strategy', () => {
+    const config: NetworkConfig = {
+      corruptions: [{ urlPattern: '/api/corrupt', strategy: 'malformed-json', probability: 1.0 }]
+    };
+    const patchedSend = patchXHR(originalXhrSend, config);
+    global.XMLHttpRequest.prototype.send = patchedSend;
+
+    const xhr = new global.XMLHttpRequest();
+    (xhr as any)._chaos_url = '/api/corrupt';
+    (xhr as any)._chaos_method = 'GET';
+
+    (xhr as any)._responseText = '{"key":"value"}';
+
+    xhr.send();
+
+    expect(xhr.responseText).toBe('{"key":"value"}"}');
+  });
+
+  it('should corrupt response text according to empty strategy', () => {
+    const config: NetworkConfig = {
+      corruptions: [{ urlPattern: '/api/corrupt', strategy: 'empty', probability: 1.0 }]
+    };
+    const patchedSend = patchXHR(originalXhrSend, config);
+    global.XMLHttpRequest.prototype.send = patchedSend;
+
+    const xhr = new global.XMLHttpRequest();
+    (xhr as any)._chaos_url = '/api/corrupt';
+    (xhr as any)._chaos_method = 'GET';
+
+    (xhr as any)._responseText = 'HelloWorld';
+
+    xhr.send();
+
+    expect(xhr.responseText).toBe('');
+  });
+
+  it('should corrupt response text according to wrong-type strategy', () => {
+    const config: NetworkConfig = {
+      corruptions: [{ urlPattern: '/api/corrupt', strategy: 'wrong-type', probability: 1.0 }]
+    };
+    const patchedSend = patchXHR(originalXhrSend, config);
+    global.XMLHttpRequest.prototype.send = patchedSend;
+
+    const xhr = new global.XMLHttpRequest();
+    (xhr as any)._chaos_url = '/api/corrupt';
+    (xhr as any)._chaos_method = 'GET';
+
+    (xhr as any)._responseText = '{"key":"value"}';
+
+    xhr.send();
+
+    expect(xhr.responseText).toBe('<html><body>Unexpected HTML</body></html>');
+  });
+
+  it('should log corruption as not applied when XHR errors before response text is available', () => {
+    const emitter = new ChaosEventEmitter();
+    const config: NetworkConfig = {
+      corruptions: [{ urlPattern: '/api/corrupt', strategy: 'truncate', probability: 1.0 }]
+    };
+    const failingSend = function (this: XMLHttpRequest) {
+      this.dispatchEvent(new Event('error'));
+      this.dispatchEvent(new Event('loadend'));
+    };
+    const patchedSend = patchXHR(failingSend, config, emitter);
+    global.XMLHttpRequest.prototype.send = patchedSend;
+
+    const xhr = new global.XMLHttpRequest();
+    (xhr as any)._chaos_url = '/api/corrupt';
+    (xhr as any)._chaos_method = 'GET';
+
+    xhr.send();
+
+    expect(emitter.getLog()).toEqual([
+      expect.objectContaining({
+        type: 'network:corruption',
+        applied: false,
+        detail: expect.objectContaining({
+          url: '/api/corrupt',
+          method: 'GET',
+          strategy: 'truncate',
+        }),
+      }),
+    ]);
+  });
+
+  it('should log abort as not applied when XHR completes before the timeout fires', () => {
+    const emitter = new ChaosEventEmitter();
+    const config: NetworkConfig = {
+      aborts: [{ urlPattern: '/api/fast', timeout: 100, probability: 1.0 }]
+    };
+    const successfulSend = function (this: XMLHttpRequest) {
+      this.dispatchEvent(new Event('load'));
+      this.dispatchEvent(new Event('loadend'));
+    };
+    const patchedSend = patchXHR(successfulSend, config, emitter);
+    global.XMLHttpRequest.prototype.send = patchedSend;
+
+    const xhr = new global.XMLHttpRequest();
+    (xhr as any)._chaos_url = '/api/fast';
+    (xhr as any)._chaos_method = 'GET';
+
+    xhr.send();
+
+    expect(mockXhrAbort).not.toHaveBeenCalled();
+    expect(emitter.getLog()).toEqual([
+      expect.objectContaining({
+        type: 'network:abort',
+        applied: false,
+        detail: expect.objectContaining({
+          url: '/api/fast',
+          method: 'GET',
+          timeoutMs: 100,
+        }),
+      }),
+    ]);
   });
 });

--- a/packages/core/test/setup.ts
+++ b/packages/core/test/setup.ts
@@ -4,16 +4,19 @@ import { vi } from 'vitest';
 export const mockFetch = vi.fn();
 export const mockXhrOpen = vi.fn();
 export const mockXhrSend = vi.fn();
+export const mockXhrAbort = vi.fn();
 
 vi.stubGlobal('fetch', mockFetch);
 
-class MockXMLHttpRequest {
+class MockXMLHttpRequest extends EventTarget {
   _chaos_url: string = '';
   _chaos_method: string = '';
+  _responseText: string = '';
 
   // Add getters/setters that were implicitly used by the patcher
   // This is a more robust mock.
   constructor() {
+    super();
     Object.defineProperties(this, {
       status: {
         writable: true,
@@ -28,6 +31,14 @@ class MockXMLHttpRequest {
     });
   }
 
+  get responseText() {
+    return this._responseText;
+  }
+
+  set responseText(val) {
+    this._responseText = val;
+  }
+
   open(method: string, url: string) {
     this._chaos_url = url;
     this._chaos_method = method;
@@ -38,8 +49,16 @@ class MockXMLHttpRequest {
     mockXhrSend(body); // Call the exported mock
   }
 
-  dispatchEvent(_event: Event) {
-    return true;
+  abort() {
+    mockXhrAbort();
+    this.status = 0;
+    this.statusText = '';
+    this.dispatchEvent(new Event('abort'));
+    this.dispatchEvent(new Event('loadend'));
+  }
+
+  dispatchEvent(event: Event) {
+    return super.dispatchEvent(event);
   }
 }
 
@@ -49,14 +68,20 @@ vi.stubGlobal('Response', class MockResponse {
   status: number;
   statusText: string;
   body: any;
+  headers: any;
 
   constructor(body: any, init: any) {
     this.body = body;
     this.status = init?.status || 200;
     this.statusText = init?.statusText || 'OK';
+    this.headers = init?.headers || {};
   }
 
   json() {
     return Promise.resolve(JSON.parse(this.body));
+  }
+
+  text() {
+    return Promise.resolve(String(this.body));
   }
 } as any);


### PR DESCRIPTION
## Summary

- Add three new network chaos types: **abort** (immediate or timed, using real `AbortController`/`xhr.abort()`), **CORS simulation** (throws `TypeError('Failed to fetch')` / sets `status: 0`), and **response corruption** (`truncate`, `malformed-json`, `empty`, `wrong-type` strategies applied post-fetch)
- Add five built-in **presets**: `unstableApi`, `slowNetwork`, `offlineMode`, `flakyConnection`, `degradedUi`
- Add **`ChaosConfigBuilder`** — fluent API for composing chaos configs with full chain support and snapshot-safe `build()`
- Export all new types and symbols from the public index

## Test plan

- [x] 72 unit tests pass (`pnpm --filter @chaos-maker/core exec vitest run`)
- [x] Build succeeds for both core and playwright packages (`pnpm build`)
- [x] E2E tests pass locally on Chromium (`playwright test --project=chromium`)
- [x] All presets validated against Zod schema in test suite
- [x] Builder snapshot isolation verified (mutating builder after `build()` doesn't affect returned config)
- [x] Abort/corruption events correctly emit `applied: false` when request completes before timeout / errors before body is available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fluent config builder and curated presets (unstableApi, slowNetwork, offlineMode, flakyConnection, degradedUi)
  * Network chaos: response corruption (truncate, malformed JSON, empty, wrong-type), request aborts with timeouts, and CORS failure injection
  * Improved event emission for new network chaos types

* **Tests**
  * Expanded tests covering builder, presets, fetch/XHR chaos scenarios and event logging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->