### PR TITLE
feat: seeded randomness for reproducible chaos

### DIFF
--- a/e2e-tests/tests/seeded-randomness.spec.ts
+++ b/e2e-tests/tests/seeded-randomness.spec.ts
@@ -1,0 +1,158 @@
+import { test, expect } from '@playwright/test';
+import { injectChaos, getChaosLog, getChaosSeed } from '@chaos-maker/playwright';
+
+const BASE_URL = 'http://127.0.0.1:8080';
+const API_PATTERN = '/api/data.json';
+const SEED = 42;
+
+// ---------------------------------------------------------------------------
+// Seeded Randomness
+// ---------------------------------------------------------------------------
+test.describe('Seeded Randomness', () => {
+  test('same seed produces identical chaos outcomes across runs', async ({ page }) => {
+    // Run 1: inject chaos with seed, make several requests, collect log
+    await injectChaos(page, {
+      seed: SEED,
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 0.5 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    // Make multiple requests to exercise the PRNG
+    for (let i = 0; i < 5; i++) {
+      await page.click('#fetch-data');
+      await page.locator('#status').filter({ hasNotText: 'Loading...' }).waitFor();
+    }
+
+    const log1 = await getChaosLog(page);
+    const outcomes1 = log1
+      .filter(e => e.type === 'network:failure')
+      .map(e => e.applied);
+
+    // Run 2: fresh page, same seed, same config
+    const page2 = await page.context().newPage();
+    await injectChaos(page2, {
+      seed: SEED,
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 0.5 }],
+      },
+    });
+    await page2.goto(BASE_URL);
+
+    for (let i = 0; i < 5; i++) {
+      await page2.click('#fetch-data');
+      await page2.locator('#status').filter({ hasNotText: 'Loading...' }).waitFor();
+    }
+
+    const log2 = await getChaosLog(page2);
+    const outcomes2 = log2
+      .filter(e => e.type === 'network:failure')
+      .map(e => e.applied);
+
+    await page2.close();
+
+    // Both runs should produce identical sequences
+    expect(outcomes1).toEqual(outcomes2);
+    expect(outcomes1.length).toBe(5);
+  });
+
+  test('different seeds produce different chaos outcomes', async ({ page }) => {
+    await injectChaos(page, {
+      seed: 42,
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 0.5 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    for (let i = 0; i < 10; i++) {
+      await page.click('#fetch-data');
+      await page.locator('#status').filter({ hasNotText: 'Loading...' }).waitFor();
+    }
+
+    const log1 = await getChaosLog(page);
+    const outcomes1 = log1
+      .filter(e => e.type === 'network:failure')
+      .map(e => e.applied);
+
+    // Fresh page with different seed
+    const page2 = await page.context().newPage();
+    await injectChaos(page2, {
+      seed: 99,
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 0.5 }],
+      },
+    });
+    await page2.goto(BASE_URL);
+
+    for (let i = 0; i < 10; i++) {
+      await page2.click('#fetch-data');
+      await page2.locator('#status').filter({ hasNotText: 'Loading...' }).waitFor();
+    }
+
+    const log2 = await getChaosLog(page2);
+    const outcomes2 = log2
+      .filter(e => e.type === 'network:failure')
+      .map(e => e.applied);
+
+    await page2.close();
+
+    // With 10 trials at p=0.5, different seeds should produce different sequences
+    // (extremely unlikely to match by chance: 1/1024)
+    expect(outcomes1).not.toEqual(outcomes2);
+  });
+
+  test('getSeed returns the seed used by the instance', async ({ page }) => {
+    await injectChaos(page, {
+      seed: 12345,
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    const seed = await getChaosSeed(page);
+    expect(seed).toBe(12345);
+  });
+
+  test('auto-generated seed is retrievable when no seed is provided', async ({ page }) => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    const seed = await getChaosSeed(page);
+    expect(typeof seed).toBe('number');
+    expect(Number.isInteger(seed)).toBe(true);
+  });
+
+  test('seed works with probability 1.0 — always applies', async ({ page }) => {
+    await injectChaos(page, {
+      seed: SEED,
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0 }],
+      },
+    });
+    await page.goto(BASE_URL);
+    await page.click('#fetch-data');
+
+    await expect(page.locator('#status')).toHaveText('Error!');
+    await expect(page.locator('#result')).toContainText('503');
+  });
+
+  test('seed works with probability 0 — never applies', async ({ page }) => {
+    await injectChaos(page, {
+      seed: SEED,
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 0 }],
+      },
+    });
+    await page.goto(BASE_URL);
+    await page.click('#fetch-data');
+
+    await expect(page.locator('#status')).toHaveText('Success!');
+  });
+});

--- a/packages/core/src/ChaosMaker.ts
+++ b/packages/core/src/ChaosMaker.ts
@@ -1,5 +1,6 @@
 import { ChaosConfig } from './config';
 import { validateConfig } from './validation';
+import { createPrng } from './prng';
 import { ChaosEventEmitter, ChaosEvent, ChaosEventType, ChaosEventListener } from './events';
 import { patchFetch } from './interceptors/networkFetch';
 import { patchXHR, patchXHROpen } from './interceptors/networkXHR';
@@ -8,6 +9,8 @@ import { attachDomAssailant } from './interceptors/domAssailant';
 export class ChaosMaker {
   private config: ChaosConfig;
   private emitter: ChaosEventEmitter;
+  private random: () => number;
+  private seed: number;
   private running = false;
   private originalFetch?: typeof window.fetch;
   private originalXhrSend?: (body?: Document | XMLHttpRequestBodyInit) => void;
@@ -17,7 +20,15 @@ export class ChaosMaker {
   constructor(config: ChaosConfig) {
     this.config = validateConfig(config);
     this.emitter = new ChaosEventEmitter();
-    console.log('Chaos Maker initialized with config:', config);
+    const prng = createPrng(config.seed);
+    this.random = prng.random;
+    this.seed = prng.seed;
+    console.log(`Chaos Maker initialized (seed: ${this.seed})`);
+  }
+
+  /** Get the seed used by this instance. Log this on failure to reproduce exact chaos decisions. */
+  public getSeed(): number {
+    return this.seed;
   }
 
   public on(type: ChaosEventType | '*', listener: ChaosEventListener): void {
@@ -46,17 +57,17 @@ export class ChaosMaker {
 
     if (this.config.network) {
       this.originalFetch = window.fetch;
-      window.fetch = patchFetch(this.originalFetch.bind(window), this.config.network, this.emitter);
+      window.fetch = patchFetch(this.originalFetch.bind(window), this.config.network, this.emitter, this.random);
 
       this.originalXhrOpen = window.XMLHttpRequest.prototype.open;
       window.XMLHttpRequest.prototype.open = patchXHROpen(this.originalXhrOpen);
 
       this.originalXhrSend = window.XMLHttpRequest.prototype.send;
-      window.XMLHttpRequest.prototype.send = patchXHR(this.originalXhrSend, this.config.network, this.emitter);
+      window.XMLHttpRequest.prototype.send = patchXHR(this.originalXhrSend, this.config.network, this.emitter, this.random);
     }
 
     if (this.config.ui) {
-      this.domObserver = attachDomAssailant(this.config.ui, this.emitter);
+      this.domObserver = attachDomAssailant(this.config.ui, this.emitter, this.random);
       this.domObserver.observe(document.body, {
         childList: true,
         subtree: true,

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -49,6 +49,12 @@ export class ChaosConfigBuilder {
     return this;
   }
 
+  /** Set the PRNG seed for reproducible chaos. */
+  withSeed(seed: number) {
+    this.config.seed = seed;
+    return this;
+  }
+
   build(): ChaosConfig {
     return cloneConfig(this.config);
   }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -58,4 +58,6 @@ export interface UiConfig {
 export interface ChaosConfig {
   network?: NetworkConfig;
   ui?: UiConfig;
+  /** Seed for the PRNG. When provided, all probability rolls become deterministic and replayable. */
+  seed?: number;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,8 +5,9 @@ import { validateConfig } from './validation';
 import { ChaosEvent, ChaosEventType, ChaosEventListener, ChaosEventEmitter } from './events';
 import { ChaosConfigBuilder } from './builder';
 import { presets } from './presets';
+import { createPrng, generateSeed } from './prng';
 
-export { ChaosMaker, ChaosConfigError, validateConfig, ChaosEventEmitter, ChaosConfigBuilder, presets };
+export { ChaosMaker, ChaosConfigError, validateConfig, ChaosEventEmitter, ChaosConfigBuilder, presets, createPrng, generateSeed };
 export type { ChaosConfig, CorruptionStrategy, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig, ChaosEvent, ChaosEventType, ChaosEventListener };
 
 // --- NEW INTERFACE ---
@@ -15,6 +16,7 @@ interface ChaosUtilsApi {
   start: (config: ChaosConfig) => { success: boolean; message: string };
   stop: () => { success: boolean; message: string };
   getLog: () => ChaosEvent[];
+  getSeed: () => number | null;
 }
 
 // --- Global API & Auto-Start Logic ---
@@ -53,6 +55,13 @@ if (typeof window !== 'undefined') {
         return chaosUtilsApi.instance.getLog();
       }
       return [];
+    },
+
+    getSeed: () => {
+      if (chaosUtilsApi.instance) {
+        return chaosUtilsApi.instance.getSeed();
+      }
+      return null;
     }
   };
   

--- a/packages/core/src/interceptors/domAssailant.ts
+++ b/packages/core/src/interceptors/domAssailant.ts
@@ -2,8 +2,8 @@ import { UiConfig, UiAssaultConfig } from '../config';
 import { shouldApplyChaos } from '../utils';
 import { ChaosEventEmitter } from '../events';
 
-function applyAssault(element: HTMLElement, assault: UiAssaultConfig, emitter?: ChaosEventEmitter) {
-  const applied = shouldApplyChaos(assault.probability);
+function applyAssault(element: HTMLElement, assault: UiAssaultConfig, emitter?: ChaosEventEmitter, random: () => number = Math.random) {
+  const applied = shouldApplyChaos(assault.probability, random);
   emitter?.emit({
     type: 'ui:assault',
     timestamp: Date.now(),
@@ -36,7 +36,7 @@ function applyAssault(element: HTMLElement, assault: UiAssaultConfig, emitter?: 
   }
 }
 
-function checkNode(node: Node, config: UiConfig, emitter?: ChaosEventEmitter) {
+function checkNode(node: Node, config: UiConfig, emitter?: ChaosEventEmitter, random: () => number = Math.random) {
   if (node.nodeType !== Node.ELEMENT_NODE || !config.assaults) {
     return;
   }
@@ -46,25 +46,25 @@ function checkNode(node: Node, config: UiConfig, emitter?: ChaosEventEmitter) {
   for (const assault of config.assaults) {
     try {
       if (element.matches(assault.selector)) {
-        applyAssault(element, assault, emitter);
+        applyAssault(element, assault, emitter, random);
       }
     } catch (e) {
       console.error(`Chaos Maker: Invalid selector '${assault.selector}'`, e);
     }
 
     element.querySelectorAll(assault.selector).forEach(childEl => {
-      applyAssault(childEl as HTMLElement, assault, emitter);
+      applyAssault(childEl as HTMLElement, assault, emitter, random);
     });
   }
 }
 
-export function attachDomAssailant(config: UiConfig, emitter?: ChaosEventEmitter): MutationObserver {
+export function attachDomAssailant(config: UiConfig, emitter?: ChaosEventEmitter, random: () => number = Math.random): MutationObserver {
   if (config.assaults) {
     console.log('CHAOS: Running initial DOM scan for existing elements...');
     for (const assault of config.assaults) {
       try {
         document.querySelectorAll(assault.selector).forEach(element => {
-          applyAssault(element as HTMLElement, assault, emitter);
+          applyAssault(element as HTMLElement, assault, emitter, random);
         });
       } catch (e) {
         console.error(`Chaos Maker: Invalid selector in initial scan '${assault.selector}'`, e);
@@ -75,7 +75,7 @@ export function attachDomAssailant(config: UiConfig, emitter?: ChaosEventEmitter
   const observer = new MutationObserver((mutationsList) => {
     for (const mutation of mutationsList) {
       if (mutation.type === 'childList') {
-        mutation.addedNodes.forEach(node => checkNode(node, config, emitter));
+        mutation.addedNodes.forEach(node => checkNode(node, config, emitter, random));
       }
     }
   });

--- a/packages/core/src/interceptors/networkFetch.ts
+++ b/packages/core/src/interceptors/networkFetch.ts
@@ -118,7 +118,7 @@ function emitCorruptionEvent(
   });
 }
 
-export function patchFetch(originalFetch: typeof window.fetch, config: NetworkConfig, emitter?: ChaosEventEmitter) {
+export function patchFetch(originalFetch: typeof window.fetch, config: NetworkConfig, emitter?: ChaosEventEmitter, random: () => number = Math.random) {
   return async (
     input: RequestInfo | URL,
     init?: RequestInit
@@ -132,7 +132,7 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
       for (const cors of config.cors) {
         if (matchUrl(url, cors.urlPattern)) {
           if (!cors.methods || cors.methods.includes(method)) {
-            const applied = shouldApplyChaos(cors.probability);
+            const applied = shouldApplyChaos(cors.probability, random);
             emitter?.emit({
               type: 'network:cors',
               timestamp: Date.now(),
@@ -173,7 +173,7 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
       for (const abort of config.aborts) {
         if (matchUrl(url, abort.urlPattern)) {
           if (!abort.methods || abort.methods.includes(method)) {
-            const applied = shouldApplyChaos(abort.probability);
+            const applied = shouldApplyChaos(abort.probability, random);
             if (!applied) {
               emitAbortEvent(emitter, abort, url, method, false);
               continue;
@@ -220,7 +220,7 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
       for (const failure of config.failures) {
         if (matchUrl(url, failure.urlPattern)) {
           if (!failure.methods || failure.methods.includes(method)) {
-            const applied = shouldApplyChaos(failure.probability);
+            const applied = shouldApplyChaos(failure.probability, random);
             emitter?.emit({
               type: 'network:failure',
               timestamp: Date.now(),
@@ -247,7 +247,7 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
       for (const latency of config.latencies) {
         if (matchUrl(url, latency.urlPattern)) {
           if (!latency.methods || latency.methods.includes(method)) {
-            const applied = shouldApplyChaos(latency.probability);
+            const applied = shouldApplyChaos(latency.probability, random);
             emitter?.emit({
               type: 'network:latency',
               timestamp: Date.now(),
@@ -269,7 +269,7 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
       for (const corruption of config.corruptions) {
         if (matchUrl(url, corruption.urlPattern)) {
           if (!corruption.methods || corruption.methods.includes(method)) {
-            const applied = shouldApplyChaos(corruption.probability);
+            const applied = shouldApplyChaos(corruption.probability, random);
             if (!applied) {
               emitCorruptionEvent(emitter, corruption, url, method, false);
               continue;

--- a/packages/core/src/interceptors/networkXHR.ts
+++ b/packages/core/src/interceptors/networkXHR.ts
@@ -32,7 +32,7 @@ function emitCorruptionEvent(
   });
 }
 
-export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyInit) => void, config: NetworkConfig, emitter?: ChaosEventEmitter) {
+export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyInit) => void, config: NetworkConfig, emitter?: ChaosEventEmitter, random: () => number = Math.random) {
   return function (this: XMLHttpRequest, body?: Document | XMLHttpRequestBodyInit) {
     const url = (this as any)._chaos_url;
     const method = (this as any)._chaos_method;
@@ -42,7 +42,7 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
       for (const cors of config.cors) {
         if (matchUrl(url, cors.urlPattern)) {
           if (!cors.methods || cors.methods.includes(method)) {
-            const applied = shouldApplyChaos(cors.probability);
+            const applied = shouldApplyChaos(cors.probability, random);
             emitter?.emit({
               type: 'network:cors',
               timestamp: Date.now(),
@@ -67,7 +67,7 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
       for (const abort of config.aborts) {
         if (matchUrl(url, abort.urlPattern)) {
           if (!abort.methods || abort.methods.includes(method)) {
-            const applied = shouldApplyChaos(abort.probability);
+            const applied = shouldApplyChaos(abort.probability, random);
             if (!applied) {
               emitAbortEvent(emitter, abort, url, method, false);
               continue;
@@ -140,7 +140,7 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
       for (const failure of config.failures) {
         if (matchUrl(url, failure.urlPattern)) {
           if (!failure.methods || failure.methods.includes(method)) {
-            const applied = shouldApplyChaos(failure.probability);
+            const applied = shouldApplyChaos(failure.probability, random);
             emitter?.emit({
               type: 'network:failure',
               timestamp: Date.now(),
@@ -188,7 +188,7 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
       for (const corruption of config.corruptions) {
         if (matchUrl(url, corruption.urlPattern)) {
           if (!corruption.methods || corruption.methods.includes(method)) {
-            const applied = shouldApplyChaos(corruption.probability);
+            const applied = shouldApplyChaos(corruption.probability, random);
             if (!applied) {
               emitCorruptionEvent(emitter, corruption, url, method, false);
               continue;
@@ -275,7 +275,7 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
       for (const latency of config.latencies) {
         if (matchUrl(url, latency.urlPattern)) {
           if (!latency.methods || latency.methods.includes(method)) {
-            const applied = shouldApplyChaos(latency.probability);
+            const applied = shouldApplyChaos(latency.probability, random);
             emitter?.emit({
               type: 'network:latency',
               timestamp: Date.now(),

--- a/packages/core/src/prng.ts
+++ b/packages/core/src/prng.ts
@@ -1,0 +1,37 @@
+/**
+ * Mulberry32 — a fast, seedable 32-bit PRNG.
+ * Returns values in [0, 1) like Math.random().
+ *
+ * @see https://gist.github.com/tommyettinger/46a874533244883189143505d203312c
+ */
+function mulberry32(seed: number): () => number {
+  let state = seed | 0;
+  return () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Generate a random seed using Math.random().
+ * Returns a 32-bit integer.
+ */
+export function generateSeed(): number {
+  return (Math.random() * 4294967296) >>> 0;
+}
+
+/**
+ * Create a seedable random number generator.
+ * If no seed is provided, one is auto-generated.
+ *
+ * @returns An object with the `random` function and the `seed` used.
+ */
+export function createPrng(seed?: number): { random: () => number; seed: number } {
+  const resolvedSeed = seed ?? generateSeed();
+  return {
+    random: mulberry32(resolvedSeed),
+    seed: resolvedSeed,
+  };
+}

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,7 +1,7 @@
 import type { CorruptionStrategy } from './config';
 
-export function shouldApplyChaos(probability: number): boolean {
-  return Math.random() < probability;
+export function shouldApplyChaos(probability: number, random: () => number = Math.random): boolean {
+  return random() < probability;
 }
 
 export function matchUrl(url: string, pattern: string): boolean {

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -62,6 +62,7 @@ const uiConfigSchema = z.object({
 const chaosConfigSchema = z.object({
   network: networkConfigSchema.optional(),
   ui: uiConfigSchema.optional(),
+  seed: z.number().int('Seed must be an integer').optional(),
 }).strict();
 
 export function validateConfig(config: unknown): ChaosConfig {

--- a/packages/core/test/builder-presets.test.ts
+++ b/packages/core/test/builder-presets.test.ts
@@ -84,6 +84,25 @@ describe('ChaosConfigBuilder', () => {
     expect(config.ui?.assaults).toHaveLength(1);
   });
 
+  it('should set seed via withSeed()', () => {
+    const config = new ChaosConfigBuilder()
+      .failRequests('/api/', 500, 1.0)
+      .withSeed(42)
+      .build();
+
+    expect(config.seed).toBe(42);
+  });
+
+  it('should include seed in chained builds', () => {
+    const config = new ChaosConfigBuilder()
+      .withSeed(12345)
+      .addLatency('/api/', 1000, 1.0)
+      .build();
+
+    expect(config.seed).toBe(12345);
+    expect(config.network?.latencies).toHaveLength(1);
+  });
+
   it('should return a snapshot from build() that is unaffected by later mutations', () => {
     const builder = new ChaosConfigBuilder()
       .failRequests('/api/1', 500, 1.0);

--- a/packages/core/test/prng.test.ts
+++ b/packages/core/test/prng.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { createPrng, generateSeed } from '../src/prng';
+import { shouldApplyChaos } from '../src/utils';
+
+describe('createPrng', () => {
+  it('should produce deterministic output with the same seed', () => {
+    const a = createPrng(42);
+    const b = createPrng(42);
+
+    const valuesA = Array.from({ length: 100 }, () => a.random());
+    const valuesB = Array.from({ length: 100 }, () => b.random());
+
+    expect(valuesA).toEqual(valuesB);
+  });
+
+  it('should produce different output with different seeds', () => {
+    const a = createPrng(42);
+    const b = createPrng(99);
+
+    const valuesA = Array.from({ length: 10 }, () => a.random());
+    const valuesB = Array.from({ length: 10 }, () => b.random());
+
+    expect(valuesA).not.toEqual(valuesB);
+  });
+
+  it('should produce values in [0, 1)', () => {
+    const { random } = createPrng(12345);
+    const values = Array.from({ length: 10000 }, () => random());
+
+    for (const v of values) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it('should auto-generate a seed when none is provided', () => {
+    const { seed } = createPrng();
+    expect(typeof seed).toBe('number');
+    expect(Number.isInteger(seed)).toBe(true);
+  });
+
+  it('should return different auto-generated seeds across calls', () => {
+    const seeds = new Set(Array.from({ length: 10 }, () => createPrng().seed));
+    // Extremely unlikely to get all duplicates
+    expect(seeds.size).toBeGreaterThan(1);
+  });
+
+  it('should return the provided seed back', () => {
+    const { seed } = createPrng(42);
+    expect(seed).toBe(42);
+  });
+});
+
+describe('generateSeed', () => {
+  it('should return a 32-bit unsigned integer', () => {
+    for (let i = 0; i < 100; i++) {
+      const seed = generateSeed();
+      expect(Number.isInteger(seed)).toBe(true);
+      expect(seed).toBeGreaterThanOrEqual(0);
+      expect(seed).toBeLessThanOrEqual(4294967295);
+    }
+  });
+});
+
+describe('shouldApplyChaos with seeded random', () => {
+  it('should produce deterministic results with the same seed', () => {
+    const a = createPrng(42);
+    const b = createPrng(42);
+
+    const resultsA = Array.from({ length: 50 }, () => shouldApplyChaos(0.5, a.random));
+    const resultsB = Array.from({ length: 50 }, () => shouldApplyChaos(0.5, b.random));
+
+    expect(resultsA).toEqual(resultsB);
+  });
+
+  it('should always apply when probability is 1.0', () => {
+    const { random } = createPrng(42);
+    const results = Array.from({ length: 100 }, () => shouldApplyChaos(1.0, random));
+    expect(results.every(r => r === true)).toBe(true);
+  });
+
+  it('should never apply when probability is 0', () => {
+    const { random } = createPrng(42);
+    const results = Array.from({ length: 100 }, () => shouldApplyChaos(0, random));
+    expect(results.every(r => r === false)).toBe(true);
+  });
+
+  it('should roughly match the expected probability distribution', () => {
+    const { random } = createPrng(42);
+    const trials = 10000;
+    const probability = 0.3;
+    const applied = Array.from({ length: trials }, () => shouldApplyChaos(probability, random)).filter(Boolean).length;
+    const ratio = applied / trials;
+
+    // Allow 5% deviation
+    expect(ratio).toBeGreaterThan(probability - 0.05);
+    expect(ratio).toBeLessThan(probability + 0.05);
+  });
+
+  it('should still work without a random function (falls back to Math.random)', () => {
+    // Just verifying it doesn't throw
+    const result = shouldApplyChaos(0.5);
+    expect(typeof result).toBe('boolean');
+  });
+});

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -170,4 +170,29 @@ describe('validateConfig', () => {
     const config = { networking: { failures: [] } };
     expect(() => validateConfig(config)).toThrow(ChaosConfigError);
   });
+
+  it('should accept a valid integer seed', () => {
+    const config = { seed: 42 };
+    expect(() => validateConfig(config)).not.toThrow();
+  });
+
+  it('should accept seed of 0', () => {
+    const config = { seed: 0 };
+    expect(() => validateConfig(config)).not.toThrow();
+  });
+
+  it('should reject a non-integer seed', () => {
+    const config = { seed: 3.14 };
+    expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+  });
+
+  it('should accept config with seed and network rules', () => {
+    const config = {
+      seed: 12345,
+      network: {
+        failures: [{ urlPattern: '/api', statusCode: 500, probability: 1.0 }],
+      },
+    };
+    expect(() => validateConfig(config)).not.toThrow();
+  });
 });

--- a/packages/playwright/src/fixture.ts
+++ b/packages/playwright/src/fixture.ts
@@ -1,12 +1,13 @@
 import { test as base } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import type { ChaosConfig, ChaosEvent } from '@chaos-maker/core';
-import { injectChaos, removeChaos, getChaosLog } from './index';
+import { injectChaos, removeChaos, getChaosLog, getChaosSeed } from './index';
 
 export interface ChaosFixture {
   inject: (config: ChaosConfig) => Promise<void>;
   remove: () => Promise<void>;
   getLog: () => Promise<ChaosEvent[]>;
+  getSeed: () => Promise<number | null>;
 }
 
 /**
@@ -34,6 +35,7 @@ export const test = base.extend<{ chaos: ChaosFixture }>({
       inject: (config: ChaosConfig) => injectChaos(page, config),
       remove: () => removeChaos(page),
       getLog: () => getChaosLog(page),
+      getSeed: () => getChaosSeed(page),
     };
     await use(fixture);
     await removeChaos(page);

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -79,4 +79,18 @@ const win = globalThis as any;
   });
 }
 
+/**
+ * Retrieve the PRNG seed from a Playwright page.
+ * Log this value on test failure to replay exact chaos decisions.
+ */
+export async function getChaosSeed(page: Page): Promise<number | null> {
+  return page.evaluate(() => {
+const win = globalThis as any;
+    if (win.chaosUtils) {
+      return win.chaosUtils.getSeed();
+    }
+    return null;
+  });
+}
+
 export type { ChaosConfig, ChaosEvent } from '@chaos-maker/core';


### PR DESCRIPTION
## Summary
- Add seedable PRNG (mulberry32) so all probability rolls become deterministic when a `seed` is provided in config
- Auto-generates a seed when none is given — retrievable via `getSeed()` / `getChaosSeed(page)` for failure replay
- Threads the `random` function through all interceptors (fetch, XHR, DOM) and the Playwright adapter/fixture
- Adds `withSeed()` to the config builder, `seed` to Zod validation, and `getSeed()` to the global `chaosUtils` API

## Changes
- **New**: `packages/core/src/prng.ts` — mulberry32 PRNG with `createPrng()` and `generateSeed()`
- **Modified**: `shouldApplyChaos` accepts optional `random` param (defaults to `Math.random`, fully backwards compatible)
- **Modified**: All interceptors (`networkFetch`, `networkXHR`, `domAssailant`) receive and use the seeded `random` function
- **Modified**: `ChaosMaker` creates PRNG on construction, passes to interceptors, exposes `getSeed()`
- **Modified**: Playwright adapter adds `getChaosSeed(page)`, fixture adds `chaos.getSeed()`
- **Modified**: Builder adds `.withSeed(seed)`, validation accepts integer `seed` field

## Test plan
- [x] 12 new unit tests for PRNG determinism, distribution, and `shouldApplyChaos` integration
- [x] 4 new validation + builder tests for seed handling
- [x] 6 new E2E tests proving same seed → identical outcomes, different seeds → different outcomes, seed retrieval
- [x] All 115 unit tests pass
- [x] All 43 E2E tests pass (Chromium)
- [x] Lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added seeded randomness support for deterministic and reproducible chaos injection scenarios
  * Added ability to retrieve the current chaos seed during testing
  * Extended configuration to accept an optional seed parameter

* **Tests**
  * Added comprehensive E2E test suite validating seeded deterministic behavior and probability controls
  * Added unit tests for seed generation, PRNG functionality, and configuration validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->