### PR TITLE
fix(extension): offline mode, tab scoping, stop button, CORS errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,10 @@
 CLAUDE.md
 PROJECT_STATUS.md
 LEARNINGS.md
-.claude/skills/
+.claude/
 AGENTS.md
 GEMINI.md
+RELEASE_PLAN_*.md
 
 # Node
 node_modules

--- a/packages/core/src/interceptors/networkFetch.ts
+++ b/packages/core/src/interceptors/networkFetch.ts
@@ -140,8 +140,12 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
               detail: { url, method },
             });
             if (applied) {
-              console.warn(`CHAOS: Forcing CORS error for ${method} ${url}`);
-              throw new TypeError('Failed to fetch');
+              console.debug(`[chaos-maker] CORS block: ${method} ${url}`);
+              // Mimic a real browser network error. Sanitize the stack so
+              // Chrome doesn't attribute the rejection to the extension.
+              const error = new TypeError('Failed to fetch');
+              error.stack = '';
+              throw error;
             }
           }
         }

--- a/packages/core/src/interceptors/networkXHR.ts
+++ b/packages/core/src/interceptors/networkXHR.ts
@@ -50,7 +50,7 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
               detail: { url, method },
             });
             if (applied) {
-              console.warn(`CHAOS: Forcing CORS error for ${method} ${url}`);
+              console.debug(`[chaos-maker] CORS block: ${method} ${url}`);
               Object.defineProperty(this, 'status', { value: 0 });
               Object.defineProperty(this, 'statusText', { value: '' });
               this.dispatchEvent(new Event('error'));

--- a/packages/extension/background.js
+++ b/packages/extension/background.js
@@ -1,113 +1,220 @@
-// Listens for messages from the popup
-chrome.runtime.onMessage.addListener((request, _sender, _sendResponse) => {
+// --- State ---
+let chaosTabId = null;
+let hasNavigationBlock = false; // true when declarativeNetRequest blocks main_frame
+
+// --- Message handling ---
+chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
   if (request.action === 'startChaos') {
-    startChaos(request.config);
+    startChaos(request.config).then((success) => sendResponse({ success }));
+    return true; // keep channel open for async response
   } else if (request.action === 'stopChaos') {
-    stopChaos();
+    stopChaos().then(() => sendResponse({ success: true }));
+    return true;
   }
 });
 
 async function getActiveTab() {
-  let [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   return tab;
 }
 
-// --- HELPER FUNCTION ---
-// This version uses the "auto-start" pattern.
+// --- declarativeNetRequest: network-level blocking ---
+// Session rules support tabIds (dynamic rules do not).
+// Used for CORS/offline chaos with probability 1.0 so that
+// navigation, sub-resources, and all network traffic is blocked
+// at the browser level — not just JS-initiated fetch/XHR.
+
+const DNR_RULE_ID_START = 1000;
+
+function buildBlockRules(config, tabId) {
+  const rules = [];
+  let ruleId = DNR_RULE_ID_START;
+
+  if (!config.network?.cors) return rules;
+
+  for (const cors of config.network.cors) {
+    // Only create browser-level rules for deterministic blocking
+    if (cors.probability !== 1.0) continue;
+
+    rules.push({
+      id: ruleId++,
+      priority: 1,
+      action: { type: 'block' },
+      condition: {
+        urlFilter: cors.urlPattern === '/' ? '*' : `*${cors.urlPattern}*`,
+        tabIds: [tabId],
+        resourceTypes: [
+          'main_frame',
+          'sub_frame',
+          'stylesheet',
+          'script',
+          'image',
+          'font',
+          'object',
+          'xmlhttprequest',
+          'ping',
+          'csp_report',
+          'media',
+          'websocket',
+          'other',
+        ],
+      },
+    });
+  }
+
+  return rules;
+}
+
+async function applyBlockRules(config, tabId) {
+  const rules = buildBlockRules(config, tabId);
+  if (rules.length === 0) return;
+
+  // Track whether navigation itself is blocked (main_frame in resourceTypes)
+  hasNavigationBlock = rules.some((r) =>
+    r.condition.resourceTypes.includes('main_frame')
+  );
+
+  // Clear stale rules, then apply new ones
+  const existing = await chrome.declarativeNetRequest.getSessionRules();
+  const staleIds = existing.map((r) => r.id);
+
+  await chrome.declarativeNetRequest.updateSessionRules({
+    removeRuleIds: staleIds,
+    addRules: rules,
+  });
+  console.log(`Applied ${rules.length} network block rule(s) for tab ${tabId}`);
+}
+
+async function clearBlockRules() {
+  hasNavigationBlock = false;
+  const existing = await chrome.declarativeNetRequest.getSessionRules();
+  const ids = existing.map((r) => r.id);
+  if (ids.length > 0) {
+    await chrome.declarativeNetRequest.updateSessionRules({ removeRuleIds: ids });
+    console.log(`Cleared ${ids.length} network block rule(s)`);
+  }
+}
+
+// --- JS-level chaos injection ---
 async function injectChaos(tabId, config) {
   try {
-    // 1. Inject the config object onto the page first.
-    // We'll store it in a temporary global variable.
+    // 1. Place config in a global the library reads on load
     await chrome.scripting.executeScript({
-      target: { tabId: tabId },
-      func: (configToInject) => {
-        window.__CHAOS_CONFIG__ = configToInject;
+      target: { tabId },
+      func: (c) => {
+        window.__CHAOS_CONFIG__ = c;
       },
       args: [config],
       world: 'MAIN',
     });
 
-    // 2. Now inject the library.
-    // Its new auto-start logic (from Step 1) will find
-    // 'window.__CHAOS_CONFIG__' and start itself.
+    // 2. Inject the library — its auto-start reads __CHAOS_CONFIG__
     await chrome.scripting.executeScript({
-      target: { tabId: tabId },
+      target: { tabId },
       files: ['dist/chaos-maker.umd.js'],
       world: 'MAIN',
     });
 
-    console.log(`ChaosMaker injected and started on tab ${tabId}`);
-    return true; // Success
-
+    console.log(`ChaosMaker injected on tab ${tabId}`);
+    return true;
   } catch (e) {
-    console.error(`Failed to inject script on tab ${tabId}:`, e.message);
-    return false; // Failure
+    console.error(`Failed to inject on tab ${tabId}:`, e.message);
+    return false;
   }
 }
 
-// --- NEW HELPER FUNCTION ---
-// Contains the core removal logic
 async function removeChaos(tabId) {
   try {
-    // Execute the global API 'stop' function
     await chrome.scripting.executeScript({
-      target: { tabId: tabId },
+      target: { tabId },
       func: () => {
         if (window.chaosUtils) {
           window.chaosUtils.stop();
         }
       },
+      world: 'MAIN', // must match the world where chaos was injected
     });
     console.log(`ChaosMaker stopped on tab ${tabId}`);
   } catch (e) {
-    console.error(`Failed to remove script on tab ${tabId}:`, e.message);
+    console.error(`Failed to stop on tab ${tabId}:`, e.message);
   }
 }
 
-// --- UPDATED START/STOP FUNCTIONS ---
+// --- Start / Stop ---
 async function startChaos(config) {
   const tab = await getActiveTab();
-  if (!tab) return;
+  if (!tab) return false;
 
+  chaosTabId = tab.id;
+
+  // Network-level blocking (offline / CORS with probability 1.0)
+  await applyBlockRules(config, tab.id);
+
+  // JS-level chaos (fetch/XHR patching, DOM assaults)
   const success = await injectChaos(tab.id, config);
-  
+
   if (success) {
-    // Only set storage IF injection was successful
-    chrome.storage.local.set({ chaosActive: true, config: config });
-    // Update extension state
-    // (This icon code is still commented out, which is fine)
-    // chrome.action.setIcon({ path: 'icons/icon-active.png', tabId: tab.id });
+    chrome.storage.local.set({
+      chaosActive: true,
+      chaosConfig: config,
+      chaosTabId: tab.id,
+    });
+  } else {
+    await clearBlockRules();
+    chaosTabId = null;
   }
+
+  return success;
 }
 
 async function stopChaos() {
-  // We want to stop chaos regardless of the current tab
-  chrome.storage.local.set({ chaosActive: false });
+  await clearBlockRules();
 
-  const tab = await getActiveTab();
-  if (tab) {
-    await removeChaos(tab.id);
-    // Update extension state
-    // chrome.action.setIcon({ path: 'icons/icon48.png', tabId: tab.id });
+  // Stop JS chaos on the tracked tab — not just whichever tab is focused
+  if (chaosTabId !== null) {
+    await removeChaos(chaosTabId);
+    chaosTabId = null;
   }
+
+  chrome.storage.local.set({ chaosActive: false, chaosConfig: null, chaosTabId: null });
 }
 
-// --- NEW: AUTO-INJECT ON NAVIGATION ---
-// This is the key to persistence
+// --- Re-inject JS chaos on navigation (scoped to the chaos tab only) ---
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  // Wait for the navigation to complete
-  if (changeInfo.status === 'complete' && tab.url) {
-    
-    // Check if chaos is supposed to be active
-    chrome.storage.local.get(['chaosActive', 'config'], (result) => {
-      if (result.chaosActive && result.config) {
-        
-        // Don't inject into non-web pages
-        if (tab.url.startsWith('http://') || tab.url.startsWith('https://')) {
-          console.log(`Tab ${tabId} finished loading. Re-injecting chaos.`);
-          // Re-run our injection logic on the new page
-          injectChaos(tabId, result.config);
-        }
+  if (changeInfo.status !== 'complete' || !tab.url) return;
+  if (tabId !== chaosTabId) return;
+  // When declarativeNetRequest blocks navigation, Chrome shows an error page.
+  // Attempting to inject into an error page always fails — skip it.
+  if (hasNavigationBlock) return;
+
+  chrome.storage.local.get(['chaosActive', 'chaosConfig'], (result) => {
+    if (!result.chaosActive || !result.chaosConfig) return;
+    if (!tab.url.startsWith('http://') && !tab.url.startsWith('https://')) return;
+
+    console.log(`Tab ${tabId} navigated. Re-injecting chaos.`);
+    injectChaos(tabId, result.chaosConfig);
+  });
+});
+
+// --- Clean up when the chaos tab is closed ---
+chrome.tabs.onRemoved.addListener((tabId) => {
+  if (tabId !== chaosTabId) return;
+  console.log(`Chaos tab ${tabId} closed. Cleaning up.`);
+  clearBlockRules();
+  chrome.storage.local.set({ chaosActive: false, chaosConfig: null, chaosTabId: null });
+  chaosTabId = null;
+});
+
+// --- Restore in-memory state when service worker wakes ---
+chrome.storage.local.get(['chaosActive', 'chaosTabId'], (result) => {
+  if (result.chaosActive && result.chaosTabId) {
+    chaosTabId = result.chaosTabId;
+    // Verify the tab still exists
+    chrome.tabs.get(chaosTabId, (tab) => {
+      if (chrome.runtime.lastError || !tab) {
+        clearBlockRules();
+        chrome.storage.local.set({ chaosActive: false, chaosConfig: null, chaosTabId: null });
+        chaosTabId = null;
       }
     });
   }

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -7,7 +7,8 @@
     "activeTab",
     "scripting",
     "storage",
-    "tabs"
+    "tabs",
+    "declarativeNetRequest"
   ],
   "host_permissions": [
     "https://*/*",

--- a/packages/extension/popup/popup.js
+++ b/packages/extension/popup/popup.js
@@ -109,9 +109,9 @@ function getActiveConfig() {
 
 // --- Load saved state ---
 document.addEventListener('DOMContentLoaded', () => {
-  chrome.storage.local.get(['chaosActive', 'config', 'mode', 'preset'], (result) => {
-    if (result.mode === 'custom' && result.config) {
-      configEl.value = JSON.stringify(result.config, null, 2);
+  chrome.storage.local.get(['chaosActive', 'mode', 'preset', 'customConfig'], (result) => {
+    if (result.mode === 'custom' && result.customConfig) {
+      configEl.value = result.customConfig;
       activateTab(document.querySelector('[data-tab="custom"]'));
     }
     if (result.preset && presets[result.preset]) {
@@ -128,15 +128,22 @@ startBtn.addEventListener('click', () => {
   try {
     const config = getActiveConfig();
     const activeTabEl = document.querySelector('.tab.active');
-    const activeTab = activeTabEl ? activeTabEl.dataset.tab : 'presets';
-    chrome.runtime.sendMessage({ action: 'startChaos', config });
-    chrome.storage.local.set({
-      chaosActive: true,
-      mode: activeTab,
-      preset: activeTab === 'presets' ? presetSelect.value : null,
-      config: activeTab === 'custom' ? config : null,
+    const mode = activeTabEl ? activeTabEl.dataset.tab : 'presets';
+
+    startBtn.disabled = true;
+    chrome.runtime.sendMessage({ action: 'startChaos', config }, (response) => {
+      startBtn.disabled = false;
+      if (response?.success) {
+        chrome.storage.local.set({
+          mode,
+          preset: mode === 'presets' ? presetSelect.value : null,
+          customConfig: mode === 'custom' ? configEl.value : null,
+        });
+        setActive(true);
+      } else {
+        setError('Failed to inject chaos. Make sure you are on a web page.');
+      }
     });
-    setActive(true);
   } catch {
     setError('Invalid JSON configuration. Check your syntax.');
   }
@@ -145,7 +152,9 @@ startBtn.addEventListener('click', () => {
 // --- Stop ---
 stopBtn.addEventListener('click', () => {
   setError('');
-  chrome.runtime.sendMessage({ action: 'stopChaos' });
-  chrome.storage.local.set({ chaosActive: false });
-  setActive(false);
+  stopBtn.disabled = true;
+  chrome.runtime.sendMessage({ action: 'stopChaos' }, () => {
+    stopBtn.disabled = false;
+    setActive(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Add `declarativeNetRequest` session rules to block requests at browser level — fixes offline mode not affecting page navigation
- Track `chaosTabId` to scope injection and stop to the correct tab (fixes chaos on all tabs, wrong-tab stop)
- Fix `removeChaos()` missing `world: 'MAIN'` — stop button was silently doing nothing
- Skip re-injection on error pages when navigation is blocked
- Sanitize CORS `TypeError` stack so Chrome doesn't attribute it to the extension error panel
- Add `tabs.onRemoved` cleanup and service worker state restoration on wake

## Test plan
- [ ] Load a page, activate Offline Mode preset — page navigation should be blocked
- [ ] Activate chaos on tab A, switch to tab B, navigate — chaos should not inject on tab B
- [ ] Start chaos, click Stop — chaos should stop on the correct tab
- [ ] Activate Offline Mode — no TypeError stack traces should appear in the extension error panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser-level network blocking now prevents CORS errors and offline scenarios at the browser level for more comprehensive chaos testing.

* **Bug Fixes**
  * Enhanced error messaging when chaos injection fails.
  * Fixed chaos state tracking and persistence across page navigation.
  * Improved handling of blocked navigation scenarios during chaos mode.

* **Chores**
  * Updated extension manifest permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->