### PR TITLE
feat: extension polish, npm publish workflow, test hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,21 @@ jobs:
       - name: Build All Packages
         run: pnpm build
 
+      - name: Report Bundle Size
+        run: |
+          echo "## Bundle Size Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| File | Size | Gzipped |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|------|---------|" >> $GITHUB_STEP_SUMMARY
+          for f in packages/core/dist/chaos-maker.js packages/core/dist/chaos-maker.cjs packages/core/dist/chaos-maker.umd.js; do
+            if [ -f "$f" ]; then
+              raw=$(wc -c < "$f" | tr -d ' ')
+              gz=$(gzip -c "$f" | wc -c | tr -d ' ')
+              name=$(basename "$f")
+              echo "| \`$name\` | ${raw}B | ${gz}B |" >> $GITHUB_STEP_SUMMARY
+            fi
+          done
+
       - name: Archive Build Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Unit Tests
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+      - name: Cache Playwright Browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('e2e-tests/package.json') }}
+
+      - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter e2e-tests exec playwright install --with-deps
+
+      - name: Install Playwright System Dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter e2e-tests exec playwright install-deps
+
+      - name: E2E Tests
+        run: pnpm --filter e2e-tests test
+
+  publish-core:
+    name: Publish @chaos-maker/core
+    runs-on: ubuntu-latest
+    needs: validate
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Build Core
+        run: pnpm build:core
+
+      - name: Publish Core
+        run: pnpm --filter @chaos-maker/core publish --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-playwright:
+    name: Publish @chaos-maker/playwright
+    runs-on: ubuntu-latest
+    needs: publish-core
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Build All
+        run: pnpm build
+
+      - name: Publish Playwright Adapter
+        run: pnpm --filter @chaos-maker/playwright publish --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Ensure tag is on main
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" "origin/main"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -26,7 +33,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
         run: pnpm lint
@@ -77,7 +84,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build Core
         run: pnpm build:core
@@ -109,10 +116,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
-      - name: Build All
-        run: pnpm build
+      - name: Build Playwright
+        run: pnpm build:core && pnpm build:playwright
 
       - name: Publish Playwright Adapter
         run: pnpm --filter @chaos-maker/playwright publish --no-git-checks --access public

--- a/packages/core/src/ChaosMaker.ts
+++ b/packages/core/src/ChaosMaker.ts
@@ -8,6 +8,7 @@ import { attachDomAssailant } from './interceptors/domAssailant';
 export class ChaosMaker {
   private config: ChaosConfig;
   private emitter: ChaosEventEmitter;
+  private running = false;
   private originalFetch?: typeof window.fetch;
   private originalXhrSend?: (body?: Document | XMLHttpRequestBodyInit) => void;
   private originalXhrOpen?: (method: string, url: string | URL) => void;
@@ -36,6 +37,11 @@ export class ChaosMaker {
   }
 
   public start(): void {
+    if (this.running) {
+      console.warn('Chaos Maker is already running. Call stop() first.');
+      return;
+    }
+    this.running = true;
     console.log('🛠️ Chaos Maker ENGAGED 🛠️');
 
     if (this.config.network) {
@@ -60,6 +66,7 @@ export class ChaosMaker {
   }
 
   public stop(): void {
+    this.running = false;
     console.log('🛑 Chaos Maker DISENGAGED 🛑');
 
     if (this.originalFetch) {

--- a/packages/core/test/ChaosMaker.edge.test.ts
+++ b/packages/core/test/ChaosMaker.edge.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { ChaosMaker } from '../src/ChaosMaker';
+import { ChaosConfig } from '../src/config';
+import { ChaosConfigError } from '../src/errors';
+
+const originalFetch = global.fetch;
+const originalXhrOpen = global.XMLHttpRequest.prototype.open;
+const originalXhrSend = global.XMLHttpRequest.prototype.send;
+
+function restore() {
+  global.fetch = originalFetch;
+  global.XMLHttpRequest.prototype.open = originalXhrOpen;
+  global.XMLHttpRequest.prototype.send = originalXhrSend;
+}
+
+describe('ChaosMaker edge cases', () => {
+  afterEach(restore);
+
+  // --- Double start ---
+
+  it('should handle double start as a no-op', () => {
+    const config: ChaosConfig = { network: {} };
+    const cm = new ChaosMaker(config);
+
+    cm.start();
+    const fetchAfterFirst = global.fetch;
+
+    // Second start is a no-op — does not re-patch
+    cm.start();
+    expect(global.fetch).toBe(fetchAfterFirst);
+
+    cm.stop();
+  });
+
+  it('should restore to original fetch after double start then stop', () => {
+    const config: ChaosConfig = { network: {} };
+    const cm = new ChaosMaker(config);
+
+    cm.start();
+    cm.start(); // no-op due to running guard
+    cm.stop();
+
+    // Original is correctly preserved since second start was a no-op
+    expect(global.fetch).toBe(originalFetch);
+  });
+
+  // --- Stop without start ---
+
+  it('should handle stop without start gracefully', () => {
+    const config: ChaosConfig = { network: {} };
+    const cm = new ChaosMaker(config);
+
+    // Should not throw
+    expect(() => cm.stop()).not.toThrow();
+
+    // Globals should remain untouched
+    expect(global.fetch).toBe(originalFetch);
+  });
+
+  it('should handle double stop gracefully', () => {
+    const config: ChaosConfig = { network: {} };
+    const cm = new ChaosMaker(config);
+
+    cm.start();
+    cm.stop();
+
+    // Second stop should not throw
+    expect(() => cm.stop()).not.toThrow();
+    expect(global.fetch).toBe(originalFetch);
+  });
+
+  // --- Multiple instances ---
+
+  it('should support two concurrent instances patching different configs', async () => {
+    const config1: ChaosConfig = {
+      network: {
+        failures: [{ urlPattern: '/api/one', statusCode: 500, probability: 1.0 }],
+      },
+    };
+    const config2: ChaosConfig = {
+      network: {
+        failures: [{ urlPattern: '/api/two', statusCode: 503, probability: 1.0 }],
+      },
+    };
+
+    const cm1 = new ChaosMaker(config1);
+    const cm2 = new ChaosMaker(config2);
+
+    cm1.start();
+    cm2.start(); // overwrites fetch with cm2's patch
+
+    // The active patch is cm2's — it intercepts /api/two
+    const res = await global.fetch('/api/two');
+    expect(res.status).toBe(503);
+
+    cm2.stop();
+    cm1.stop();
+  });
+
+  // --- Event log ---
+
+  it('should return empty log before start', () => {
+    const config: ChaosConfig = { network: {} };
+    const cm = new ChaosMaker(config);
+    expect(cm.getLog()).toEqual([]);
+  });
+
+  it('should accumulate events across multiple requests', async () => {
+    const config: ChaosConfig = {
+      network: {
+        failures: [{ urlPattern: '/api/', statusCode: 500, probability: 1.0 }],
+      },
+    };
+    const cm = new ChaosMaker(config);
+    cm.start();
+
+    await global.fetch('/api/a');
+    await global.fetch('/api/b');
+    await global.fetch('/api/c');
+
+    expect(cm.getLog().length).toBe(3);
+    expect(cm.getLog().every((e) => e.type === 'network:failure' && e.applied)).toBe(true);
+
+    cm.stop();
+  });
+
+  it('should clear log independently of chaos state', async () => {
+    const config: ChaosConfig = {
+      network: {
+        failures: [{ urlPattern: '/api/', statusCode: 500, probability: 1.0 }],
+      },
+    };
+    const cm = new ChaosMaker(config);
+    cm.start();
+
+    await global.fetch('/api/test');
+    expect(cm.getLog().length).toBe(1);
+
+    cm.clearLog();
+    expect(cm.getLog().length).toBe(0);
+
+    // Chaos still works after clearing log
+    await global.fetch('/api/test');
+    expect(cm.getLog().length).toBe(1);
+
+    cm.stop();
+  });
+
+  // --- Config validation ---
+
+  it('should reject invalid config at construction time', () => {
+    expect(() => {
+      new ChaosMaker({
+        network: {
+          failures: [{ urlPattern: '', statusCode: 999, probability: 2.0 }],
+        },
+      });
+    }).toThrow(ChaosConfigError);
+  });
+
+  // --- Empty config ---
+
+  it('should handle empty config without patching anything', () => {
+    const cm = new ChaosMaker({});
+    cm.start();
+
+    // No network config means fetch/XHR not patched
+    expect(global.fetch).toBe(originalFetch);
+    expect(global.XMLHttpRequest.prototype.send).toBe(originalXhrSend);
+
+    cm.stop();
+  });
+
+  it('should handle ui-only config without patching network', () => {
+    const cm = new ChaosMaker({
+      ui: {
+        assaults: [{ selector: 'button', action: 'disable', probability: 1.0 }],
+      },
+    });
+    cm.start();
+
+    // fetch/XHR should NOT be patched
+    expect(global.fetch).toBe(originalFetch);
+    expect(global.XMLHttpRequest.prototype.send).toBe(originalXhrSend);
+
+    cm.stop();
+  });
+});

--- a/packages/core/test/domAssailant.test.ts
+++ b/packages/core/test/domAssailant.test.ts
@@ -121,7 +121,7 @@ describe('domAssailant', () => {
     el.textContent = 'Dynamic content';
     document.body.appendChild(el);
 
-    // MutationObserver fires asynchronously — flush microtasks
+    // MutationObserver fires asynchronously — wait for callback to execute
     await new Promise((r) => setTimeout(r, 0));
 
     expect(el.style.display).toBe('none');
@@ -207,7 +207,7 @@ describe('domAssailant', () => {
     expect(() => startObserver(config)).not.toThrow();
   });
 
-  it('should handle disconnect correctly', () => {
+  it('should handle disconnect correctly', async () => {
     const config: UiConfig = {
       assaults: [{ selector: 'button', action: 'disable', probability: 1.0 }],
     };
@@ -219,7 +219,9 @@ describe('domAssailant', () => {
     btn.textContent = 'After disconnect';
     document.body.appendChild(btn);
 
-    // Even after a tick, the observer is disconnected
+    // Wait to confirm no deferred callback fires
+    await new Promise((r) => setTimeout(r, 0));
+
     expect(btn.disabled).toBe(false);
   });
 });

--- a/packages/core/test/domAssailant.test.ts
+++ b/packages/core/test/domAssailant.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { attachDomAssailant } from '../src/interceptors/domAssailant';
+import { UiConfig } from '../src/config';
+import { ChaosEventEmitter } from '../src/events';
+
+describe('domAssailant', () => {
+  let emitter: ChaosEventEmitter;
+  let observer: MutationObserver;
+
+  beforeEach(() => {
+    emitter = new ChaosEventEmitter();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    if (observer) {
+      observer.disconnect();
+    }
+    document.body.innerHTML = '';
+  });
+
+  function startObserver(config: UiConfig): MutationObserver {
+    observer = attachDomAssailant(config, emitter);
+    observer.observe(document.body, { childList: true, subtree: true });
+    return observer;
+  }
+
+  // --- Initial scan tests ---
+
+  it('should disable existing buttons on initial scan', () => {
+    document.body.innerHTML = '<button id="btn">Click</button>';
+
+    const config: UiConfig = {
+      assaults: [{ selector: 'button', action: 'disable', probability: 1.0 }],
+    };
+    startObserver(config);
+
+    const btn = document.getElementById('btn') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('should hide existing elements on initial scan', () => {
+    document.body.innerHTML = '<div class="sidebar">Sidebar</div>';
+
+    const config: UiConfig = {
+      assaults: [{ selector: '.sidebar', action: 'hide', probability: 1.0 }],
+    };
+    startObserver(config);
+
+    const sidebar = document.querySelector('.sidebar') as HTMLElement;
+    expect(sidebar.style.display).toBe('none');
+  });
+
+  it('should remove existing elements on initial scan', () => {
+    document.body.innerHTML = '<span class="ad">Ad content</span>';
+
+    const config: UiConfig = {
+      assaults: [{ selector: '.ad', action: 'remove', probability: 1.0 }],
+    };
+    startObserver(config);
+
+    expect(document.querySelector('.ad')).toBeNull();
+  });
+
+  it('should not apply assault when probability is 0', () => {
+    document.body.innerHTML = '<button id="btn">Click</button>';
+
+    const config: UiConfig = {
+      assaults: [{ selector: 'button', action: 'disable', probability: 0 }],
+    };
+    startObserver(config);
+
+    const btn = document.getElementById('btn') as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+  });
+
+  it('should handle multiple assaults on different selectors', () => {
+    document.body.innerHTML = `
+      <button id="btn">Click</button>
+      <div class="sidebar">Side</div>
+    `;
+
+    const config: UiConfig = {
+      assaults: [
+        { selector: 'button', action: 'disable', probability: 1.0 },
+        { selector: '.sidebar', action: 'hide', probability: 1.0 },
+      ],
+    };
+    startObserver(config);
+
+    expect((document.getElementById('btn') as HTMLButtonElement).disabled).toBe(true);
+    expect((document.querySelector('.sidebar') as HTMLElement).style.display).toBe('none');
+  });
+
+  it('should handle nested matching elements in initial scan', () => {
+    document.body.innerHTML = `
+      <div class="container">
+        <button class="inner">Inner</button>
+      </div>
+    `;
+
+    const config: UiConfig = {
+      assaults: [{ selector: 'button.inner', action: 'disable', probability: 1.0 }],
+    };
+    startObserver(config);
+
+    const btn = document.querySelector('button.inner') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  // --- MutationObserver tests ---
+
+  it('should assault dynamically added elements', async () => {
+    const config: UiConfig = {
+      assaults: [{ selector: '.dynamic', action: 'hide', probability: 1.0 }],
+    };
+    startObserver(config);
+
+    const el = document.createElement('div');
+    el.className = 'dynamic';
+    el.textContent = 'Dynamic content';
+    document.body.appendChild(el);
+
+    // MutationObserver fires asynchronously — flush microtasks
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(el.style.display).toBe('none');
+  });
+
+  it('should assault children of dynamically added parent nodes', async () => {
+    const config: UiConfig = {
+      assaults: [{ selector: 'button', action: 'disable', probability: 1.0 }],
+    };
+    startObserver(config);
+
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = '<button id="dynamic-btn">New</button>';
+    document.body.appendChild(wrapper);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const btn = document.getElementById('dynamic-btn') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  // --- Event emission tests ---
+
+  it('should emit ui:assault event with applied: true', () => {
+    document.body.innerHTML = '<button>Click</button>';
+
+    const config: UiConfig = {
+      assaults: [{ selector: 'button', action: 'disable', probability: 1.0 }],
+    };
+    startObserver(config);
+
+    const log = emitter.getLog();
+    expect(log.length).toBeGreaterThanOrEqual(1);
+
+    const event = log.find((e) => e.type === 'ui:assault' && e.applied);
+    expect(event).toBeDefined();
+    expect(event!.detail.selector).toBe('button');
+    expect(event!.detail.action).toBe('disable');
+  });
+
+  it('should emit ui:assault event with applied: false when skipped', () => {
+    document.body.innerHTML = '<button>Click</button>';
+
+    const config: UiConfig = {
+      assaults: [{ selector: 'button', action: 'disable', probability: 0 }],
+    };
+    startObserver(config);
+
+    const log = emitter.getLog();
+    const event = log.find((e) => e.type === 'ui:assault' && !e.applied);
+    expect(event).toBeDefined();
+  });
+
+  // --- Edge cases ---
+
+  it('should handle empty assaults array gracefully', () => {
+    document.body.innerHTML = '<button>Click</button>';
+
+    const config: UiConfig = { assaults: [] };
+    startObserver(config);
+
+    expect(emitter.getLog()).toHaveLength(0);
+    expect((document.querySelector('button') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('should handle no assaults key gracefully', () => {
+    document.body.innerHTML = '<button>Click</button>';
+
+    const config: UiConfig = {};
+    startObserver(config);
+
+    expect(emitter.getLog()).toHaveLength(0);
+  });
+
+  it('should not crash on invalid CSS selector', () => {
+    document.body.innerHTML = '<button>Click</button>';
+
+    const config: UiConfig = {
+      assaults: [{ selector: '[[[invalid', action: 'disable', probability: 1.0 }],
+    };
+
+    // Should not throw
+    expect(() => startObserver(config)).not.toThrow();
+  });
+
+  it('should handle disconnect correctly', () => {
+    const config: UiConfig = {
+      assaults: [{ selector: 'button', action: 'disable', probability: 1.0 }],
+    };
+    startObserver(config);
+    observer.disconnect();
+
+    // Add element after disconnect — should NOT be assaulted
+    const btn = document.createElement('button');
+    btn.textContent = 'After disconnect';
+    document.body.appendChild(btn);
+
+    // Even after a tick, the observer is disconnected
+    expect(btn.disabled).toBe(false);
+  });
+});

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Chaos Utils",
+  "name": "Chaos Maker",
   "version": "1.0.0",
   "description": "Injects chaos into web applications to test resilience.",
   "permissions": [

--- a/packages/extension/popup/popup.css
+++ b/packages/extension/popup/popup.css
@@ -4,6 +4,18 @@
   box-sizing: border-box;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   width: 380px;

--- a/packages/extension/popup/popup.css
+++ b/packages/extension/popup/popup.css
@@ -1,0 +1,231 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  width: 380px;
+  padding: 16px;
+  background: #1a1a2e;
+  color: #e0e0e0;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+h1 {
+  font-size: 18px;
+  font-weight: 700;
+  color: #fff;
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: 12px;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.status-inactive {
+  background: rgba(255, 255, 255, 0.08);
+  color: #888;
+}
+
+.status-inactive .status-dot {
+  background: #666;
+}
+
+.status-active {
+  background: rgba(76, 175, 80, 0.15);
+  color: #4caf50;
+}
+
+.status-active .status-dot {
+  background: #4caf50;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* Tabs */
+.tabs {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 3px;
+}
+
+.tab {
+  flex: 1;
+  padding: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  background: transparent;
+  color: #888;
+  transition: all 0.15s ease;
+}
+
+.tab:hover {
+  color: #ccc;
+}
+
+.tab.active {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+/* Panels */
+.panel {
+  display: none;
+}
+
+.panel.active {
+  display: block;
+}
+
+select {
+  width: 100%;
+  padding: 10px 12px;
+  font-size: 13px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #e0e0e0;
+  cursor: pointer;
+  margin-bottom: 10px;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23888' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+}
+
+select:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.5);
+}
+
+.config-preview {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  color: #a0a0a0;
+  max-height: 160px;
+  overflow-y: auto;
+  white-space: pre;
+}
+
+textarea {
+  width: 100%;
+  height: 200px;
+  padding: 10px 12px;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #e0e0e0;
+  resize: vertical;
+}
+
+textarea:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.5);
+}
+
+/* Error */
+.error {
+  color: #ef4444;
+  font-size: 12px;
+  margin-top: 8px;
+  padding: 8px 10px;
+  background: rgba(239, 68, 68, 0.1);
+  border-radius: 6px;
+  border: 1px solid rgba(239, 68, 68, 0.2);
+}
+
+.hidden {
+  display: none !important;
+}
+
+/* Buttons */
+.actions {
+  margin-top: 12px;
+}
+
+.btn {
+  width: 100%;
+  padding: 11px;
+  font-size: 14px;
+  font-weight: 600;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.btn-start {
+  background: #4caf50;
+  color: #fff;
+}
+
+.btn-start:hover {
+  background: #43a047;
+}
+
+.btn-stop {
+  background: #ef4444;
+  color: #fff;
+}
+
+.btn-stop:hover {
+  background: #dc2626;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Footer */
+footer {
+  margin-top: 12px;
+  text-align: center;
+}
+
+footer a {
+  color: #6366f1;
+  font-size: 12px;
+  text-decoration: none;
+}
+
+footer a:hover {
+  text-decoration: underline;
+}

--- a/packages/extension/popup/popup.css
+++ b/packages/extension/popup/popup.css
@@ -11,7 +11,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/packages/extension/popup/popup.html
+++ b/packages/extension/popup/popup.html
@@ -13,12 +13,13 @@
     </div>
   </header>
 
-  <div class="tabs">
-    <button class="tab active" data-tab="presets">Presets</button>
-    <button class="tab" data-tab="custom">Custom JSON</button>
+  <div class="tabs" role="tablist" aria-label="Configuration mode">
+    <button id="tab-presets" class="tab active" data-tab="presets" role="tab" aria-selected="true" aria-controls="presets-panel">Presets</button>
+    <button id="tab-custom" class="tab" data-tab="custom" role="tab" aria-selected="false" aria-controls="custom-panel">Custom JSON</button>
   </div>
 
-  <div id="presets-panel" class="panel active">
+  <div id="presets-panel" class="panel active" role="tabpanel" aria-labelledby="tab-presets">
+    <label for="preset-select" class="sr-only">Preset</label>
     <select id="preset-select">
       <option value="unstableApi">Unstable API</option>
       <option value="slowNetwork">Slow Network</option>
@@ -29,7 +30,8 @@
     <div id="preset-preview" class="config-preview"></div>
   </div>
 
-  <div id="custom-panel" class="panel">
+  <div id="custom-panel" class="panel" role="tabpanel" aria-labelledby="tab-custom">
+    <label for="config-json" class="sr-only">Custom config JSON</label>
     <textarea id="config-json" spellcheck="false" placeholder="Paste your chaos config JSON here..."></textarea>
   </div>
 

--- a/packages/extension/popup/popup.html
+++ b/packages/extension/popup/popup.html
@@ -41,7 +41,7 @@
   </div>
 
   <footer>
-    <a href="https://github.com/jvjithin/chaos-maker" target="_blank">Docs</a>
+    <a href="https://github.com/jvjithin/chaos-maker" target="_blank" rel="noopener noreferrer">Docs</a>
   </footer>
 
   <script src="popup.js"></script>

--- a/packages/extension/popup/popup.html
+++ b/packages/extension/popup/popup.html
@@ -2,21 +2,48 @@
 <html>
 <head>
   <title>Chaos Maker</title>
-  <style>
-    body { font-family: sans-serif; width: 350px; padding: 10px; }
-    textarea { width: 100%; height: 200px; box-sizing: border-box; }
-    button { width: 100%; padding: 10px; font-size: 16px; cursor: pointer; }
-    #start { background-color: #4CAF50; color: white; border: none; }
-    #stop { background-color: #f44336; color: white; border: none; margin-top: 5px; }
-    .hidden { display: none; }
-    #error-message { color: #f44336; margin-top: 5px; }
-  </style>
+  <link rel="stylesheet" href="popup.css">
 </head>
 <body>
-  <h3>Chaos Configuration</h3>
-  <textarea id="config-json"></textarea>
-  <div id="error-message" class="hidden"></div> <button id="start">Start Chaos</button>
-  <button id="stop" class="hidden">Stop Chaos</button>
+  <header>
+    <h1>Chaos Maker</h1>
+    <div id="status" class="status status-inactive">
+      <span class="status-dot"></span>
+      <span id="status-text">Inactive</span>
+    </div>
+  </header>
+
+  <div class="tabs">
+    <button class="tab active" data-tab="presets">Presets</button>
+    <button class="tab" data-tab="custom">Custom JSON</button>
+  </div>
+
+  <div id="presets-panel" class="panel active">
+    <select id="preset-select">
+      <option value="unstableApi">Unstable API</option>
+      <option value="slowNetwork">Slow Network</option>
+      <option value="offlineMode">Offline Mode</option>
+      <option value="flakyConnection">Flaky Connection</option>
+      <option value="degradedUi">Degraded UI</option>
+    </select>
+    <div id="preset-preview" class="config-preview"></div>
+  </div>
+
+  <div id="custom-panel" class="panel">
+    <textarea id="config-json" spellcheck="false" placeholder="Paste your chaos config JSON here..."></textarea>
+  </div>
+
+  <div id="error-message" class="error hidden"></div>
+
+  <div class="actions">
+    <button id="start" class="btn btn-start">Start Chaos</button>
+    <button id="stop" class="btn btn-stop hidden">Stop Chaos</button>
+  </div>
+
+  <footer>
+    <a href="https://github.com/jvjithin/chaos-maker" target="_blank">Docs</a>
+  </footer>
+
   <script src="popup.js"></script>
 </body>
 </html>

--- a/packages/extension/popup/popup.js
+++ b/packages/extension/popup/popup.js
@@ -51,7 +51,8 @@ function activateTab(tab) {
   document.querySelectorAll('.panel').forEach((p) => p.classList.remove('active'));
   tab.classList.add('active');
   tab.setAttribute('aria-selected', 'true');
-  document.getElementById(`${tab.dataset.tab}-panel`).classList.add('active');
+  const panel = document.getElementById(`${tab.dataset.tab}-panel`);
+  if (panel) panel.classList.add('active');
 }
 
 document.querySelectorAll('.tab').forEach((tab) => {

--- a/packages/extension/popup/popup.js
+++ b/packages/extension/popup/popup.js
@@ -91,7 +91,8 @@ function setActive(active) {
 
 // --- Get config from active tab ---
 function getActiveConfig() {
-  const activeTab = document.querySelector('.tab.active').dataset.tab;
+  const activeTabEl = document.querySelector('.tab.active');
+  const activeTab = activeTabEl ? activeTabEl.dataset.tab : 'presets';
   if (activeTab === 'presets') {
     return presets[presetSelect.value];
   }
@@ -122,9 +123,11 @@ startBtn.addEventListener('click', () => {
   setError('');
   try {
     const config = getActiveConfig();
-    const activeTab = document.querySelector('.tab.active').dataset.tab;
+    const activeTabEl = document.querySelector('.tab.active');
+    const activeTab = activeTabEl ? activeTabEl.dataset.tab : 'presets';
     chrome.runtime.sendMessage({ action: 'startChaos', config });
     chrome.storage.local.set({
+      chaosActive: true,
       mode: activeTab,
       preset: activeTab === 'presets' ? presetSelect.value : null,
     });
@@ -138,5 +141,6 @@ startBtn.addEventListener('click', () => {
 stopBtn.addEventListener('click', () => {
   setError('');
   chrome.runtime.sendMessage({ action: 'stopChaos' });
+  chrome.storage.local.set({ chaosActive: false });
   setActive(false);
 });

--- a/packages/extension/popup/popup.js
+++ b/packages/extension/popup/popup.js
@@ -43,6 +43,7 @@ const presets = {
 
 // --- Tab switching ---
 function activateTab(tab) {
+  if (!tab) return;
   document.querySelectorAll('.tab').forEach((t) => {
     t.classList.remove('active');
     t.setAttribute('aria-selected', 'false');

--- a/packages/extension/popup/popup.js
+++ b/packages/extension/popup/popup.js
@@ -1,72 +1,142 @@
 const configEl = document.getElementById('config-json');
+const presetSelect = document.getElementById('preset-select');
+const presetPreview = document.getElementById('preset-preview');
 const startBtn = document.getElementById('start');
 const stopBtn = document.getElementById('stop');
 const errorEl = document.getElementById('error-message');
+const statusEl = document.getElementById('status');
+const statusText = document.getElementById('status-text');
 
-const defaultConfig = {
-  "network": {
-    "failures": [
-      { "urlPattern": "/api/", "statusCode": 503, "probability": 0.5 }
-    ],
-    "latencies": [
-      { "urlPattern": "/api/", "delayMs": 2000, "probability": 0.5 }
-    ]
-  }
+// Presets must match packages/core/src/presets.ts
+const presets = {
+  unstableApi: {
+    network: {
+      failures: [{ urlPattern: '/api/', statusCode: 500, probability: 0.1 }],
+      latencies: [{ urlPattern: '/api/', delayMs: 1000, probability: 0.2 }],
+    },
+  },
+  slowNetwork: {
+    network: {
+      latencies: [{ urlPattern: '/', delayMs: 2000, probability: 1.0 }],
+    },
+  },
+  offlineMode: {
+    network: {
+      cors: [{ urlPattern: '/', probability: 1.0 }],
+    },
+  },
+  flakyConnection: {
+    network: {
+      aborts: [{ urlPattern: '/', probability: 0.05 }],
+      latencies: [{ urlPattern: '/', delayMs: 3000, probability: 0.1 }],
+    },
+  },
+  degradedUi: {
+    ui: {
+      assaults: [
+        { selector: 'button', action: 'disable', probability: 0.2 },
+        { selector: 'a', action: 'hide', probability: 0.1 },
+      ],
+    },
+  },
 };
 
-// Function to show/hide error messages
-function setErrorMessage(message) {
-  errorEl.textContent = message;
-  if (message) {
-    errorEl.classList.remove('hidden');
-    configEl.style.borderColor = '#f44336';
-  } else {
-    errorEl.classList.add('hidden');
-    configEl.style.borderColor = '';
-  }
-}
-
-// Load saved state on popup open
-document.addEventListener('DOMContentLoaded', () => {
-  chrome.storage.local.get(['chaosActive', 'config'], (result) => {
-    if (result.config) {
-      configEl.value = JSON.stringify(result.config, null, 2);
-    } else {
-      configEl.value = JSON.stringify(defaultConfig, null, 2);
-    }
-    
-    if (result.chaosActive) {
-      startBtn.classList.add('hidden');
-      stopBtn.classList.remove('hidden');
-      configEl.disabled = true;
-    } else {
-      startBtn.classList.remove('hidden');
-      stopBtn.classList.add('hidden');
-      configEl.disabled = false;
-    }
+// --- Tab switching ---
+document.querySelectorAll('.tab').forEach((tab) => {
+  tab.addEventListener('click', () => {
+    document.querySelectorAll('.tab').forEach((t) => t.classList.remove('active'));
+    document.querySelectorAll('.panel').forEach((p) => p.classList.remove('active'));
+    tab.classList.add('active');
+    document.getElementById(`${tab.dataset.tab}-panel`).classList.add('active');
   });
 });
 
-startBtn.addEventListener('click', () => {
-  setErrorMessage('');
-  try {
-    const config = JSON.parse(configEl.value);
-    chrome.runtime.sendMessage({ action: 'startChaos', config: config });
-    
+// --- Preset preview ---
+function updatePresetPreview() {
+  const selected = presetSelect.value;
+  presetPreview.textContent = JSON.stringify(presets[selected], null, 2);
+}
+
+presetSelect.addEventListener('change', updatePresetPreview);
+updatePresetPreview();
+
+// --- Error display ---
+function setError(message) {
+  errorEl.textContent = message;
+  if (message) {
+    errorEl.classList.remove('hidden');
+  } else {
+    errorEl.classList.add('hidden');
+  }
+}
+
+// --- Status display ---
+function setActive(active) {
+  if (active) {
+    statusEl.className = 'status status-active';
+    statusText.textContent = 'Active';
     startBtn.classList.add('hidden');
     stopBtn.classList.remove('hidden');
     configEl.disabled = true;
+    presetSelect.disabled = true;
+  } else {
+    statusEl.className = 'status status-inactive';
+    statusText.textContent = 'Inactive';
+    startBtn.classList.remove('hidden');
+    stopBtn.classList.add('hidden');
+    configEl.disabled = false;
+    presetSelect.disabled = false;
+  }
+}
 
+// --- Get config from active tab ---
+function getActiveConfig() {
+  const activeTab = document.querySelector('.tab.active').dataset.tab;
+  if (activeTab === 'presets') {
+    return presets[presetSelect.value];
+  }
+  return JSON.parse(configEl.value);
+}
+
+// --- Load saved state ---
+document.addEventListener('DOMContentLoaded', () => {
+  chrome.storage.local.get(['chaosActive', 'config', 'mode', 'preset'], (result) => {
+    if (result.mode === 'custom' && result.config) {
+      configEl.value = JSON.stringify(result.config, null, 2);
+      // Switch to custom tab
+      document.querySelectorAll('.tab').forEach((t) => t.classList.remove('active'));
+      document.querySelectorAll('.panel').forEach((p) => p.classList.remove('active'));
+      document.querySelector('[data-tab="custom"]').classList.add('active');
+      document.getElementById('custom-panel').classList.add('active');
+    }
+    if (result.preset && presets[result.preset]) {
+      presetSelect.value = result.preset;
+      updatePresetPreview();
+    }
+    setActive(!!result.chaosActive);
+  });
+});
+
+// --- Start ---
+startBtn.addEventListener('click', () => {
+  setError('');
+  try {
+    const config = getActiveConfig();
+    const activeTab = document.querySelector('.tab.active').dataset.tab;
+    chrome.runtime.sendMessage({ action: 'startChaos', config });
+    chrome.storage.local.set({
+      mode: activeTab,
+      preset: activeTab === 'presets' ? presetSelect.value : null,
+    });
+    setActive(true);
   } catch {
-    setErrorMessage('Invalid JSON configuration!');
+    setError('Invalid JSON configuration. Check your syntax.');
   }
 });
 
+// --- Stop ---
 stopBtn.addEventListener('click', () => {
-  setErrorMessage('');
+  setError('');
   chrome.runtime.sendMessage({ action: 'stopChaos' });
-
-  startBtn.classList.remove('hidden');
-  stopBtn.classList.add('hidden');
-  configEl.disabled = false;
+  setActive(false);
 });

--- a/packages/extension/popup/popup.js
+++ b/packages/extension/popup/popup.js
@@ -132,6 +132,7 @@ startBtn.addEventListener('click', () => {
       chaosActive: true,
       mode: activeTab,
       preset: activeTab === 'presets' ? presetSelect.value : null,
+      config: activeTab === 'custom' ? config : null,
     });
     setActive(true);
   } catch {

--- a/packages/extension/popup/popup.js
+++ b/packages/extension/popup/popup.js
@@ -42,13 +42,19 @@ const presets = {
 };
 
 // --- Tab switching ---
-document.querySelectorAll('.tab').forEach((tab) => {
-  tab.addEventListener('click', () => {
-    document.querySelectorAll('.tab').forEach((t) => t.classList.remove('active'));
-    document.querySelectorAll('.panel').forEach((p) => p.classList.remove('active'));
-    tab.classList.add('active');
-    document.getElementById(`${tab.dataset.tab}-panel`).classList.add('active');
+function activateTab(tab) {
+  document.querySelectorAll('.tab').forEach((t) => {
+    t.classList.remove('active');
+    t.setAttribute('aria-selected', 'false');
   });
+  document.querySelectorAll('.panel').forEach((p) => p.classList.remove('active'));
+  tab.classList.add('active');
+  tab.setAttribute('aria-selected', 'true');
+  document.getElementById(`${tab.dataset.tab}-panel`).classList.add('active');
+}
+
+document.querySelectorAll('.tab').forEach((tab) => {
+  tab.addEventListener('click', () => activateTab(tab));
 });
 
 // --- Preset preview ---
@@ -104,11 +110,7 @@ document.addEventListener('DOMContentLoaded', () => {
   chrome.storage.local.get(['chaosActive', 'config', 'mode', 'preset'], (result) => {
     if (result.mode === 'custom' && result.config) {
       configEl.value = JSON.stringify(result.config, null, 2);
-      // Switch to custom tab
-      document.querySelectorAll('.tab').forEach((t) => t.classList.remove('active'));
-      document.querySelectorAll('.panel').forEach((p) => p.classList.remove('active'));
-      document.querySelector('[data-tab="custom"]').classList.add('active');
-      document.getElementById('custom-panel').classList.add('active');
+      activateTab(document.querySelector('[data-tab="custom"]'));
     }
     if (result.preset && presets[result.preset]) {
       presetSelect.value = result.preset;


### PR DESCRIPTION
## Summary

- **Extension polish**: Renamed to "Chaos Maker", redesigned popup with dark theme, preset dropdown (all 5 presets), tabbed UI (Presets vs Custom JSON), status indicator with pulse animation, extracted CSS to separate file
- **npm publish workflow**: `release.yml` triggers on `v*` tags, validates (lint + test + build + e2e) then publishes `@chaos-maker/core` → `@chaos-maker/playwright` sequentially
- **CI hardening**: Bundle size report (ESM/CJS/UMD with gzip) in GitHub Actions step summary
- **Test hardening**: 14 DOM chaos tests, 11 ChaosMaker edge case tests, `start()` double-call guard — 97 total tests (up from 72)

## Test plan

- [x] ESLint passes
- [x] 97 unit tests pass (8 test files)
- [x] Build succeeds (core ESM/CJS/UMD + playwright ESM/CJS)
- [x] 2 E2E tests pass (chromium)
- [x] CI passes on this PR
- [ ] Manually load extension in Chrome and verify preset dropdown works
- [ ] Verify `release.yml` workflow syntax is valid (will run on first `v*` tag push)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preset configurations for quick chaos setup
  * Tag-triggered release workflow to validate and publish packages
  * Bundle size report appended to CI summaries

* **UI Improvements**
  * Tabbed popup (Presets / Custom), externalized styling, real-time status indicator, accessibility helpers

* **Bug Fixes**
  * start() is now a no-op if already running; stop() resets running state

* **Tests**
  * New edge-case and DOM interaction test suites

* **Chores**
  * Extension name updated to “Chaos Maker”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->