### PR TITLE
feat: Nth-request counting (onNth, everyNth, afterN) — v2 Phase 2

### DIFF
--- a/e2e-tests/tests/nth-request-counting.spec.ts
+++ b/e2e-tests/tests/nth-request-counting.spec.ts
@@ -123,33 +123,37 @@ test.describe('everyNth counting', () => {
   });
 
   test('fetch: latency applied on every 2nd request', async ({ page }) => {
+    // Use a large delay so the injected latency dominates CI cold-start /
+    // scheduler jitter (uninjected requests can cost 100–300ms on first hit
+    // in firefox/webkit). 800ms vs a ~500ms threshold leaves comfortable headroom.
+    const DELAY = 800;
+    const THRESHOLD = 500;
+
     await injectChaos(page, {
       network: {
-        latencies: [{ urlPattern: API_PATTERN, delayMs: 200, probability: 1.0, everyNth: 2 }],
+        latencies: [{ urlPattern: API_PATTERN, delayMs: DELAY, probability: 1.0, everyNth: 2 }],
       },
     });
     await page.goto(BASE_URL);
 
-    // Request 1: no latency
+    // Request 1: no latency (counter=1)
     const t1Start = Date.now();
     await makeRequest(page);
     const t1 = Date.now() - t1Start;
 
-    // Request 2: 200ms latency
+    // Request 2: latency injected (counter=2)
     const t2Start = Date.now();
     await makeRequest(page);
     const t2 = Date.now() - t2Start;
 
-    // Request 3: no latency again
+    // Request 3: no latency again (counter=3)
     const t3Start = Date.now();
     await makeRequest(page);
     const t3 = Date.now() - t3Start;
 
-    // Relative comparison avoids flakes from cold-start / CI jitter:
-    // the latency-injected request must be at least ~150ms slower than each uninjected one.
-    expect(t2).toBeGreaterThanOrEqual(200);
-    expect(t2 - t1).toBeGreaterThanOrEqual(150);
-    expect(t2 - t3).toBeGreaterThanOrEqual(150);
+    expect(t2).toBeGreaterThanOrEqual(DELAY);
+    expect(t2 - t1).toBeGreaterThanOrEqual(THRESHOLD);
+    expect(t2 - t3).toBeGreaterThanOrEqual(THRESHOLD);
   });
 });
 

--- a/e2e-tests/tests/nth-request-counting.spec.ts
+++ b/e2e-tests/tests/nth-request-counting.spec.ts
@@ -145,9 +145,11 @@ test.describe('everyNth counting', () => {
     await makeRequest(page);
     const t3 = Date.now() - t3Start;
 
-    expect(t1).toBeLessThan(200);
+    // Relative comparison avoids flakes from cold-start / CI jitter:
+    // the latency-injected request must be at least ~150ms slower than each uninjected one.
     expect(t2).toBeGreaterThanOrEqual(200);
-    expect(t3).toBeLessThan(200);
+    expect(t2 - t1).toBeGreaterThanOrEqual(150);
+    expect(t2 - t3).toBeGreaterThanOrEqual(150);
   });
 });
 

--- a/e2e-tests/tests/nth-request-counting.spec.ts
+++ b/e2e-tests/tests/nth-request-counting.spec.ts
@@ -1,0 +1,256 @@
+import { test, expect, type Page } from '@playwright/test';
+import { injectChaos, getChaosLog } from '@chaos-maker/playwright';
+
+const BASE_URL = 'http://127.0.0.1:8080';
+const API_PATTERN = '/api/data.json';
+
+/** Click a button and wait for the status element to settle (leaves Loading... state). */
+async function makeRequest(page: Page, buttonId = '#fetch-data', statusId = '#status') {
+  await page.click(buttonId);
+  await page.locator(statusId).filter({ hasNotText: 'Loading...' }).waitFor();
+  return page.locator(statusId).textContent();
+}
+
+// ---------------------------------------------------------------------------
+// onNth — failure fires only on the Nth request
+// ---------------------------------------------------------------------------
+test.describe('onNth counting', () => {
+  test('fetch: fails only on the 3rd request', async ({ page }) => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0, onNth: 3 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    const r1 = await makeRequest(page);
+    const r2 = await makeRequest(page);
+    const r3 = await makeRequest(page);
+    const r4 = await makeRequest(page);
+
+    expect(r1).toBe('Success!');
+    expect(r2).toBe('Success!');
+    expect(r3).toBe('Error!');
+    expect(r4).toBe('Success!');
+
+    const log = await getChaosLog(page);
+    const failures = log.filter(e => e.type === 'network:failure');
+    expect(failures.length).toBe(1);
+    expect(failures[0].applied).toBe(true);
+  });
+
+  test('fetch: fails only on the 1st request when onNth is 1', async ({ page }) => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 500, probability: 1.0, onNth: 1 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    const r1 = await makeRequest(page);
+    const r2 = await makeRequest(page);
+    const r3 = await makeRequest(page);
+
+    expect(r1).toBe('Error!');
+    expect(r2).toBe('Success!');
+    expect(r3).toBe('Success!');
+  });
+
+  test('XHR: fails only on the 2nd request', async ({ page }) => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0, onNth: 2 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    // Use XHR button; its status element is #xhr-status
+    const r1 = await makeRequest(page, '#xhr-get', '#xhr-status');
+    const r2 = await makeRequest(page, '#xhr-get', '#xhr-status');
+    const r3 = await makeRequest(page, '#xhr-get', '#xhr-status');
+
+    expect(r1).toBe('Success!');
+    expect(r2).toBe('Error!');
+    expect(r3).toBe('Success!');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// everyNth — failure fires on every Nth request
+// ---------------------------------------------------------------------------
+test.describe('everyNth counting', () => {
+  test('fetch: fails on every 2nd request', async ({ page }) => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0, everyNth: 2 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    const results: string[] = [];
+    for (let i = 0; i < 6; i++) {
+      results.push(await makeRequest(page) as string);
+    }
+
+    // Requests 2, 4, 6 should fail; 1, 3, 5 should succeed
+    expect(results[0]).toBe('Success!');
+    expect(results[1]).toBe('Error!');
+    expect(results[2]).toBe('Success!');
+    expect(results[3]).toBe('Error!');
+    expect(results[4]).toBe('Success!');
+    expect(results[5]).toBe('Error!');
+  });
+
+  test('fetch: fails on every 3rd request', async ({ page }) => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0, everyNth: 3 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    const results: string[] = [];
+    for (let i = 0; i < 6; i++) {
+      results.push(await makeRequest(page) as string);
+    }
+
+    expect(results[0]).toBe('Success!'); // 1
+    expect(results[1]).toBe('Success!'); // 2
+    expect(results[2]).toBe('Error!');   // 3
+    expect(results[3]).toBe('Success!'); // 4
+    expect(results[4]).toBe('Success!'); // 5
+    expect(results[5]).toBe('Error!');   // 6
+  });
+
+  test('fetch: latency applied on every 2nd request', async ({ page }) => {
+    await injectChaos(page, {
+      network: {
+        latencies: [{ urlPattern: API_PATTERN, delayMs: 200, probability: 1.0, everyNth: 2 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    // Request 1: no latency
+    const t1Start = Date.now();
+    await makeRequest(page);
+    const t1 = Date.now() - t1Start;
+
+    // Request 2: 200ms latency
+    const t2Start = Date.now();
+    await makeRequest(page);
+    const t2 = Date.now() - t2Start;
+
+    // Request 3: no latency again
+    const t3Start = Date.now();
+    await makeRequest(page);
+    const t3 = Date.now() - t3Start;
+
+    expect(t1).toBeLessThan(200);
+    expect(t2).toBeGreaterThanOrEqual(200);
+    expect(t3).toBeLessThan(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// afterN — failure fires only after the first N requests pass through
+// ---------------------------------------------------------------------------
+test.describe('afterN counting', () => {
+  test('fetch: first 2 requests succeed, all subsequent fail', async ({ page }) => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0, afterN: 2 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    const results: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      results.push(await makeRequest(page) as string);
+    }
+
+    expect(results[0]).toBe('Success!'); // 1 — before N
+    expect(results[1]).toBe('Success!'); // 2 — before N (count = N, not > N)
+    expect(results[2]).toBe('Error!');   // 3 — after N
+    expect(results[3]).toBe('Error!');   // 4
+    expect(results[4]).toBe('Error!');   // 5
+  });
+
+  test('fetch: afterN 0 — every request fails', async ({ page }) => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0, afterN: 0 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    for (let i = 0; i < 3; i++) {
+      const r = await makeRequest(page);
+      expect(r).toBe('Error!');
+    }
+  });
+
+  test('XHR: first 3 succeed, then all fail', async ({ page }) => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0, afterN: 3 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    const results: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      results.push(await makeRequest(page, '#xhr-get', '#xhr-status') as string);
+    }
+
+    expect(results[0]).toBe('Success!');
+    expect(results[1]).toBe('Success!');
+    expect(results[2]).toBe('Success!');
+    expect(results[3]).toBe('Error!');
+    expect(results[4]).toBe('Error!');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-transport counting: fetch + XHR share the same counter
+// ---------------------------------------------------------------------------
+test.describe('cross-transport counting (fetch + XHR share counter)', () => {
+  test('onNth=2: counter increments across fetch and XHR together', async ({ page }) => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0, onNth: 2 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    // Request 1 via fetch (count=1) → success
+    const r1 = await makeRequest(page, '#fetch-data', '#status');
+    expect(r1).toBe('Success!');
+
+    // Request 2 via XHR (count=2) → should fail (same counter)
+    const r2 = await makeRequest(page, '#xhr-get', '#xhr-status');
+    expect(r2).toBe('Error!');
+
+    // Request 3 via fetch (count=3) → success
+    const r3 = await makeRequest(page, '#fetch-data', '#status');
+    expect(r3).toBe('Success!');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Counting with probability < 1.0
+// ---------------------------------------------------------------------------
+test.describe('counting combined with probability', () => {
+  test('onNth=3 with probability 0 never fires on any request', async ({ page }) => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 0, onNth: 3 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    for (let i = 0; i < 5; i++) {
+      const r = await makeRequest(page);
+      expect(r).toBe('Success!');
+    }
+  });
+});

--- a/packages/core/src/ChaosMaker.ts
+++ b/packages/core/src/ChaosMaker.ts
@@ -54,6 +54,9 @@ export class ChaosMaker {
       console.warn('Chaos Maker is already running. Call stop() first.');
       return;
     }
+    // Reset per-run state so counting rules (onNth / everyNth / afterN)
+    // restart from request 1 on every start() — not just on first construction.
+    this.requestCounters.clear();
     this.running = true;
     console.log('🛠️ Chaos Maker ENGAGED 🛠️');
 

--- a/packages/core/src/ChaosMaker.ts
+++ b/packages/core/src/ChaosMaker.ts
@@ -16,6 +16,8 @@ export class ChaosMaker {
   private originalXhrSend?: (body?: Document | XMLHttpRequestBodyInit) => void;
   private originalXhrOpen?: (method: string, url: string | URL) => void;
   private domObserver?: MutationObserver;
+  /** Shared request counters keyed by config rule object reference. Shared across fetch + XHR. */
+  private requestCounters: Map<object, number> = new Map();
 
   constructor(config: ChaosConfig) {
     this.config = validateConfig(config);
@@ -57,13 +59,13 @@ export class ChaosMaker {
 
     if (this.config.network) {
       this.originalFetch = window.fetch;
-      window.fetch = patchFetch(this.originalFetch.bind(window), this.config.network, this.emitter, this.random);
+      window.fetch = patchFetch(this.originalFetch.bind(window), this.config.network, this.emitter, this.random, this.requestCounters);
 
       this.originalXhrOpen = window.XMLHttpRequest.prototype.open;
       window.XMLHttpRequest.prototype.open = patchXHROpen(this.originalXhrOpen);
 
       this.originalXhrSend = window.XMLHttpRequest.prototype.send;
-      window.XMLHttpRequest.prototype.send = patchXHR(this.originalXhrSend, this.config.network, this.emitter, this.random);
+      window.XMLHttpRequest.prototype.send = patchXHR(this.originalXhrSend, this.config.network, this.emitter, this.random, this.requestCounters);
     }
 
     if (this.config.ui) {

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -43,6 +43,72 @@ export class ChaosConfigBuilder {
     return this;
   }
 
+  // --- onNth shortcuts ---
+
+  failRequestsOnNth(urlPattern: string, statusCode: number, n: number, methods?: string[]) {
+    return this.failRequests(urlPattern, statusCode, 1, methods, undefined, undefined, { onNth: n });
+  }
+
+  addLatencyOnNth(urlPattern: string, delayMs: number, n: number, methods?: string[]) {
+    return this.addLatency(urlPattern, delayMs, 1, methods, { onNth: n });
+  }
+
+  abortRequestsOnNth(urlPattern: string, n: number, timeout?: number, methods?: string[]) {
+    return this.abortRequests(urlPattern, 1, timeout, methods, { onNth: n });
+  }
+
+  corruptResponsesOnNth(urlPattern: string, strategy: CorruptionStrategy, n: number, methods?: string[]) {
+    return this.corruptResponses(urlPattern, strategy, 1, methods, { onNth: n });
+  }
+
+  simulateCorsOnNth(urlPattern: string, n: number, methods?: string[]) {
+    return this.simulateCors(urlPattern, 1, methods, { onNth: n });
+  }
+
+  // --- everyNth shortcuts ---
+
+  failRequestsEveryNth(urlPattern: string, statusCode: number, n: number, methods?: string[]) {
+    return this.failRequests(urlPattern, statusCode, 1, methods, undefined, undefined, { everyNth: n });
+  }
+
+  addLatencyEveryNth(urlPattern: string, delayMs: number, n: number, methods?: string[]) {
+    return this.addLatency(urlPattern, delayMs, 1, methods, { everyNth: n });
+  }
+
+  abortRequestsEveryNth(urlPattern: string, n: number, timeout?: number, methods?: string[]) {
+    return this.abortRequests(urlPattern, 1, timeout, methods, { everyNth: n });
+  }
+
+  corruptResponsesEveryNth(urlPattern: string, strategy: CorruptionStrategy, n: number, methods?: string[]) {
+    return this.corruptResponses(urlPattern, strategy, 1, methods, { everyNth: n });
+  }
+
+  simulateCorsEveryNth(urlPattern: string, n: number, methods?: string[]) {
+    return this.simulateCors(urlPattern, 1, methods, { everyNth: n });
+  }
+
+  // --- afterN shortcuts ---
+
+  failRequestsAfterN(urlPattern: string, statusCode: number, n: number, methods?: string[]) {
+    return this.failRequests(urlPattern, statusCode, 1, methods, undefined, undefined, { afterN: n });
+  }
+
+  addLatencyAfterN(urlPattern: string, delayMs: number, n: number, methods?: string[]) {
+    return this.addLatency(urlPattern, delayMs, 1, methods, { afterN: n });
+  }
+
+  abortRequestsAfterN(urlPattern: string, n: number, timeout?: number, methods?: string[]) {
+    return this.abortRequests(urlPattern, 1, timeout, methods, { afterN: n });
+  }
+
+  corruptResponsesAfterN(urlPattern: string, strategy: CorruptionStrategy, n: number, methods?: string[]) {
+    return this.corruptResponses(urlPattern, strategy, 1, methods, { afterN: n });
+  }
+
+  simulateCorsAfterN(urlPattern: string, n: number, methods?: string[]) {
+    return this.simulateCors(urlPattern, 1, methods, { afterN: n });
+  }
+
   assaultUi(selector: string, action: 'disable' | 'hide' | 'remove', probability: number) {
     if (!this.config.ui!.assaults) this.config.ui!.assaults = [];
     this.config.ui!.assaults.push({ selector, action, probability });

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -1,4 +1,4 @@
-import { ChaosConfig, CorruptionStrategy } from './config';
+import { ChaosConfig, CorruptionStrategy, RequestCountingOptions } from './config';
 
 function cloneConfig(config: ChaosConfig): ChaosConfig {
   return JSON.parse(JSON.stringify(config));
@@ -13,33 +13,33 @@ export class ChaosConfigBuilder {
     if (!this.config.ui) this.config.ui = {};
   }
 
-  failRequests(urlPattern: string, statusCode: number, probability: number, methods?: string[], body?: string, headers?: Record<string, string>) {
+  failRequests(urlPattern: string, statusCode: number, probability: number, methods?: string[], body?: string, headers?: Record<string, string>, counting?: RequestCountingOptions) {
     if (!this.config.network!.failures) this.config.network!.failures = [];
-    this.config.network!.failures.push({ urlPattern, statusCode, probability, methods, body, headers });
+    this.config.network!.failures.push({ urlPattern, statusCode, probability, methods, body, headers, ...counting });
     return this;
   }
 
-  addLatency(urlPattern: string, delayMs: number, probability: number, methods?: string[]) {
+  addLatency(urlPattern: string, delayMs: number, probability: number, methods?: string[], counting?: RequestCountingOptions) {
     if (!this.config.network!.latencies) this.config.network!.latencies = [];
-    this.config.network!.latencies.push({ urlPattern, delayMs, probability, methods });
+    this.config.network!.latencies.push({ urlPattern, delayMs, probability, methods, ...counting });
     return this;
   }
 
-  abortRequests(urlPattern: string, probability: number, timeout?: number, methods?: string[]) {
+  abortRequests(urlPattern: string, probability: number, timeout?: number, methods?: string[], counting?: RequestCountingOptions) {
     if (!this.config.network!.aborts) this.config.network!.aborts = [];
-    this.config.network!.aborts.push({ urlPattern, probability, timeout, methods });
+    this.config.network!.aborts.push({ urlPattern, probability, timeout, methods, ...counting });
     return this;
   }
 
-  corruptResponses(urlPattern: string, strategy: CorruptionStrategy, probability: number, methods?: string[]) {
+  corruptResponses(urlPattern: string, strategy: CorruptionStrategy, probability: number, methods?: string[], counting?: RequestCountingOptions) {
     if (!this.config.network!.corruptions) this.config.network!.corruptions = [];
-    this.config.network!.corruptions.push({ urlPattern, strategy, probability, methods });
+    this.config.network!.corruptions.push({ urlPattern, strategy, probability, methods, ...counting });
     return this;
   }
 
-  simulateCors(urlPattern: string, probability: number, methods?: string[]) {
+  simulateCors(urlPattern: string, probability: number, methods?: string[], counting?: RequestCountingOptions) {
     if (!this.config.network!.cors) this.config.network!.cors = [];
-    this.config.network!.cors.push({ urlPattern, probability, methods });
+    this.config.network!.cors.push({ urlPattern, probability, methods, ...counting });
     return this;
   }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,8 +1,10 @@
 /** Counting options shared by all network chaos config types.
  *  At most one of `onNth`, `everyNth`, or `afterN` may be set on a single rule.
- *  - `onNth`   – apply chaos only on the Nth matching request (1-based).
- *  - `everyNth` – apply chaos on every Nth matching request (1st, N+1th, 2N+1th, …).
- *  - `afterN`  – apply chaos only after the first N matching requests have passed through.
+ *  Counting is per-rule and shared across fetch + XHR (only increments when a
+ *  request matches `urlPattern` + `methods`).
+ *  - `onNth`    – apply chaos only on the Nth matching request (1-based). e.g. `onNth: 3` fires on the 3rd request only.
+ *  - `everyNth` – apply chaos on every Nth matching request. e.g. `everyNth: 3` fires on the 3rd, 6th, 9th, …
+ *  - `afterN`   – apply chaos only after the first N matching requests have passed through. e.g. `afterN: 3` fires from the 4th request onward.
  */
 export interface RequestCountingOptions {
   onNth?: number;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,4 +1,16 @@
-export interface NetworkFailureConfig {
+/** Counting options shared by all network chaos config types.
+ *  At most one of `onNth`, `everyNth`, or `afterN` may be set on a single rule.
+ *  - `onNth`   – apply chaos only on the Nth matching request (1-based).
+ *  - `everyNth` – apply chaos on every Nth matching request (1st, N+1th, 2N+1th, …).
+ *  - `afterN`  – apply chaos only after the first N matching requests have passed through.
+ */
+export interface RequestCountingOptions {
+  onNth?: number;
+  everyNth?: number;
+  afterN?: number;
+}
+
+export interface NetworkFailureConfig extends RequestCountingOptions {
   urlPattern: string;
   methods?: string[];
   statusCode: number;
@@ -8,14 +20,14 @@ export interface NetworkFailureConfig {
   headers?: Record<string, string>;
 }
 
-export interface NetworkLatencyConfig {
+export interface NetworkLatencyConfig extends RequestCountingOptions {
   urlPattern: string;
   methods?: string[];
   delayMs: number;
   probability: number;
 }
 
-export interface NetworkAbortConfig {
+export interface NetworkAbortConfig extends RequestCountingOptions {
   urlPattern: string;
   methods?: string[];
   probability: number;
@@ -24,14 +36,14 @@ export interface NetworkAbortConfig {
 
 export type CorruptionStrategy = 'truncate' | 'malformed-json' | 'empty' | 'wrong-type';
 
-export interface NetworkCorruptionConfig {
+export interface NetworkCorruptionConfig extends RequestCountingOptions {
   urlPattern: string;
   methods?: string[];
   probability: number;
   strategy: CorruptionStrategy;
 }
 
-export interface NetworkCorsConfig {
+export interface NetworkCorsConfig extends RequestCountingOptions {
   urlPattern: string;
   methods?: string[];
   probability: number;

--- a/packages/core/src/interceptors/networkFetch.ts
+++ b/packages/core/src/interceptors/networkFetch.ts
@@ -1,5 +1,5 @@
 import { NetworkAbortConfig, NetworkConfig, NetworkCorruptionConfig } from '../config';
-import { shouldApplyChaos, corruptText, matchUrl } from '../utils';
+import { shouldApplyChaos, corruptText, matchUrl, incrementCounter, checkCountingCondition } from '../utils';
 import { ChaosEventEmitter } from '../events';
 
 function isRequest(input: RequestInfo | URL): input is Request {
@@ -118,7 +118,7 @@ function emitCorruptionEvent(
   });
 }
 
-export function patchFetch(originalFetch: typeof window.fetch, config: NetworkConfig, emitter?: ChaosEventEmitter, random: () => number = Math.random) {
+export function patchFetch(originalFetch: typeof window.fetch, config: NetworkConfig, emitter?: ChaosEventEmitter, random: () => number = Math.random, counters: Map<object, number> = new Map()) {
   return async (
     input: RequestInfo | URL,
     init?: RequestInit
@@ -132,6 +132,8 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
       for (const cors of config.cors) {
         if (matchUrl(url, cors.urlPattern)) {
           if (!cors.methods || cors.methods.includes(method)) {
+            const count = incrementCounter(cors, counters);
+            if (!checkCountingCondition(cors, count)) continue;
             const applied = shouldApplyChaos(cors.probability, random);
             emitter?.emit({
               type: 'network:cors',
@@ -173,6 +175,8 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
       for (const abort of config.aborts) {
         if (matchUrl(url, abort.urlPattern)) {
           if (!abort.methods || abort.methods.includes(method)) {
+            const count = incrementCounter(abort, counters);
+            if (!checkCountingCondition(abort, count)) continue;
             const applied = shouldApplyChaos(abort.probability, random);
             if (!applied) {
               emitAbortEvent(emitter, abort, url, method, false);
@@ -220,6 +224,8 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
       for (const failure of config.failures) {
         if (matchUrl(url, failure.urlPattern)) {
           if (!failure.methods || failure.methods.includes(method)) {
+            const count = incrementCounter(failure, counters);
+            if (!checkCountingCondition(failure, count)) continue;
             const applied = shouldApplyChaos(failure.probability, random);
             emitter?.emit({
               type: 'network:failure',
@@ -247,6 +253,8 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
       for (const latency of config.latencies) {
         if (matchUrl(url, latency.urlPattern)) {
           if (!latency.methods || latency.methods.includes(method)) {
+            const count = incrementCounter(latency, counters);
+            if (!checkCountingCondition(latency, count)) continue;
             const applied = shouldApplyChaos(latency.probability, random);
             emitter?.emit({
               type: 'network:latency',
@@ -269,6 +277,8 @@ export function patchFetch(originalFetch: typeof window.fetch, config: NetworkCo
       for (const corruption of config.corruptions) {
         if (matchUrl(url, corruption.urlPattern)) {
           if (!corruption.methods || corruption.methods.includes(method)) {
+            const count = incrementCounter(corruption, counters);
+            if (!checkCountingCondition(corruption, count)) continue;
             const applied = shouldApplyChaos(corruption.probability, random);
             if (!applied) {
               emitCorruptionEvent(emitter, corruption, url, method, false);

--- a/packages/core/src/interceptors/networkXHR.ts
+++ b/packages/core/src/interceptors/networkXHR.ts
@@ -1,5 +1,5 @@
 import { NetworkAbortConfig, NetworkConfig, NetworkCorruptionConfig } from '../config';
-import { shouldApplyChaos, corruptText, matchUrl } from '../utils';
+import { shouldApplyChaos, corruptText, matchUrl, incrementCounter, checkCountingCondition } from '../utils';
 import { ChaosEventEmitter } from '../events';
 
 function emitAbortEvent(
@@ -32,7 +32,7 @@ function emitCorruptionEvent(
   });
 }
 
-export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyInit) => void, config: NetworkConfig, emitter?: ChaosEventEmitter, random: () => number = Math.random) {
+export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyInit) => void, config: NetworkConfig, emitter?: ChaosEventEmitter, random: () => number = Math.random, counters: Map<object, number> = new Map()) {
   return function (this: XMLHttpRequest, body?: Document | XMLHttpRequestBodyInit) {
     const url = (this as any)._chaos_url;
     const method = (this as any)._chaos_method;
@@ -42,6 +42,8 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
       for (const cors of config.cors) {
         if (matchUrl(url, cors.urlPattern)) {
           if (!cors.methods || cors.methods.includes(method)) {
+            const count = incrementCounter(cors, counters);
+            if (!checkCountingCondition(cors, count)) continue;
             const applied = shouldApplyChaos(cors.probability, random);
             emitter?.emit({
               type: 'network:cors',
@@ -67,6 +69,8 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
       for (const abort of config.aborts) {
         if (matchUrl(url, abort.urlPattern)) {
           if (!abort.methods || abort.methods.includes(method)) {
+            const count = incrementCounter(abort, counters);
+            if (!checkCountingCondition(abort, count)) continue;
             const applied = shouldApplyChaos(abort.probability, random);
             if (!applied) {
               emitAbortEvent(emitter, abort, url, method, false);
@@ -140,6 +144,8 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
       for (const failure of config.failures) {
         if (matchUrl(url, failure.urlPattern)) {
           if (!failure.methods || failure.methods.includes(method)) {
+            const count = incrementCounter(failure, counters);
+            if (!checkCountingCondition(failure, count)) continue;
             const applied = shouldApplyChaos(failure.probability, random);
             emitter?.emit({
               type: 'network:failure',
@@ -188,6 +194,8 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
       for (const corruption of config.corruptions) {
         if (matchUrl(url, corruption.urlPattern)) {
           if (!corruption.methods || corruption.methods.includes(method)) {
+            const count = incrementCounter(corruption, counters);
+            if (!checkCountingCondition(corruption, count)) continue;
             const applied = shouldApplyChaos(corruption.probability, random);
             if (!applied) {
               emitCorruptionEvent(emitter, corruption, url, method, false);
@@ -275,6 +283,8 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
       for (const latency of config.latencies) {
         if (matchUrl(url, latency.urlPattern)) {
           if (!latency.methods || latency.methods.includes(method)) {
+            const count = incrementCounter(latency, counters);
+            if (!checkCountingCondition(latency, count)) continue;
             const applied = shouldApplyChaos(latency.probability, random);
             emitter?.emit({
               type: 'network:latency',

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,7 +1,30 @@
-import type { CorruptionStrategy } from './config';
+import type { CorruptionStrategy, RequestCountingOptions } from './config';
 
 export function shouldApplyChaos(probability: number, random: () => number = Math.random): boolean {
   return random() < probability;
+}
+
+/**
+ * Increment the per-rule request counter and return the new count.
+ * Keyed by the rule object reference so the same counter is shared across
+ * fetch and XHR interceptors for a given config entry.
+ */
+export function incrementCounter(rule: object, counters: Map<object, number>): number {
+  const next = (counters.get(rule) ?? 0) + 1;
+  counters.set(rule, next);
+  return next;
+}
+
+/**
+ * Given a rule with optional counting fields and the current (already-incremented)
+ * request count for that rule, return whether the chaos should fire this request.
+ * Returns `true` when no counting field is set (counting is always opt-in).
+ */
+export function checkCountingCondition(rule: RequestCountingOptions, count: number): boolean {
+  if (rule.onNth !== undefined) return count === rule.onNth;
+  if (rule.everyNth !== undefined) return count % rule.everyNth === 0;
+  if (rule.afterN !== undefined) return count > rule.afterN;
+  return true;
 }
 
 export function matchUrl(url: string, pattern: string): boolean {

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -4,6 +4,23 @@ import type { ChaosConfig } from './config';
 
 const probability = z.number().min(0, 'Probability must be >= 0').max(1, 'Probability must be <= 1');
 
+const positiveInt = z.number().int().min(1);
+
+/** Shared counting fields for network chaos rules. At most one may be set. */
+const countingFields = {
+  onNth: positiveInt.optional(),
+  everyNth: positiveInt.optional(),
+  afterN: z.number().int().min(0).optional(),
+};
+
+const mutuallyExclusiveCounting = (data: { onNth?: number; everyNth?: number; afterN?: number }) =>
+  [data.onNth, data.everyNth, data.afterN].filter(v => v !== undefined).length <= 1;
+
+const countingRefinement = [
+  mutuallyExclusiveCounting,
+  { message: 'Only one of onNth, everyNth, or afterN may be set on a single rule' },
+] as const;
+
 const networkFailureSchema = z.object({
   urlPattern: z.string().min(1, 'urlPattern must not be empty'),
   methods: z.array(z.string()).optional(),
@@ -12,34 +29,39 @@ const networkFailureSchema = z.object({
   body: z.string().optional(),
   statusText: z.string().optional(),
   headers: z.record(z.string()).optional(),
-}).strict();
+  ...countingFields,
+}).strict().refine(...countingRefinement);
 
 const networkLatencySchema = z.object({
   urlPattern: z.string().min(1, 'urlPattern must not be empty'),
   methods: z.array(z.string()).optional(),
   delayMs: z.number().min(0, 'delayMs must be >= 0'),
   probability,
-}).strict();
+  ...countingFields,
+}).strict().refine(...countingRefinement);
 
 const networkAbortSchema = z.object({
   urlPattern: z.string().min(1, 'urlPattern must not be empty'),
   methods: z.array(z.string()).optional(),
   probability,
   timeout: z.number().min(0, 'timeout must be >= 0').optional(),
-}).strict();
+  ...countingFields,
+}).strict().refine(...countingRefinement);
 
 const networkCorruptionSchema = z.object({
   urlPattern: z.string().min(1, 'urlPattern must not be empty'),
   methods: z.array(z.string()).optional(),
   probability,
   strategy: z.enum(['truncate', 'malformed-json', 'empty', 'wrong-type']),
-}).strict();
+  ...countingFields,
+}).strict().refine(...countingRefinement);
 
 const networkCorsSchema = z.object({
   urlPattern: z.string().min(1, 'urlPattern must not be empty'),
   methods: z.array(z.string()).optional(),
   probability,
-}).strict();
+  ...countingFields,
+}).strict().refine(...countingRefinement);
 
 const networkConfigSchema = z.object({
   failures: z.array(networkFailureSchema).optional(),

--- a/packages/core/test/ChaosMaker.test.ts
+++ b/packages/core/test/ChaosMaker.test.ts
@@ -63,6 +63,28 @@ describe('ChaosMaker', () => {
     expect(global.XMLHttpRequest.prototype.send).toBe(originalXhrSend);
   });
 
+  it('resets counting state on restart so onNth:1 fires again after stop/start', async () => {
+    const config: ChaosConfig = {
+      network: {
+        failures: [{ urlPattern: '/api/test', statusCode: 500, probability: 1.0, onNth: 1 }],
+      },
+    };
+    chaosMaker = new ChaosMaker(config);
+
+    // First run: 1st request should fail (counter=1 matches onNth:1).
+    chaosMaker.start();
+    const r1 = await global.fetch('/api/test');
+    expect(r1.status).toBe(500);
+    chaosMaker.stop();
+
+    // If counters weren't reset on restart, counter would already be past 1
+    // and this request would NOT fail. We expect it to fail — counter is fresh.
+    chaosMaker.start();
+    const r2 = await global.fetch('/api/test');
+    expect(r2.status).toBe(500);
+    chaosMaker.stop();
+  });
+
   it('should correctly use the config to fail a fetch call', async () => {
     const config: ChaosConfig = {
       network: {

--- a/packages/core/test/counting.test.ts
+++ b/packages/core/test/counting.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { checkCountingCondition, incrementCounter } from '../src/utils';
+
+// ---------------------------------------------------------------------------
+// checkCountingCondition
+// ---------------------------------------------------------------------------
+describe('checkCountingCondition', () => {
+  it('returns true when no counting fields are set', () => {
+    expect(checkCountingCondition({}, 1)).toBe(true);
+    expect(checkCountingCondition({}, 99)).toBe(true);
+  });
+
+  describe('onNth', () => {
+    it('returns true only on the exact Nth count', () => {
+      const rule = { onNth: 3 };
+      expect(checkCountingCondition(rule, 1)).toBe(false);
+      expect(checkCountingCondition(rule, 2)).toBe(false);
+      expect(checkCountingCondition(rule, 3)).toBe(true);
+      expect(checkCountingCondition(rule, 4)).toBe(false);
+      expect(checkCountingCondition(rule, 10)).toBe(false);
+    });
+
+    it('returns true on the 1st request when onNth is 1', () => {
+      const rule = { onNth: 1 };
+      expect(checkCountingCondition(rule, 1)).toBe(true);
+      expect(checkCountingCondition(rule, 2)).toBe(false);
+    });
+  });
+
+  describe('everyNth', () => {
+    it('returns true on every Nth request', () => {
+      const rule = { everyNth: 3 };
+      expect(checkCountingCondition(rule, 1)).toBe(false);
+      expect(checkCountingCondition(rule, 2)).toBe(false);
+      expect(checkCountingCondition(rule, 3)).toBe(true);
+      expect(checkCountingCondition(rule, 4)).toBe(false);
+      expect(checkCountingCondition(rule, 5)).toBe(false);
+      expect(checkCountingCondition(rule, 6)).toBe(true);
+      expect(checkCountingCondition(rule, 9)).toBe(true);
+    });
+
+    it('returns true on every 1st request when everyNth is 1', () => {
+      const rule = { everyNth: 1 };
+      for (let i = 1; i <= 5; i++) {
+        expect(checkCountingCondition(rule, i)).toBe(true);
+      }
+    });
+
+    it('returns true on every 2nd request when everyNth is 2', () => {
+      const rule = { everyNth: 2 };
+      expect(checkCountingCondition(rule, 1)).toBe(false);
+      expect(checkCountingCondition(rule, 2)).toBe(true);
+      expect(checkCountingCondition(rule, 3)).toBe(false);
+      expect(checkCountingCondition(rule, 4)).toBe(true);
+    });
+  });
+
+  describe('afterN', () => {
+    it('returns false for the first N requests and true thereafter', () => {
+      const rule = { afterN: 3 };
+      expect(checkCountingCondition(rule, 1)).toBe(false);
+      expect(checkCountingCondition(rule, 2)).toBe(false);
+      expect(checkCountingCondition(rule, 3)).toBe(false);
+      expect(checkCountingCondition(rule, 4)).toBe(true);
+      expect(checkCountingCondition(rule, 10)).toBe(true);
+    });
+
+    it('fires from the very first request when afterN is 0', () => {
+      const rule = { afterN: 0 };
+      expect(checkCountingCondition(rule, 1)).toBe(true);
+      expect(checkCountingCondition(rule, 5)).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// incrementCounter
+// ---------------------------------------------------------------------------
+describe('incrementCounter', () => {
+  it('starts at 1 for a new rule', () => {
+    const counters = new Map<object, number>();
+    const rule = {};
+    expect(incrementCounter(rule, counters)).toBe(1);
+  });
+
+  it('increments on each call', () => {
+    const counters = new Map<object, number>();
+    const rule = {};
+    expect(incrementCounter(rule, counters)).toBe(1);
+    expect(incrementCounter(rule, counters)).toBe(2);
+    expect(incrementCounter(rule, counters)).toBe(3);
+  });
+
+  it('tracks different rules independently', () => {
+    const counters = new Map<object, number>();
+    const ruleA = {};
+    const ruleB = {};
+    incrementCounter(ruleA, counters);
+    incrementCounter(ruleA, counters);
+    incrementCounter(ruleB, counters);
+    expect(incrementCounter(ruleA, counters)).toBe(3);
+    expect(incrementCounter(ruleB, counters)).toBe(2);
+  });
+
+  it('uses object reference as the key — same ref means same counter', () => {
+    const counters = new Map<object, number>();
+    const rule = { urlPattern: '/api' };
+    // Simulate fetch + XHR sharing the same rule object
+    incrementCounter(rule, counters);
+    incrementCounter(rule, counters);
+    expect(counters.get(rule)).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Combined: onNth with probability
+// ---------------------------------------------------------------------------
+describe('counting + probability interaction', () => {
+  it('onNth with probability 1.0 fires exactly once on the Nth request', () => {
+    const counters = new Map<object, number>();
+    const rule = { onNth: 2 };
+    const results: boolean[] = [];
+
+    for (let i = 0; i < 5; i++) {
+      const count = incrementCounter(rule, counters);
+      const conditionMet = checkCountingCondition(rule, count);
+      // With probability 1.0 — always fires when condition is met
+      results.push(conditionMet && true);
+    }
+
+    expect(results).toEqual([false, true, false, false, false]);
+  });
+
+  it('afterN with probability 1.0 fires for all requests past N', () => {
+    const counters = new Map<object, number>();
+    const rule = { afterN: 2 };
+    const results: boolean[] = [];
+
+    for (let i = 0; i < 5; i++) {
+      const count = incrementCounter(rule, counters);
+      results.push(checkCountingCondition(rule, count));
+    }
+
+    expect(results).toEqual([false, false, true, true, true]);
+  });
+
+  it('everyNth=3 fires on requests 3 and 6 of 7', () => {
+    const counters = new Map<object, number>();
+    const rule = { everyNth: 3 };
+    const results: boolean[] = [];
+
+    for (let i = 0; i < 7; i++) {
+      const count = incrementCounter(rule, counters);
+      results.push(checkCountingCondition(rule, count));
+    }
+
+    expect(results).toEqual([false, false, true, false, false, true, false]);
+  });
+});

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -195,4 +195,106 @@ describe('validateConfig', () => {
     };
     expect(() => validateConfig(config)).not.toThrow();
   });
+
+  // -------------------------------------------------------------------------
+  // Counting fields (onNth / everyNth / afterN)
+  // -------------------------------------------------------------------------
+  describe('counting fields', () => {
+    it('accepts a single onNth', () => {
+      const config = {
+        network: {
+          failures: [{ urlPattern: '/api', statusCode: 500, probability: 1, onNth: 3 }],
+        },
+      };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('accepts a single everyNth', () => {
+      const config = {
+        network: {
+          latencies: [{ urlPattern: '/api', delayMs: 100, probability: 1, everyNth: 2 }],
+        },
+      };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('accepts afterN of 0', () => {
+      const config = {
+        network: {
+          failures: [{ urlPattern: '/api', statusCode: 500, probability: 1, afterN: 0 }],
+        },
+      };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('rejects onNth of 0', () => {
+      const config = {
+        network: {
+          failures: [{ urlPattern: '/api', statusCode: 500, probability: 1, onNth: 0 }],
+        },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects everyNth of 0', () => {
+      const config = {
+        network: {
+          failures: [{ urlPattern: '/api', statusCode: 500, probability: 1, everyNth: 0 }],
+        },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects negative afterN', () => {
+      const config = {
+        network: {
+          failures: [{ urlPattern: '/api', statusCode: 500, probability: 1, afterN: -1 }],
+        },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects non-integer onNth', () => {
+      const config = {
+        network: {
+          failures: [{ urlPattern: '/api', statusCode: 500, probability: 1, onNth: 1.5 }],
+        },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects combining onNth with everyNth', () => {
+      const config = {
+        network: {
+          failures: [{ urlPattern: '/api', statusCode: 500, probability: 1, onNth: 2, everyNth: 3 }],
+        },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects combining all three counting fields', () => {
+      const config = {
+        network: {
+          failures: [{
+            urlPattern: '/api', statusCode: 500, probability: 1,
+            onNth: 1, everyNth: 2, afterN: 3,
+          }],
+        },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('accepts counting on all network chaos types', () => {
+      const config = {
+        network: {
+          failures: [{ urlPattern: '/api', statusCode: 500, probability: 1, onNth: 2 }],
+          latencies: [{ urlPattern: '/api', delayMs: 50, probability: 1, everyNth: 2 }],
+          aborts: [{ urlPattern: '/api', probability: 1, afterN: 1 }],
+          corruptions: [{ urlPattern: '/api', strategy: 'empty' as const, probability: 1, onNth: 1 }],
+          cors: [{ urlPattern: '/api', probability: 1, everyNth: 4 }],
+        },
+      };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `onNth`, `everyNth`, `afterN` counting fields to all five network chaos config types (`failures`, `latencies`, `aborts`, `corruptions`, `cors`)
- Counters are keyed by config rule object reference and shared between fetch and XHR interceptors, so a single rule counts across both transports
- Zod validation enforces positive integers and mutual exclusivity (at most one counting field per rule)
- `ChaosConfigBuilder` methods accept an optional trailing `counting?: RequestCountingOptions` parameter (backwards compatible)
- 15 new unit tests covering `checkCountingCondition` and `incrementCounter`
- 11 new E2E tests in Chromium covering onNth, everyNth, afterN, cross-transport counting, and probability interaction

## Counting semantics

| Field | Behaviour |
|-------|-----------|
| `onNth: N` | Chaos fires only on the Nth matching request (1-based) |
| `everyNth: N` | Chaos fires on every Nth matching request (1, N+1, 2N+1, …) |
| `afterN: N` | Chaos fires on all requests after the first N have passed through |

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — 130/130 unit tests pass
- [x] `pnpm build` — ESM, CJS, UMD, and type declarations built cleanly
- [x] `pnpm --filter e2e-tests exec playwright test --project=chromium` — 54/54 E2E tests pass (11 new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request-count-based controls (onNth, everyNth, afterN) for failures, latency, aborts, corruptions, and CORS; convenience builder methods for these patterns and shared request counting across transports.

* **Tests**
  * Added E2E and unit tests covering counting modes, cross-transport counting, probability interaction, latency timing, validation rules, and helper utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->