### PR TITLE
feat: phase 3 — WebSocket chaos (drop, delay, corrupt, close) [0.2.0-beta.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0-beta.1] - 2026-04-16
+
+### Added
+
+- **WebSocket chaos**: intercept `window.WebSocket` to drop, delay, corrupt, or force-close messages and connections (inbound/outbound/both)
+  - Config types: `WebSocketDropConfig`, `WebSocketDelayConfig`, `WebSocketCorruptConfig`, `WebSocketCloseConfig`
+  - Corruption strategies: `truncate`, `malformed-json`, `empty`, `wrong-type` (JSON strategies emit `applied: false` with `reason: 'incompatible-payload-type'` for binary frames)
+  - Ordering per message: drop → corrupt → delay; close chaos cancels pending per-socket timers so pending delays never fire after close
+  - Wrapper preserves `instanceof WebSocket` via prototype aliasing so app code using `instanceof` keeps working
+  - New `unreliableWebSocket` preset (10% drop both ways, 500ms inbound delay, 5% inbound truncate)
+  - Builder: `.dropMessages()`, `.delayMessages()`, `.corruptMessages()`, `.closeConnection()` + `.dropMessagesOnNth()`, `.delayMessagesOnNth()` shortcuts
+  - Emitted events: `websocket:drop`, `websocket:delay`, `websocket:corrupt`, `websocket:close` with `direction`, `payloadType`, `closeCode`, `closeReason`, and `reason` detail fields
+- **Per-rule request counting** (Phase 2): `onNth`, `everyNth`, `afterN` on every network and websocket rule — deterministic "fail the 3rd request", "drop every other message"
+- **Seeded randomness** (Phase 1): `seed` field on `ChaosConfig`, auto-generated if omitted, exposed via `getChaosSeed(page)` for reproducible chaos runs
+- **Playwright adapter**: re-exports `WebSocketConfig`, `WebSocketDropConfig`, `WebSocketDelayConfig`, `WebSocketCorruptConfig`, `WebSocketCloseConfig`, `WebSocketDirection`, `WebSocketCorruptionStrategy`
+- **E2E coverage**: WebSocket chaos E2E suite across chromium, firefox, webkit, edge (24 tests) — includes seeded replay determinism, per-message `onNth` counting, close-with-custom-code, truncation, relative-latency baseline
+
 ### Removed
 
 - **Chrome extension**: Extracted from monorepo to keep focus on core library and framework adapters

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ test('app handles slow network gracefully', async ({ page }) => {
 });
 ```
 
-Available presets: `unstableApi`, `slowNetwork`, `offlineMode`, `flakyConnection`, `degradedUi`
+Available presets: `unstableApi`, `slowNetwork`, `offlineMode`, `flakyConnection`, `degradedUi`, `unreliableWebSocket`
 
 ### Using the Config Builder
 
@@ -196,6 +196,33 @@ Simulates CORS failures. Fetch throws `TypeError('Failed to fetch')`, XHR fires 
 }
 ```
 
+### WebSocket Chaos
+
+Intercept `window.WebSocket` connections to drop, delay, corrupt, or force-close messages. Works without server cooperation — the chaos layer sits between the page and the real socket.
+
+```ts
+{
+  websocket: {
+    drops: [
+      { urlPattern: 'wss://chat', direction: 'outbound', probability: 0.1 }
+    ],
+    delays: [
+      { urlPattern: 'wss://chat', direction: 'inbound', delayMs: 500, probability: 1.0 }
+    ],
+    corruptions: [
+      { urlPattern: 'wss://chat', direction: 'inbound', strategy: 'truncate', probability: 0.05 }
+    ],
+    closes: [
+      { urlPattern: 'wss://chat', probability: 1.0, afterMs: 30000, code: 4000, reason: 'chaos' }
+    ]
+  }
+}
+```
+
+`direction` is `'inbound' | 'outbound' | 'both'`. Corruption strategies are the same four as network responses (`truncate`, `malformed-json`, `empty`, `wrong-type`); JSON-specific strategies are skipped on binary frames and logged with `applied: false, reason: 'incompatible-payload-type'`. Per-rule counting (`onNth`, `everyNth`, `afterN`) works on every WS rule — for example, `{ drops: [{ urlPattern: 'wss://', direction: 'outbound', probability: 1, everyNth: 2 }] }` drops every 2nd outbound message.
+
+Presets include `unreliableWebSocket` for a realistic flaky-socket profile.
+
 ### UI Assaults
 
 Manipulate DOM elements by CSS selector. Works on elements present at page load and dynamically added elements (via `MutationObserver`).
@@ -229,10 +256,12 @@ const log = await getChaosLog(page);
 // Each event has:
 // {
 //   type: 'network:failure' | 'network:latency' | 'network:abort' |
-//         'network:corruption' | 'network:cors' | 'ui:assault',
+//         'network:corruption' | 'network:cors' | 'ui:assault' |
+//         'websocket:drop' | 'websocket:delay' | 'websocket:corrupt' | 'websocket:close',
 //   timestamp: number,
-//   applied: boolean,       // true = chaos was applied, false = probability skipped it
-//   detail: { url?, method?, statusCode?, delayMs?, strategy?, ... }
+//   applied: boolean,       // true = chaos was applied, false = probability/compat skipped it
+//   detail: { url?, method?, statusCode?, delayMs?, strategy?,
+//             direction?, payloadType?, closeCode?, closeReason?, reason?, ... }
 // }
 ```
 
@@ -293,7 +322,7 @@ await driver.get('http://localhost:3000');
 ```bash
 pnpm install              # install dependencies
 pnpm build                # build core + playwright
-pnpm test                 # unit tests (72 tests)
+pnpm test                 # unit tests (178 tests)
 pnpm lint                 # eslint
 pnpm --filter e2e-tests exec playwright test  # e2e tests
 ```

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -10,6 +10,8 @@
     "@chaos-maker/core": "workspace:*",
     "@chaos-maker/playwright": "workspace:*",
     "@playwright/test": "^1.45.0",
-    "http-server": "^14.1.1"
+    "@types/ws": "^8.18.1",
+    "http-server": "^14.1.1",
+    "ws": "^8.20.0"
   }
 }

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -25,11 +25,18 @@ export default defineConfig({
       use: { ...devices['Desktop Edge'] },
     },
   ],
-  webServer: {
-    command: process.env.CI
-      ? 'npx http-server ./src -p 8080 -s'
-      : 'python3 -m http.server 8080 -d ./src',
-    url: 'http://127.0.0.1:8080',
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer: [
+    {
+      command: process.env.CI
+        ? 'npx http-server ./src -p 8080 -s'
+        : 'python3 -m http.server 8080 -d ./src',
+      url: 'http://127.0.0.1:8080',
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command: 'node ./src/ws-echo-server.js',
+      port: 8081,
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
 });

--- a/e2e-tests/src/index.html
+++ b/e2e-tests/src/index.html
@@ -42,6 +42,17 @@
     <div id="dynamic-container"></div>
   </section>
 
+  <!-- WebSocket -->
+  <section>
+    <h2>WebSocket</h2>
+    <button id="ws-connect">Connect</button>
+    <button id="ws-send">Send "ping"</button>
+    <button id="ws-close">Close</button>
+    <div id="ws-status">idle</div>
+    <div id="ws-inbound-count">0</div>
+    <pre id="ws-log"></pre>
+  </section>
+
   <script>
     var API_URL = '/api/data.json';
 
@@ -149,6 +160,54 @@
       btn.className = 'dynamic-btn';
       btn.textContent = 'Dynamic Button';
       container.appendChild(btn);
+    });
+
+    // --- WebSocket ---
+    var WS_URL = 'ws://127.0.0.1:8081';
+    var ws = null;
+    var wsInboundCount = 0;
+
+    function wsLog(line) {
+      var pre = document.getElementById('ws-log');
+      pre.textContent += line + '\n';
+    }
+
+    function setWsStatus(text) {
+      document.getElementById('ws-status').textContent = text;
+    }
+
+    function setWsInboundCount(n) {
+      document.getElementById('ws-inbound-count').textContent = String(n);
+    }
+
+    document.getElementById('ws-connect').addEventListener('click', function () {
+      if (ws && ws.readyState !== WebSocket.CLOSED) return;
+      wsInboundCount = 0;
+      setWsInboundCount(0);
+      setWsStatus('connecting');
+      ws = new WebSocket(WS_URL);
+      ws.addEventListener('open', function () { setWsStatus('open'); });
+      ws.addEventListener('message', function (evt) {
+        wsInboundCount += 1;
+        setWsInboundCount(wsInboundCount);
+        wsLog('in ' + Date.now() + ' ' + String(evt.data));
+      });
+      ws.addEventListener('close', function (evt) {
+        setWsStatus('closed ' + evt.code + ' ' + (evt.reason || ''));
+      });
+      ws.addEventListener('error', function () { setWsStatus('error'); });
+    });
+
+    document.getElementById('ws-send').addEventListener('click', function () {
+      if (!ws || ws.readyState !== WebSocket.OPEN) return;
+      var msg = 'ping';
+      wsLog('out ' + Date.now() + ' ' + msg);
+      ws.send(msg);
+    });
+
+    document.getElementById('ws-close').addEventListener('click', function () {
+      if (!ws) return;
+      ws.close();
     });
   </script>
 </body>

--- a/e2e-tests/src/ws-echo-server.js
+++ b/e2e-tests/src/ws-echo-server.js
@@ -1,0 +1,28 @@
+// Minimal WebSocket echo server for chaos-maker E2E tests.
+// Echoes every message back to the same client. Binds to 127.0.0.1:8081.
+// Kept as plain JS (not TS) so Playwright `webServer` can `node` it directly.
+
+const { WebSocketServer } = require('ws');
+
+const PORT = Number(process.env.WS_ECHO_PORT || 8081);
+const server = new WebSocketServer({ host: '127.0.0.1', port: PORT });
+
+server.on('connection', (socket) => {
+  socket.on('message', (data, isBinary) => {
+    // ws gives us a Buffer by default; preserve binary-ness.
+    socket.send(data, { binary: isBinary });
+  });
+});
+
+server.on('listening', () => {
+  // Print a stable marker line so Playwright's webServer `url` probe (which
+  // only checks socket connectability) works; the log aids local debugging.
+  console.log(`[ws-echo] listening on ws://127.0.0.1:${PORT}`);
+});
+
+// Graceful shutdown when Playwright stops us.
+const close = () => {
+  server.close(() => process.exit(0));
+};
+process.on('SIGTERM', close);
+process.on('SIGINT', close);

--- a/e2e-tests/tests/websocket-chaos.spec.ts
+++ b/e2e-tests/tests/websocket-chaos.spec.ts
@@ -1,0 +1,196 @@
+import { test, expect, type Page } from '@playwright/test';
+import { injectChaos, getChaosLog, getChaosSeed } from '@chaos-maker/playwright';
+
+const BASE_URL = 'http://127.0.0.1:8080';
+const WS_URL_PATTERN = '127.0.0.1:8081';
+
+async function connect(page: Page): Promise<void> {
+  await page.click('#ws-connect');
+  await expect(page.locator('#ws-status')).toHaveText('open');
+}
+
+async function send(page: Page, n: number): Promise<void> {
+  for (let i = 0; i < n; i++) {
+    await page.click('#ws-send');
+    // Small settle so the send events are serialized; chaos timing may hold
+    // ordering otherwise.
+    await page.waitForTimeout(30);
+  }
+}
+
+async function inboundCount(page: Page): Promise<number> {
+  return Number(await page.locator('#ws-inbound-count').textContent());
+}
+
+// ---------------------------------------------------------------------------
+// Drop — outbound every other message
+// ---------------------------------------------------------------------------
+test.describe('WebSocket drop', () => {
+  test('drops every 2nd outbound message; server echoes only half', async ({ page }) => {
+    await injectChaos(page, {
+      websocket: {
+        drops: [{ urlPattern: WS_URL_PATTERN, direction: 'outbound', probability: 1, everyNth: 2 }],
+      },
+    });
+    await page.goto(BASE_URL);
+    await connect(page);
+    await send(page, 4);
+    // Give the server time to echo the non-dropped messages back.
+    await page.waitForFunction(() => Number(document.getElementById('ws-inbound-count')?.textContent) === 2, null, { timeout: 5000 });
+    expect(await inboundCount(page)).toBe(2);
+
+    const log = await getChaosLog(page);
+    const drops = log.filter(e => e.type === 'websocket:drop' && e.detail.direction === 'outbound');
+    expect(drops.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delay — inbound messages arrive no sooner than delayMs
+// ---------------------------------------------------------------------------
+test.describe('WebSocket delay', () => {
+  test('delays inbound by >= 800ms (relative to baseline)', async ({ page }) => {
+    // Baseline: no chaos, measure round-trip.
+    await injectChaos(page, { websocket: {} });
+    await page.goto(BASE_URL);
+    await connect(page);
+    const t0 = Date.now();
+    await send(page, 1);
+    await page.waitForFunction(() => Number(document.getElementById('ws-inbound-count')?.textContent) === 1);
+    const baseline = Date.now() - t0;
+
+    // Chaos run with 800ms inbound delay.
+    const page2 = await page.context().newPage();
+    await injectChaos(page2, {
+      websocket: {
+        delays: [{ urlPattern: WS_URL_PATTERN, direction: 'inbound', delayMs: 800, probability: 1 }],
+      },
+    });
+    await page2.goto(BASE_URL);
+    await page2.click('#ws-connect');
+    await expect(page2.locator('#ws-status')).toHaveText('open');
+    const t1 = Date.now();
+    await page2.click('#ws-send');
+    await page2.waitForFunction(() => Number(document.getElementById('ws-inbound-count')?.textContent) === 1);
+    const withChaos = Date.now() - t1;
+
+    // Relative assertion dominates over baseline jitter on slow browser projects.
+    expect(withChaos - baseline).toBeGreaterThanOrEqual(600);
+
+    const log = await getChaosLog(page2);
+    expect(log.filter(e => e.type === 'websocket:delay').length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Corrupt — truncate inbound payload
+// ---------------------------------------------------------------------------
+test.describe('WebSocket corrupt', () => {
+  test('truncates inbound text payload', async ({ page }) => {
+    await injectChaos(page, {
+      websocket: {
+        corruptions: [{ urlPattern: WS_URL_PATTERN, direction: 'inbound', strategy: 'truncate', probability: 1 }],
+      },
+    });
+    await page.goto(BASE_URL);
+    await connect(page);
+    await send(page, 1);
+    await page.waitForFunction(() => Number(document.getElementById('ws-inbound-count')?.textContent) === 1);
+
+    const logText = await page.locator('#ws-log').textContent();
+    // 'ping' truncated to half → 'pi' (length 2).
+    expect(logText).toMatch(/in \d+ pi\n/);
+
+    const log = await getChaosLog(page);
+    const corrupted = log.find(e => e.type === 'websocket:corrupt' && e.applied);
+    expect(corrupted?.detail.strategy).toBe('truncate');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Close — force-close after 500ms with custom code/reason
+// ---------------------------------------------------------------------------
+test.describe('WebSocket close', () => {
+  test('force-closes after afterMs with configured code and reason', async ({ page }) => {
+    await injectChaos(page, {
+      websocket: {
+        closes: [{ urlPattern: WS_URL_PATTERN, probability: 1, afterMs: 500, code: 4000, reason: 'chaos' }],
+      },
+    });
+    await page.goto(BASE_URL);
+    await connect(page);
+
+    await expect(page.locator('#ws-status')).toContainText('closed', { timeout: 3000 });
+    await expect(page.locator('#ws-status')).toContainText('4000');
+
+    const log = await getChaosLog(page);
+    const closes = log.filter(e => e.type === 'websocket:close' && e.applied);
+    expect(closes.length).toBe(1);
+    expect(closes[0].detail.closeCode).toBe(4000);
+    expect(closes[0].detail.closeReason).toBe('chaos');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Seeded replay — identical seeds → identical drop patterns
+// ---------------------------------------------------------------------------
+test.describe('WebSocket seeded replay', () => {
+  test('same seed produces identical drop outcomes', async ({ page }) => {
+    const cfg = {
+      seed: 777,
+      websocket: {
+        drops: [{ urlPattern: WS_URL_PATTERN, direction: 'outbound' as const, probability: 0.5 }],
+      },
+    };
+    await injectChaos(page, cfg);
+    await page.goto(BASE_URL);
+    await connect(page);
+    await send(page, 6);
+    await page.waitForTimeout(500);
+    const seed1 = await getChaosSeed(page);
+    const drops1 = (await getChaosLog(page))
+      .filter(e => e.type === 'websocket:drop')
+      .map(e => e.detail.direction);
+
+    const page2 = await page.context().newPage();
+    await injectChaos(page2, cfg);
+    await page2.goto(BASE_URL);
+    await page2.click('#ws-connect');
+    await expect(page2.locator('#ws-status')).toHaveText('open');
+    for (let i = 0; i < 6; i++) {
+      await page2.click('#ws-send');
+      await page2.waitForTimeout(30);
+    }
+    await page2.waitForTimeout(500);
+    const seed2 = await getChaosSeed(page2);
+    const drops2 = (await getChaosLog(page2))
+      .filter(e => e.type === 'websocket:drop')
+      .map(e => e.detail.direction);
+
+    expect(seed1).toBe(777);
+    expect(seed2).toBe(777);
+    expect(drops1).toEqual(drops2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Counting — onNth: 3 drops only the 3rd outbound
+// ---------------------------------------------------------------------------
+test.describe('WebSocket counting', () => {
+  test('onNth: 3 drops only the 3rd outbound message', async ({ page }) => {
+    await injectChaos(page, {
+      websocket: {
+        drops: [{ urlPattern: WS_URL_PATTERN, direction: 'outbound', probability: 1, onNth: 3 }],
+      },
+    });
+    await page.goto(BASE_URL);
+    await connect(page);
+    await send(page, 5);
+    await page.waitForFunction(() => Number(document.getElementById('ws-inbound-count')?.textContent) === 4, null, { timeout: 5000 });
+    expect(await inboundCount(page)).toBe(4);
+
+    const log = await getChaosLog(page);
+    const drops = log.filter(e => e.type === 'websocket:drop' && e.applied && e.detail.direction === 'outbound');
+    expect(drops.length).toBe(1);
+  });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,7 +24,7 @@ export default [
   },
   {
     // Plain-JS Node scripts (e.g., Playwright webServer entry points) run as CJS.
-    files: ["e2e-tests/src/*.js"],
+    files: ["e2e-tests/src/**/*.js"],
     rules: {
       "@typescript-eslint/no-require-imports": "off",
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,13 @@ export default [
     },
   },
   {
+    // Plain-JS Node scripts (e.g., Playwright webServer entry points) run as CJS.
+    files: ["e2e-tests/src/*.js"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
+  {
     // Configuration for test files
     files: ["**/*.test.ts"],
     plugins: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/core",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.1",
   "type": "module",
   "description": "A lightweight, framework-agnostic toolkit for injecting chaos into web applications to test frontend resilience",
   "keywords": [

--- a/packages/core/src/ChaosMaker.ts
+++ b/packages/core/src/ChaosMaker.ts
@@ -5,6 +5,7 @@ import { ChaosEventEmitter, ChaosEvent, ChaosEventType, ChaosEventListener } fro
 import { patchFetch } from './interceptors/networkFetch';
 import { patchXHR, patchXHROpen } from './interceptors/networkXHR';
 import { attachDomAssailant } from './interceptors/domAssailant';
+import { patchWebSocket, WebSocketPatchHandle } from './interceptors/websocket';
 
 export class ChaosMaker {
   private config: ChaosConfig;
@@ -16,7 +17,9 @@ export class ChaosMaker {
   private originalXhrSend?: (body?: Document | XMLHttpRequestBodyInit) => void;
   private originalXhrOpen?: (method: string, url: string | URL) => void;
   private domObserver?: MutationObserver;
-  /** Shared request counters keyed by config rule object reference. Shared across fetch + XHR. */
+  private originalWebSocket?: typeof WebSocket;
+  private webSocketHandle?: WebSocketPatchHandle;
+  /** Shared counters keyed by config rule object reference. Shared across fetch + XHR + WS. */
   private requestCounters: Map<object, number> = new Map();
 
   constructor(config: ChaosConfig) {
@@ -79,6 +82,18 @@ export class ChaosMaker {
       });
       console.log('UI Assailant is now observing the DOM.');
     }
+
+    if (this.config.websocket && typeof window !== 'undefined' && typeof window.WebSocket !== 'undefined') {
+      this.originalWebSocket = window.WebSocket;
+      this.webSocketHandle = patchWebSocket(
+        this.originalWebSocket,
+        this.config.websocket,
+        this.emitter,
+        this.random,
+        this.requestCounters,
+      );
+      window.WebSocket = this.webSocketHandle.Wrapped;
+    }
   }
 
   public stop(): void {
@@ -97,6 +112,14 @@ export class ChaosMaker {
     if (this.domObserver) {
       this.domObserver.disconnect();
       console.log('UI Assailant has stopped observing.');
+    }
+    if (this.originalWebSocket) {
+      window.WebSocket = this.originalWebSocket;
+      this.originalWebSocket = undefined;
+    }
+    if (this.webSocketHandle) {
+      this.webSocketHandle.uninstall();
+      this.webSocketHandle = undefined;
     }
   }
 }

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -1,4 +1,4 @@
-import { ChaosConfig, CorruptionStrategy, RequestCountingOptions } from './config';
+import { ChaosConfig, CorruptionStrategy, RequestCountingOptions, WebSocketDirection, WebSocketCorruptionStrategy } from './config';
 
 function cloneConfig(config: ChaosConfig): ChaosConfig {
   return JSON.parse(JSON.stringify(config));
@@ -8,9 +8,10 @@ export class ChaosConfigBuilder {
   private config: ChaosConfig;
 
   constructor(initialConfig?: ChaosConfig) {
-    this.config = initialConfig ? cloneConfig(initialConfig) : { network: {}, ui: {} };
+    this.config = initialConfig ? cloneConfig(initialConfig) : { network: {}, ui: {}, websocket: {} };
     if (!this.config.network) this.config.network = {};
     if (!this.config.ui) this.config.ui = {};
+    if (!this.config.websocket) this.config.websocket = {};
   }
 
   failRequests(urlPattern: string, statusCode: number, probability: number, methods?: string[], body?: string, headers?: Record<string, string>, counting?: RequestCountingOptions) {
@@ -113,6 +114,42 @@ export class ChaosConfigBuilder {
     if (!this.config.ui!.assaults) this.config.ui!.assaults = [];
     this.config.ui!.assaults.push({ selector, action, probability });
     return this;
+  }
+
+  // --- WebSocket chaos ---
+
+  dropMessages(urlPattern: string, direction: WebSocketDirection, probability: number, counting?: RequestCountingOptions) {
+    if (!this.config.websocket!.drops) this.config.websocket!.drops = [];
+    this.config.websocket!.drops.push({ urlPattern, direction, probability, ...counting });
+    return this;
+  }
+
+  delayMessages(urlPattern: string, direction: WebSocketDirection, delayMs: number, probability: number, counting?: RequestCountingOptions) {
+    if (!this.config.websocket!.delays) this.config.websocket!.delays = [];
+    this.config.websocket!.delays.push({ urlPattern, direction, delayMs, probability, ...counting });
+    return this;
+  }
+
+  corruptMessages(urlPattern: string, direction: WebSocketDirection, strategy: WebSocketCorruptionStrategy, probability: number, counting?: RequestCountingOptions) {
+    if (!this.config.websocket!.corruptions) this.config.websocket!.corruptions = [];
+    this.config.websocket!.corruptions.push({ urlPattern, direction, strategy, probability, ...counting });
+    return this;
+  }
+
+  closeConnection(urlPattern: string, probability: number, opts?: { code?: number; reason?: string; afterMs?: number }, counting?: RequestCountingOptions) {
+    if (!this.config.websocket!.closes) this.config.websocket!.closes = [];
+    this.config.websocket!.closes.push({ urlPattern, probability, ...opts, ...counting });
+    return this;
+  }
+
+  // Counting shortcuts (only the two highest-value ones — see plan §8).
+
+  dropMessagesOnNth(urlPattern: string, direction: WebSocketDirection, n: number) {
+    return this.dropMessages(urlPattern, direction, 1, { onNth: n });
+  }
+
+  delayMessagesOnNth(urlPattern: string, direction: WebSocketDirection, delayMs: number, n: number) {
+    return this.delayMessages(urlPattern, direction, delayMs, 1, { onNth: n });
   }
 
   /** Set the PRNG seed for reproducible chaos. */

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -69,9 +69,63 @@ export interface UiConfig {
   assaults?: UiAssaultConfig[];
 }
 
+/** Direction of a WebSocket message relative to the client.
+ *  - `outbound` = client → server (intercepted at `.send()`).
+ *  - `inbound`  = server → client (intercepted at `message` event dispatch).
+ *  - `both`     = apply independently in either direction.
+ */
+export type WebSocketDirection = 'inbound' | 'outbound' | 'both';
+
+export interface WebSocketDropConfig extends RequestCountingOptions {
+  urlPattern: string;
+  direction: WebSocketDirection;
+  probability: number;
+}
+
+export interface WebSocketDelayConfig extends RequestCountingOptions {
+  urlPattern: string;
+  direction: WebSocketDirection;
+  delayMs: number;
+  probability: number;
+}
+
+/** Strategies for corrupting WebSocket payloads.
+ *  `truncate` and `empty` apply to both text and binary payloads.
+ *  `malformed-json` and `wrong-type` apply to text payloads only; when the
+ *  actual payload at runtime is binary, corruption is skipped and an event is
+ *  emitted with `applied: false`.
+ */
+export type WebSocketCorruptionStrategy = 'truncate' | 'malformed-json' | 'empty' | 'wrong-type';
+
+export interface WebSocketCorruptConfig extends RequestCountingOptions {
+  urlPattern: string;
+  direction: WebSocketDirection;
+  strategy: WebSocketCorruptionStrategy;
+  probability: number;
+}
+
+export interface WebSocketCloseConfig extends RequestCountingOptions {
+  urlPattern: string;
+  /** WebSocket close code (default 1006 — abnormal closure). */
+  code?: number;
+  /** WebSocket close reason string (default "Chaos Maker close"). */
+  reason?: string;
+  /** Delay after `open` before closing, in ms. Default 0 = close immediately. */
+  afterMs?: number;
+  probability: number;
+}
+
+export interface WebSocketConfig {
+  drops?: WebSocketDropConfig[];
+  delays?: WebSocketDelayConfig[];
+  corruptions?: WebSocketCorruptConfig[];
+  closes?: WebSocketCloseConfig[];
+}
+
 export interface ChaosConfig {
   network?: NetworkConfig;
   ui?: UiConfig;
+  websocket?: WebSocketConfig;
   /** Seed for the PRNG. When provided, all probability rolls become deterministic and replayable. */
   seed?: number;
 }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -106,9 +106,17 @@ export interface WebSocketCorruptConfig extends RequestCountingOptions {
 
 export interface WebSocketCloseConfig extends RequestCountingOptions {
   urlPattern: string;
-  /** WebSocket close code (default 1006 — abnormal closure). */
+  /**
+   * WebSocket close code. Must be either `1000` (Normal Closure) or in the
+   * `3000–4999` range per the WebSocket spec; other values are rejected by
+   * the browser's `close()` call. Defaults to `1000`. Use `4000–4999` for
+   * application-defined chaos codes.
+   */
   code?: number;
-  /** WebSocket close reason string (default "Chaos Maker close"). */
+  /**
+   * WebSocket close reason string. Must encode to <= 123 UTF-8 bytes per the
+   * spec. Defaults to `"Chaos Maker close"`.
+   */
   reason?: string;
   /** Delay after `open` before closing, in ms. Default 0 = close immediately. */
   afterMs?: number;

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,4 +1,14 @@
-export type ChaosEventType = 'network:failure' | 'network:latency' | 'network:abort' | 'network:corruption' | 'network:cors' | 'ui:assault';
+export type ChaosEventType =
+  | 'network:failure'
+  | 'network:latency'
+  | 'network:abort'
+  | 'network:corruption'
+  | 'network:cors'
+  | 'ui:assault'
+  | 'websocket:drop'
+  | 'websocket:delay'
+  | 'websocket:corrupt'
+  | 'websocket:close';
 
 export interface ChaosEvent {
   type: ChaosEventType;
@@ -13,6 +23,16 @@ export interface ChaosEvent {
     strategy?: string;
     selector?: string;
     action?: string;
+    /** WebSocket message direction (for `websocket:*` events). */
+    direction?: 'inbound' | 'outbound';
+    /** WebSocket payload kind (for `websocket:*` events). */
+    payloadType?: 'text' | 'binary';
+    /** WebSocket close code (for `websocket:close` events). */
+    closeCode?: number;
+    /** WebSocket close reason (for `websocket:close` events). */
+    closeReason?: string;
+    /** Reason string for diagnostic `applied: false` events. */
+    reason?: string;
   };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 import { ChaosMaker } from './ChaosMaker';
-import { ChaosConfig, CorruptionStrategy, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig } from './config';
+import { ChaosConfig, CorruptionStrategy, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig, WebSocketConfig, WebSocketDropConfig, WebSocketDelayConfig, WebSocketCorruptConfig, WebSocketCloseConfig, WebSocketDirection, WebSocketCorruptionStrategy } from './config';
 import { ChaosConfigError } from './errors';
 import { validateConfig } from './validation';
 import { ChaosEvent, ChaosEventType, ChaosEventListener, ChaosEventEmitter } from './events';
@@ -8,7 +8,7 @@ import { presets } from './presets';
 import { createPrng, generateSeed } from './prng';
 
 export { ChaosMaker, ChaosConfigError, validateConfig, ChaosEventEmitter, ChaosConfigBuilder, presets, createPrng, generateSeed };
-export type { ChaosConfig, CorruptionStrategy, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig, ChaosEvent, ChaosEventType, ChaosEventListener };
+export type { ChaosConfig, CorruptionStrategy, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig, WebSocketConfig, WebSocketDropConfig, WebSocketDelayConfig, WebSocketCorruptConfig, WebSocketCloseConfig, WebSocketDirection, WebSocketCorruptionStrategy, ChaosEvent, ChaosEventType, ChaosEventListener };
 
 // --- NEW INTERFACE ---
 interface ChaosUtilsApi {

--- a/packages/core/src/interceptors/websocket.ts
+++ b/packages/core/src/interceptors/websocket.ts
@@ -10,8 +10,11 @@
  *   A dropped message short-circuits the remaining primitives.
  * - Counting for drop/delay/corrupt is per-rule, per-message. Counting for
  *   close is per-rule, per-connection.
- * - On `stop()`, all pending-delay timers are cleared and a `websocket:drop`
- *   event is emitted for each with `detail.reason: 'stop-during-delay'`.
+ * - On `stop()`, the interceptor flips a `running` flag and cancels every
+ *   pending timer. Any already-wrapped socket is disarmed in place so its
+ *   patched `.send` and inbound listener become no-ops; pending delay timers
+ *   emit `websocket:drop` with `detail.reason: 'stop-during-delay'`; pending
+ *   close timers silently cancel (they never fired a close event).
  * - Close chaos clears pending-delay timers for the socket before closing.
  * - Binary corruption runs `truncate` / `empty` natively; `malformed-json` and
  *   `wrong-type` emit `applied: false` with `reason: 'incompatible-payload-type'`.
@@ -34,12 +37,20 @@ type PayloadType = 'text' | 'binary';
 
 const INTERCEPT_MARKER = Symbol.for('chaos-maker.websocket.intercepted');
 
-interface PendingTimer {
+interface PendingDelayTimer {
+  kind: 'delay';
   handle: ReturnType<typeof setTimeout>;
   url: string;
   direction: Direction;
   payloadType: PayloadType;
 }
+
+interface PendingCloseTimer {
+  kind: 'close';
+  handle: ReturnType<typeof setTimeout>;
+}
+
+type PendingTimer = PendingDelayTimer | PendingCloseTimer;
 
 export interface WebSocketPatchHandle {
   /** Wrapped WebSocket constructor suitable for `window.WebSocket = …`. */
@@ -89,7 +100,9 @@ function corruptBinaryPayload(
   }
   const view = data as ArrayBufferView;
   const end = Math.max(0, Math.floor(view.byteLength / 2));
-  return new Uint8Array(view.buffer, view.byteOffset, end);
+  // Copy (not alias) to match the ArrayBuffer branch above and avoid leaking
+  // mutations to/from the caller's underlying buffer.
+  return new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + end));
 }
 
 function findFiringRule<T extends RequestCountingOptions & { urlPattern: string; direction: WebSocketDirection; probability: number }>(
@@ -180,6 +193,9 @@ export function patchWebSocket(
   counters: Map<object, number>,
 ): WebSocketPatchHandle {
   const pendingTimersBySocket = new Map<WebSocket, Set<PendingTimer>>();
+  // Set to false in uninstall() so that already-wrapped sockets stop applying
+  // chaos on any subsequent message / scheduled close after ChaosMaker.stop().
+  let running = true;
 
   const trackTimer = (socket: WebSocket, timer: PendingTimer): void => {
     let set = pendingTimersBySocket.get(socket);
@@ -199,7 +215,11 @@ export function patchWebSocket(
     if (!set) return;
     for (const timer of set) {
       clearTimeout(timer.handle);
-      emitDrop(emitter, timer.url, timer.direction, timer.payloadType, reason);
+      // Only pending delays were observable as a "message in flight"; close
+      // timers haven't emitted anything yet, so cancelling them is silent.
+      if (timer.kind === 'delay') {
+        emitDrop(emitter, timer.url, timer.direction, timer.payloadType, reason);
+      }
     }
     pendingTimersBySocket.delete(socket);
   };
@@ -222,6 +242,10 @@ export function patchWebSocket(
     data: string | ArrayBuffer | ArrayBufferView | Blob,
     originalSend: (d: string | ArrayBuffer | ArrayBufferView | Blob) => void,
   ): { handled: boolean; data: string | ArrayBuffer | ArrayBufferView | Blob } => {
+    // After stop(), leave existing sockets alone — pass the payload through
+    // untouched so the real socket still behaves normally.
+    if (!running) return { handled: false, data };
+
     const direction: Direction = 'outbound';
     const payloadType = getPayloadType(data);
 
@@ -250,7 +274,8 @@ export function patchWebSocket(
     const delayRule = findFiringRule<WebSocketDelayConfig>(config.delays, url, direction, random, counters);
     if (delayRule) {
       emitDelay(emitter, url, direction, payloadType, delayRule.delayMs);
-      const timer: PendingTimer = {
+      const timer: PendingDelayTimer = {
+        kind: 'delay',
         handle: setTimeout(() => {
           untrackTimer(socket, timer);
           try {
@@ -272,6 +297,8 @@ export function patchWebSocket(
     socket.addEventListener('message', (evt: Event) => {
       const msgEvt = evt as MessageEvent;
       if ((msgEvt as unknown as Record<symbol, unknown>)[INTERCEPT_MARKER]) return;
+      // After stop(), let the event through untouched to app listeners.
+      if (!running) return;
 
       const direction: Direction = 'inbound';
       const payloadType = getPayloadType(msgEvt.data);
@@ -306,7 +333,8 @@ export function patchWebSocket(
       if (delayRule) {
         msgEvt.stopImmediatePropagation();
         emitDelay(emitter, url, direction, payloadType, delayRule.delayMs);
-        const timer: PendingTimer = {
+        const timer: PendingDelayTimer = {
+          kind: 'delay',
           handle: setTimeout(() => {
             untrackTimer(socket, timer);
             redispatch(socket, msgEvt, payload);
@@ -331,11 +359,18 @@ export function patchWebSocket(
       const count = incrementCounter(rule, counters);
       if (!checkCountingCondition(rule, count)) continue;
       if (!shouldApplyChaos(rule.probability, random)) continue;
-      const code = rule.code ?? 1006;
+      // Default to 1000 (Normal Closure) — the only 1xxx code browsers accept
+      // as input to `socket.close(code)`. Reserved codes like 1006 throw
+      // InvalidAccessError. Apps wanting a chaos-specific code should pass
+      // something in the 4000–4999 range (e.g., `code: 4000`).
+      const code = rule.code ?? 1000;
       const reason = rule.reason ?? 'Chaos Maker close';
       const afterMs = rule.afterMs ?? 0;
 
       const fire = () => {
+        // If stop() ran between scheduling and firing, abandon the close so
+        // the app socket survives intact.
+        if (!running) return;
         clearSocketTimers(socket, 'close-interrupt');
         emitClose(emitter, url, code, reason);
         try {
@@ -353,9 +388,9 @@ export function patchWebSocket(
         }
       } else {
         const scheduleDeferred = () => {
-          const timer: PendingTimer = {
+          const timer: PendingCloseTimer = {
+            kind: 'close',
             handle: setTimeout(fire, afterMs),
-            url, direction: 'outbound', payloadType: 'text',
           };
           trackTimer(socket, timer);
         };
@@ -400,10 +435,17 @@ export function patchWebSocket(
   return {
     Wrapped: ChaosWebSocket as unknown as typeof WebSocket,
     uninstall(): void {
+      // Disarm interception on every already-wrapped socket *before* clearing
+      // timers so any listeners/fire callbacks that run during teardown also
+      // bail out. Without this, existing sockets would keep applying chaos
+      // indefinitely after ChaosMaker.stop().
+      running = false;
       for (const [, timers] of pendingTimersBySocket) {
         for (const timer of timers) {
           clearTimeout(timer.handle);
-          emitDrop(emitter, timer.url, timer.direction, timer.payloadType, 'stop-during-delay');
+          if (timer.kind === 'delay') {
+            emitDrop(emitter, timer.url, timer.direction, timer.payloadType, 'stop-during-delay');
+          }
         }
       }
       pendingTimersBySocket.clear();

--- a/packages/core/src/interceptors/websocket.ts
+++ b/packages/core/src/interceptors/websocket.ts
@@ -1,0 +1,412 @@
+/**
+ * WebSocket chaos interceptor.
+ *
+ * Design decisions (see V2_PHASE3_WEBSOCKET_PLAN.md §4, §9):
+ * - Patch `window.WebSocket` with a wrapper constructor. Real socket is returned
+ *   so `instanceof WebSocket` continues to work. `.send` is overridden on the
+ *   instance; inbound messages are intercepted via a listener installed *before*
+ *   user code runs.
+ * - Ordering of primitives on a matched message: drop → corrupt → delay.
+ *   A dropped message short-circuits the remaining primitives.
+ * - Counting for drop/delay/corrupt is per-rule, per-message. Counting for
+ *   close is per-rule, per-connection.
+ * - On `stop()`, all pending-delay timers are cleared and a `websocket:drop`
+ *   event is emitted for each with `detail.reason: 'stop-during-delay'`.
+ * - Close chaos clears pending-delay timers for the socket before closing.
+ * - Binary corruption runs `truncate` / `empty` natively; `malformed-json` and
+ *   `wrong-type` emit `applied: false` with `reason: 'incompatible-payload-type'`.
+ */
+
+import {
+  WebSocketConfig,
+  WebSocketDropConfig,
+  WebSocketDelayConfig,
+  WebSocketCorruptConfig,
+  WebSocketDirection,
+  WebSocketCorruptionStrategy,
+  RequestCountingOptions,
+} from '../config';
+import { ChaosEventEmitter } from '../events';
+import { shouldApplyChaos, matchUrl, incrementCounter, checkCountingCondition } from '../utils';
+
+type Direction = 'inbound' | 'outbound';
+type PayloadType = 'text' | 'binary';
+
+const INTERCEPT_MARKER = Symbol.for('chaos-maker.websocket.intercepted');
+
+interface PendingTimer {
+  handle: ReturnType<typeof setTimeout>;
+  url: string;
+  direction: Direction;
+  payloadType: PayloadType;
+}
+
+export interface WebSocketPatchHandle {
+  /** Wrapped WebSocket constructor suitable for `window.WebSocket = …`. */
+  readonly Wrapped: typeof WebSocket;
+  /** Clear all pending delay timers and emit drop events for them. Call on ChaosMaker.stop(). */
+  uninstall(): void;
+}
+
+function directionApplies(configDir: WebSocketDirection, actual: Direction): boolean {
+  if (configDir === 'both') return true;
+  return configDir === actual;
+}
+
+function getPayloadType(data: unknown): PayloadType {
+  return typeof data === 'string' ? 'text' : 'binary';
+}
+
+function corruptTextPayload(text: string, strategy: WebSocketCorruptionStrategy): string {
+  switch (strategy) {
+    case 'truncate':
+      return text.slice(0, Math.max(0, Math.floor(text.length / 2)));
+    case 'malformed-json':
+      return `${text}"}`;
+    case 'empty':
+      return '';
+    case 'wrong-type':
+      return '<html><body>Unexpected HTML</body></html>';
+  }
+}
+
+function corruptBinaryPayload(
+  data: ArrayBuffer | ArrayBufferView | Blob,
+  strategy: WebSocketCorruptionStrategy,
+): ArrayBuffer | ArrayBufferView | Blob | null {
+  if (strategy === 'malformed-json' || strategy === 'wrong-type') return null;
+  if (strategy === 'empty') {
+    if (typeof Blob !== 'undefined' && data instanceof Blob) return new Blob([]);
+    if (data instanceof ArrayBuffer) return new ArrayBuffer(0);
+    return new Uint8Array(0);
+  }
+  // truncate
+  if (typeof Blob !== 'undefined' && data instanceof Blob) {
+    return data.slice(0, Math.max(0, Math.floor(data.size / 2)));
+  }
+  if (data instanceof ArrayBuffer) {
+    return data.slice(0, Math.max(0, Math.floor(data.byteLength / 2)));
+  }
+  const view = data as ArrayBufferView;
+  const end = Math.max(0, Math.floor(view.byteLength / 2));
+  return new Uint8Array(view.buffer, view.byteOffset, end);
+}
+
+function findFiringRule<T extends RequestCountingOptions & { urlPattern: string; direction: WebSocketDirection; probability: number }>(
+  rules: T[] | undefined,
+  url: string,
+  direction: Direction,
+  random: () => number,
+  counters: Map<object, number>,
+): T | null {
+  if (!rules) return null;
+  for (const rule of rules) {
+    if (!matchUrl(url, rule.urlPattern)) continue;
+    if (!directionApplies(rule.direction, direction)) continue;
+    const count = incrementCounter(rule, counters);
+    if (!checkCountingCondition(rule, count)) continue;
+    if (!shouldApplyChaos(rule.probability, random)) continue;
+    return rule;
+  }
+  return null;
+}
+
+function emitDrop(
+  emitter: ChaosEventEmitter,
+  url: string,
+  direction: Direction,
+  payloadType: PayloadType,
+  reason?: string,
+): void {
+  emitter.emit({
+    type: 'websocket:drop',
+    timestamp: Date.now(),
+    applied: true,
+    detail: { url, direction, payloadType, ...(reason ? { reason } : {}) },
+  });
+}
+
+function emitDelay(
+  emitter: ChaosEventEmitter,
+  url: string,
+  direction: Direction,
+  payloadType: PayloadType,
+  delayMs: number,
+): void {
+  emitter.emit({
+    type: 'websocket:delay',
+    timestamp: Date.now(),
+    applied: true,
+    detail: { url, direction, payloadType, delayMs },
+  });
+}
+
+function emitCorrupt(
+  emitter: ChaosEventEmitter,
+  url: string,
+  direction: Direction,
+  payloadType: PayloadType,
+  strategy: string,
+  applied: boolean,
+  reason?: string,
+): void {
+  emitter.emit({
+    type: 'websocket:corrupt',
+    timestamp: Date.now(),
+    applied,
+    detail: { url, direction, payloadType, strategy, ...(reason ? { reason } : {}) },
+  });
+}
+
+function emitClose(
+  emitter: ChaosEventEmitter,
+  url: string,
+  code: number,
+  reason: string,
+): void {
+  emitter.emit({
+    type: 'websocket:close',
+    timestamp: Date.now(),
+    applied: true,
+    detail: { url, closeCode: code, closeReason: reason },
+  });
+}
+
+export function patchWebSocket(
+  OriginalWebSocket: typeof WebSocket,
+  config: WebSocketConfig,
+  emitter: ChaosEventEmitter,
+  random: () => number,
+  counters: Map<object, number>,
+): WebSocketPatchHandle {
+  const pendingTimersBySocket = new Map<WebSocket, Set<PendingTimer>>();
+
+  const trackTimer = (socket: WebSocket, timer: PendingTimer): void => {
+    let set = pendingTimersBySocket.get(socket);
+    if (!set) {
+      set = new Set();
+      pendingTimersBySocket.set(socket, set);
+    }
+    set.add(timer);
+  };
+
+  const untrackTimer = (socket: WebSocket, timer: PendingTimer): void => {
+    pendingTimersBySocket.get(socket)?.delete(timer);
+  };
+
+  const clearSocketTimers = (socket: WebSocket, reason: string): void => {
+    const set = pendingTimersBySocket.get(socket);
+    if (!set) return;
+    for (const timer of set) {
+      clearTimeout(timer.handle);
+      emitDrop(emitter, timer.url, timer.direction, timer.payloadType, reason);
+    }
+    pendingTimersBySocket.delete(socket);
+  };
+
+  const redispatch = (socket: WebSocket, original: MessageEvent, data: unknown): void => {
+    const newEvent = new MessageEvent('message', {
+      data,
+      origin: original.origin,
+      lastEventId: original.lastEventId,
+      source: original.source,
+      ports: Array.from(original.ports ?? []),
+    });
+    (newEvent as unknown as Record<symbol, unknown>)[INTERCEPT_MARKER] = true;
+    socket.dispatchEvent(newEvent);
+  };
+
+  const handleOutbound = (
+    socket: WebSocket,
+    url: string,
+    data: string | ArrayBuffer | ArrayBufferView | Blob,
+    originalSend: (d: string | ArrayBuffer | ArrayBufferView | Blob) => void,
+  ): { handled: boolean; data: string | ArrayBuffer | ArrayBufferView | Blob } => {
+    const direction: Direction = 'outbound';
+    const payloadType = getPayloadType(data);
+
+    if (findFiringRule<WebSocketDropConfig>(config.drops, url, direction, random, counters)) {
+      emitDrop(emitter, url, direction, payloadType);
+      return { handled: true, data };
+    }
+
+    let payload = data;
+    const corruptRule = findFiringRule<WebSocketCorruptConfig>(config.corruptions, url, direction, random, counters);
+    if (corruptRule) {
+      if (payloadType === 'text') {
+        payload = corruptTextPayload(payload as string, corruptRule.strategy);
+        emitCorrupt(emitter, url, direction, payloadType, corruptRule.strategy, true);
+      } else {
+        const corrupted = corruptBinaryPayload(payload as ArrayBuffer | ArrayBufferView | Blob, corruptRule.strategy);
+        if (corrupted === null) {
+          emitCorrupt(emitter, url, direction, payloadType, corruptRule.strategy, false, 'incompatible-payload-type');
+        } else {
+          payload = corrupted;
+          emitCorrupt(emitter, url, direction, payloadType, corruptRule.strategy, true);
+        }
+      }
+    }
+
+    const delayRule = findFiringRule<WebSocketDelayConfig>(config.delays, url, direction, random, counters);
+    if (delayRule) {
+      emitDelay(emitter, url, direction, payloadType, delayRule.delayMs);
+      const timer: PendingTimer = {
+        handle: setTimeout(() => {
+          untrackTimer(socket, timer);
+          try {
+            originalSend(payload);
+          } catch {
+            // socket may have closed; matches real lost-message semantics
+          }
+        }, delayRule.delayMs),
+        url, direction, payloadType,
+      };
+      trackTimer(socket, timer);
+      return { handled: true, data: payload };
+    }
+
+    return { handled: false, data: payload };
+  };
+
+  const attachInboundListener = (socket: WebSocket, url: string): void => {
+    socket.addEventListener('message', (evt: Event) => {
+      const msgEvt = evt as MessageEvent;
+      if ((msgEvt as unknown as Record<symbol, unknown>)[INTERCEPT_MARKER]) return;
+
+      const direction: Direction = 'inbound';
+      const payloadType = getPayloadType(msgEvt.data);
+
+      if (findFiringRule<WebSocketDropConfig>(config.drops, url, direction, random, counters)) {
+        msgEvt.stopImmediatePropagation();
+        emitDrop(emitter, url, direction, payloadType);
+        return;
+      }
+
+      let payload: unknown = msgEvt.data;
+      let wasCorrupted = false;
+      const corruptRule = findFiringRule<WebSocketCorruptConfig>(config.corruptions, url, direction, random, counters);
+      if (corruptRule) {
+        if (payloadType === 'text') {
+          payload = corruptTextPayload(payload as string, corruptRule.strategy);
+          wasCorrupted = true;
+          emitCorrupt(emitter, url, direction, payloadType, corruptRule.strategy, true);
+        } else {
+          const corrupted = corruptBinaryPayload(payload as ArrayBuffer | ArrayBufferView | Blob, corruptRule.strategy);
+          if (corrupted === null) {
+            emitCorrupt(emitter, url, direction, payloadType, corruptRule.strategy, false, 'incompatible-payload-type');
+          } else {
+            payload = corrupted;
+            wasCorrupted = true;
+            emitCorrupt(emitter, url, direction, payloadType, corruptRule.strategy, true);
+          }
+        }
+      }
+
+      const delayRule = findFiringRule<WebSocketDelayConfig>(config.delays, url, direction, random, counters);
+      if (delayRule) {
+        msgEvt.stopImmediatePropagation();
+        emitDelay(emitter, url, direction, payloadType, delayRule.delayMs);
+        const timer: PendingTimer = {
+          handle: setTimeout(() => {
+            untrackTimer(socket, timer);
+            redispatch(socket, msgEvt, payload);
+          }, delayRule.delayMs),
+          url, direction, payloadType,
+        };
+        trackTimer(socket, timer);
+        return;
+      }
+
+      if (wasCorrupted) {
+        msgEvt.stopImmediatePropagation();
+        redispatch(socket, msgEvt, payload);
+      }
+    });
+  };
+
+  const scheduleCloseChaos = (socket: WebSocket, url: string): void => {
+    if (!config.closes) return;
+    for (const rule of config.closes) {
+      if (!matchUrl(url, rule.urlPattern)) continue;
+      const count = incrementCounter(rule, counters);
+      if (!checkCountingCondition(rule, count)) continue;
+      if (!shouldApplyChaos(rule.probability, random)) continue;
+      const code = rule.code ?? 1006;
+      const reason = rule.reason ?? 'Chaos Maker close';
+      const afterMs = rule.afterMs ?? 0;
+
+      const fire = () => {
+        clearSocketTimers(socket, 'close-interrupt');
+        emitClose(emitter, url, code, reason);
+        try {
+          socket.close(code, reason);
+        } catch {
+          try { socket.close(); } catch { /* already closing */ }
+        }
+      };
+
+      if (afterMs <= 0) {
+        if (socket.readyState === socket.OPEN) {
+          fire();
+        } else {
+          socket.addEventListener('open', fire, { once: true });
+        }
+      } else {
+        const scheduleDeferred = () => {
+          const timer: PendingTimer = {
+            handle: setTimeout(fire, afterMs),
+            url, direction: 'outbound', payloadType: 'text',
+          };
+          trackTimer(socket, timer);
+        };
+        if (socket.readyState === socket.OPEN) {
+          scheduleDeferred();
+        } else {
+          socket.addEventListener('open', scheduleDeferred, { once: true });
+        }
+      }
+      return; // one close rule per socket
+    }
+  };
+
+  function ChaosWebSocket(this: unknown, url: string | URL, protocols?: string | string[]): WebSocket {
+    const socket = new OriginalWebSocket(url, protocols);
+    const urlStr = typeof url === 'string' ? url : url.toString();
+
+    const boundOriginalSend = socket.send.bind(socket) as (
+      d: string | ArrayBuffer | ArrayBufferView | Blob,
+    ) => void;
+    socket.send = function patchedSend(data: string | ArrayBuffer | ArrayBufferView | Blob): void {
+      const result = handleOutbound(socket, urlStr, data, boundOriginalSend);
+      if (!result.handled) boundOriginalSend(result.data);
+    };
+
+    attachInboundListener(socket, urlStr);
+    scheduleCloseChaos(socket, urlStr);
+
+    return socket;
+  }
+
+  // `instanceof` compatibility + static constants.
+  Object.defineProperty(ChaosWebSocket, 'prototype', {
+    value: OriginalWebSocket.prototype,
+    writable: false,
+  });
+  for (const key of ['CONNECTING', 'OPEN', 'CLOSING', 'CLOSED'] as const) {
+    (ChaosWebSocket as unknown as Record<string, unknown>)[key] =
+      (OriginalWebSocket as unknown as Record<string, unknown>)[key];
+  }
+
+  return {
+    Wrapped: ChaosWebSocket as unknown as typeof WebSocket,
+    uninstall(): void {
+      for (const [, timers] of pendingTimersBySocket) {
+        for (const timer of timers) {
+          clearTimeout(timer.handle);
+          emitDrop(emitter, timer.url, timer.direction, timer.payloadType, 'stop-during-delay');
+        }
+      }
+      pendingTimersBySocket.clear();
+    },
+  };
+}

--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -43,4 +43,11 @@ export const presets: Readonly<Record<string, ChaosConfig>> = deepFreeze({
       ],
     },
   },
+  unreliableWebSocket: {
+    websocket: {
+      drops: [{ urlPattern: MATCH_ALL_URLS, direction: 'both', probability: 0.1 }],
+      delays: [{ urlPattern: MATCH_ALL_URLS, direction: 'inbound', delayMs: 500, probability: 1.0 }],
+      corruptions: [{ urlPattern: MATCH_ALL_URLS, direction: 'inbound', strategy: 'truncate', probability: 0.05 }],
+    },
+  },
 });

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -81,9 +81,51 @@ const uiConfigSchema = z.object({
   assaults: z.array(uiAssaultSchema).optional(),
 }).strict();
 
+const webSocketDirection = z.enum(['inbound', 'outbound', 'both']);
+
+const webSocketDropSchema = z.object({
+  urlPattern: z.string().min(1, 'urlPattern must not be empty'),
+  direction: webSocketDirection,
+  probability,
+  ...countingFields,
+}).strict().refine(...countingRefinement);
+
+const webSocketDelaySchema = z.object({
+  urlPattern: z.string().min(1, 'urlPattern must not be empty'),
+  direction: webSocketDirection,
+  delayMs: z.number().min(0, 'delayMs must be >= 0'),
+  probability,
+  ...countingFields,
+}).strict().refine(...countingRefinement);
+
+const webSocketCorruptSchema = z.object({
+  urlPattern: z.string().min(1, 'urlPattern must not be empty'),
+  direction: webSocketDirection,
+  strategy: z.enum(['truncate', 'malformed-json', 'empty', 'wrong-type']),
+  probability,
+  ...countingFields,
+}).strict().refine(...countingRefinement);
+
+const webSocketCloseSchema = z.object({
+  urlPattern: z.string().min(1, 'urlPattern must not be empty'),
+  code: z.number().int().optional(),
+  reason: z.string().optional(),
+  afterMs: z.number().min(0, 'afterMs must be >= 0').optional(),
+  probability,
+  ...countingFields,
+}).strict().refine(...countingRefinement);
+
+const webSocketConfigSchema = z.object({
+  drops: z.array(webSocketDropSchema).optional(),
+  delays: z.array(webSocketDelaySchema).optional(),
+  corruptions: z.array(webSocketCorruptSchema).optional(),
+  closes: z.array(webSocketCloseSchema).optional(),
+}).strict();
+
 const chaosConfigSchema = z.object({
   network: networkConfigSchema.optional(),
   ui: uiConfigSchema.optional(),
+  websocket: webSocketConfigSchema.optional(),
   seed: z.number().int('Seed must be an integer').optional(),
 }).strict();
 

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -106,10 +106,25 @@ const webSocketCorruptSchema = z.object({
   ...countingFields,
 }).strict().refine(...countingRefinement);
 
+// WebSocket close code spec: only 1000 or the 3000–4999 range are valid as input
+// to `WebSocket.close(code, reason)`. Codes 1001–1015 are reserved for the
+// browser/protocol; passing them throws `InvalidAccessError` at runtime.
+const webSocketCloseCode = z.number().int().refine(
+  (code) => code === 1000 || (code >= 3000 && code <= 4999),
+  { message: 'code must be 1000 or in the range 3000-4999' },
+);
+
+// WebSocket close reason: the UTF-8 encoded string must be <= 123 bytes.
+// Control frame payload is 125 bytes; 2 are reserved for the code.
+const webSocketCloseReason = z.string().refine(
+  (reason) => new TextEncoder().encode(reason).length <= 123,
+  { message: 'reason must be <= 123 UTF-8 bytes' },
+);
+
 const webSocketCloseSchema = z.object({
   urlPattern: z.string().min(1, 'urlPattern must not be empty'),
-  code: z.number().int().optional(),
-  reason: z.string().optional(),
+  code: webSocketCloseCode.optional(),
+  reason: webSocketCloseReason.optional(),
   afterMs: z.number().min(0, 'afterMs must be >= 0').optional(),
   probability,
   ...countingFields,

--- a/packages/core/test/builder-presets.test.ts
+++ b/packages/core/test/builder-presets.test.ts
@@ -118,6 +118,49 @@ describe('ChaosConfigBuilder', () => {
     expect(firstConfig.network?.aborts).toBeUndefined();
     expect(firstConfig.network?.corruptions).toBeUndefined();
   });
+
+  it('should add websocket drop rules', () => {
+    const config = new ChaosConfigBuilder()
+      .dropMessages('/ws', 'inbound', 0.5)
+      .build();
+    expect(config.websocket?.drops).toEqual([
+      { urlPattern: '/ws', direction: 'inbound', probability: 0.5 },
+    ]);
+  });
+
+  it('should add websocket delay rules with counting', () => {
+    const config = new ChaosConfigBuilder()
+      .delayMessages('/ws', 'outbound', 100, 1.0, { everyNth: 3 })
+      .build();
+    expect(config.websocket?.delays?.[0]).toMatchObject({
+      urlPattern: '/ws', direction: 'outbound', delayMs: 100, probability: 1, everyNth: 3,
+    });
+  });
+
+  it('should add websocket corrupt rules', () => {
+    const config = new ChaosConfigBuilder()
+      .corruptMessages('/ws', 'both', 'truncate', 0.2)
+      .build();
+    expect(config.websocket?.corruptions?.[0].strategy).toBe('truncate');
+  });
+
+  it('should add websocket close rules with code and reason', () => {
+    const config = new ChaosConfigBuilder()
+      .closeConnection('/ws', 1.0, { code: 4001, reason: 'kick', afterMs: 1000 })
+      .build();
+    expect(config.websocket?.closes?.[0]).toMatchObject({
+      urlPattern: '/ws', probability: 1, code: 4001, reason: 'kick', afterMs: 1000,
+    });
+  });
+
+  it('dropMessagesOnNth and delayMessagesOnNth set onNth', () => {
+    const config = new ChaosConfigBuilder()
+      .dropMessagesOnNth('/ws', 'outbound', 3)
+      .delayMessagesOnNth('/ws', 'inbound', 200, 2)
+      .build();
+    expect(config.websocket?.drops?.[0]).toMatchObject({ onNth: 3, probability: 1 });
+    expect(config.websocket?.delays?.[0]).toMatchObject({ onNth: 2, probability: 1 });
+  });
 });
 
 describe('Presets', () => {
@@ -127,6 +170,14 @@ describe('Presets', () => {
     expect(presets.offlineMode).toBeDefined();
     expect(presets.flakyConnection).toBeDefined();
     expect(presets.degradedUi).toBeDefined();
+    expect(presets.unreliableWebSocket).toBeDefined();
+  });
+
+  it('unreliableWebSocket has drop/delay/corrupt rules', () => {
+    const cfg = presets.unreliableWebSocket;
+    expect(cfg.websocket?.drops?.length).toBeGreaterThan(0);
+    expect(cfg.websocket?.delays?.length).toBeGreaterThan(0);
+    expect(cfg.websocket?.corruptions?.length).toBeGreaterThan(0);
   });
 
   it('unstableApi should have failures and latencies', () => {

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -346,5 +346,51 @@ describe('validateConfig', () => {
       };
       expect(() => validateConfig(config)).toThrow(ChaosConfigError);
     });
+
+    it('accepts close code 1000', () => {
+      const config = {
+        websocket: { closes: [{ urlPattern: '/ws', probability: 1, code: 1000 }] },
+      };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('accepts close code in 3000-4999 range', () => {
+      const config = {
+        websocket: { closes: [{ urlPattern: '/ws', probability: 1, code: 4999 }] },
+      };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('rejects reserved close code 1006', () => {
+      // 1006 (Abnormal Closure) is reserved for the browser/protocol and is
+      // not a valid input to WebSocket.close(code).
+      const config = {
+        websocket: { closes: [{ urlPattern: '/ws', probability: 1, code: 1006 }] },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects close code outside 1000 | 3000-4999', () => {
+      const config = {
+        websocket: { closes: [{ urlPattern: '/ws', probability: 1, code: 2000 }] },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects close reason whose UTF-8 encoding exceeds 123 bytes', () => {
+      // 124 × 'a' encodes to 124 bytes — just over the spec limit.
+      const config = {
+        websocket: { closes: [{ urlPattern: '/ws', probability: 1, reason: 'a'.repeat(124) }] },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects close reason whose UTF-8 encoding exceeds 123 bytes for multi-byte chars', () => {
+      // '🌀' is 4 UTF-8 bytes; 31 × '🌀' = 124 bytes > 123.
+      const config = {
+        websocket: { closes: [{ urlPattern: '/ws', probability: 1, reason: '🌀'.repeat(31) }] },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
   });
 });

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -297,4 +297,54 @@ describe('validateConfig', () => {
       expect(() => validateConfig(config)).not.toThrow();
     });
   });
+
+  describe('websocket config', () => {
+    it('accepts valid drop/delay/corrupt/close rules', () => {
+      const config = {
+        websocket: {
+          drops: [{ urlPattern: '/ws', direction: 'inbound' as const, probability: 0.5 }],
+          delays: [{ urlPattern: '/ws', direction: 'outbound' as const, delayMs: 100, probability: 1 }],
+          corruptions: [{ urlPattern: '/ws', direction: 'both' as const, strategy: 'truncate' as const, probability: 0.2 }],
+          closes: [{ urlPattern: '/ws', code: 4000, reason: 'chaos', afterMs: 500, probability: 1 }],
+        },
+      };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('rejects invalid direction', () => {
+      const config = {
+        websocket: {
+          drops: [{ urlPattern: '/ws', direction: 'sideways' as unknown as 'inbound', probability: 1 }],
+        },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects empty urlPattern', () => {
+      const config = {
+        websocket: {
+          drops: [{ urlPattern: '', direction: 'both' as const, probability: 1 }],
+        },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects negative afterMs on close', () => {
+      const config = {
+        websocket: {
+          closes: [{ urlPattern: '/ws', probability: 1, afterMs: -5 }],
+        },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects multiple counting fields on a single ws rule', () => {
+      const config = {
+        websocket: {
+          drops: [{ urlPattern: '/ws', direction: 'both' as const, probability: 1, onNth: 1, everyNth: 2 }],
+        },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+  });
 });

--- a/packages/core/test/websocket.test.ts
+++ b/packages/core/test/websocket.test.ts
@@ -294,15 +294,18 @@ describe('close chaos', () => {
     expect(socket.closedWith).not.toBeNull();
   });
 
-  it('defaults to code 1006 and reason "Chaos Maker close"', () => {
+  it('defaults to code 1000 (Normal Closure) and reason "Chaos Maker close"', () => {
+    // 1000 is the only 1xxx code browsers accept as input to close(code);
+    // 1006 (the previous default) is reserved and throws InvalidAccessError.
     const { emitter, Wrapped } = setupPatch({
       closes: [{ urlPattern: '/api', probability: 1 }],
     }, ALWAYS);
     const socket = new Wrapped('ws://test/api');
     socket.simulateOpen();
     const closeEvt = emitter.getLog().find(e => e.type === 'websocket:close');
-    expect(closeEvt?.detail.closeCode).toBe(1006);
+    expect(closeEvt?.detail.closeCode).toBe(1000);
     expect(closeEvt?.detail.closeReason).toBe('Chaos Maker close');
+    expect(socket.closedWith).toEqual({ code: 1000, reason: 'Chaos Maker close' });
   });
 });
 
@@ -382,6 +385,53 @@ describe('lifecycle — uninstall', () => {
       e => e.type === 'websocket:drop' && e.detail.reason === 'stop-during-delay'
     );
     expect(drops.length).toBe(1);
+  });
+
+  it('disarms already-wrapped sockets so post-stop outbound messages pass through untouched', () => {
+    const { emitter, handle, Wrapped } = setupPatch({
+      drops: [{ urlPattern: '/api', direction: 'outbound', probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.simulateOpen();
+    socket.send('before-stop'); // dropped
+    expect(socket.sentMessages).toEqual([]);
+    handle.uninstall();
+    socket.send('after-stop'); // must pass through
+    expect(socket.sentMessages).toEqual(['after-stop']);
+    // No new drop event should be emitted after uninstall.
+    const postStopDrops = emitter.getLog()
+      .filter(e => e.type === 'websocket:drop' && !e.detail.reason);
+    expect(postStopDrops.length).toBe(1); // only the pre-stop drop
+  });
+
+  it('disarms inbound interception after stop so listeners see raw messages', () => {
+    const { handle, Wrapped } = setupPatch({
+      drops: [{ urlPattern: '/api', direction: 'inbound', probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    const received: unknown[] = [];
+    socket.addEventListener('message', (evt) => received.push((evt as MessageEvent).data));
+    socket.simulateMessage('blocked'); // dropped
+    expect(received).toEqual([]);
+    handle.uninstall();
+    socket.simulateMessage('allowed'); // must pass through
+    expect(received).toEqual(['allowed']);
+  });
+
+  it('cancels pending close timers silently (no phantom drop event)', () => {
+    const { emitter, handle, Wrapped } = setupPatch({
+      closes: [{ urlPattern: '/api', probability: 1, afterMs: 500 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.simulateOpen();
+    handle.uninstall();
+    vi.advanceTimersByTime(1000);
+    // Socket must not be closed; no misleading drop event emitted.
+    expect(socket.closedWith).toBeNull();
+    const drops = emitter.getLog().filter(e => e.type === 'websocket:drop');
+    expect(drops.length).toBe(0);
+    const closes = emitter.getLog().filter(e => e.type === 'websocket:close');
+    expect(closes.length).toBe(0);
   });
 });
 

--- a/packages/core/test/websocket.test.ts
+++ b/packages/core/test/websocket.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { patchWebSocket } from '../src/interceptors/websocket';
+import { ChaosEventEmitter } from '../src/events';
+import type { WebSocketConfig } from '../src/config';
+
+// ---------------------------------------------------------------------------
+// MockWebSocket — minimal, deterministic stand-in for the browser's WebSocket.
+// Does not actually open any connection. Tests drive inbound messages via
+// `simulateMessage` and observe outbound messages via `sentMessages`.
+// ---------------------------------------------------------------------------
+class MockWebSocket extends EventTarget {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  CONNECTING = 0;
+  OPEN = 1;
+  CLOSING = 2;
+  CLOSED = 3;
+
+  readyState: number = MockWebSocket.CONNECTING;
+  url: string;
+  sentMessages: unknown[] = [];
+  closedWith: { code?: number; reason?: string } | null = null;
+
+  constructor(url: string | URL, _protocols?: string | string[]) {
+    super();
+    this.url = typeof url === 'string' ? url : url.toString();
+    void _protocols;
+  }
+
+  send(data: string | ArrayBuffer | ArrayBufferView | Blob): void {
+    this.sentMessages.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.closedWith = { code, reason };
+  }
+
+  // Test helpers
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.dispatchEvent(new Event('open'));
+  }
+
+  simulateMessage(data: unknown): MessageEvent {
+    const evt = new MessageEvent('message', { data });
+    this.dispatchEvent(evt);
+    return evt;
+  }
+}
+
+type WSCtor = new (url: string | URL, protocols?: string | string[]) => MockWebSocket;
+
+function setupPatch(config: WebSocketConfig, random: () => number = () => 0) {
+  const emitter = new ChaosEventEmitter();
+  const counters = new Map<object, number>();
+  const handle = patchWebSocket(
+    MockWebSocket as unknown as typeof WebSocket,
+    config, emitter, random, counters,
+  );
+  const Wrapped = handle.Wrapped as unknown as WSCtor;
+  return { emitter, counters, handle, Wrapped };
+}
+
+// random() => 0 → probability always fires (Math.random() < probability).
+const ALWAYS = () => 0;
+// random() => 0.99 → probability never fires (unless p >= 1).
+const NEVER = () => 0.99;
+
+describe('patchWebSocket — wrapper constructor', () => {
+  it('returns a real MockWebSocket instance (instanceof compatibility)', () => {
+    const { Wrapped } = setupPatch({});
+    const socket = new Wrapped('ws://test/api');
+    expect(socket).toBeInstanceOf(MockWebSocket);
+  });
+
+  it('passes through send when no rules match the URL', () => {
+    const { Wrapped } = setupPatch({
+      drops: [{ urlPattern: '/other', direction: 'outbound', probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.send('hello');
+    expect(socket.sentMessages).toEqual(['hello']);
+  });
+
+  it('passes inbound through when no rules match', () => {
+    const { Wrapped } = setupPatch({});
+    const socket = new Wrapped('ws://test/api');
+    const received: unknown[] = [];
+    socket.addEventListener('message', (evt) => {
+      received.push((evt as MessageEvent).data);
+    });
+    socket.simulateMessage('hi');
+    expect(received).toEqual(['hi']);
+  });
+});
+
+describe('drop chaos', () => {
+  it('drops outbound messages matching the rule', () => {
+    const { emitter, Wrapped } = setupPatch({
+      drops: [{ urlPattern: '/api', direction: 'outbound', probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.send('a');
+    socket.send('b');
+    expect(socket.sentMessages).toEqual([]);
+    const drops = emitter.getLog().filter(e => e.type === 'websocket:drop');
+    expect(drops.length).toBe(2);
+    expect(drops.every(e => e.applied && e.detail.direction === 'outbound')).toBe(true);
+  });
+
+  it('drops inbound messages matching the rule', () => {
+    const { emitter, Wrapped } = setupPatch({
+      drops: [{ urlPattern: '/api', direction: 'inbound', probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    const received: unknown[] = [];
+    socket.addEventListener('message', (evt) => received.push((evt as MessageEvent).data));
+    socket.simulateMessage('payload');
+    expect(received).toEqual([]);
+    const drops = emitter.getLog().filter(e => e.type === 'websocket:drop');
+    expect(drops.length).toBe(1);
+    expect(drops[0].detail.direction).toBe('inbound');
+  });
+
+  it('does not drop when probability roll fails', () => {
+    const { Wrapped } = setupPatch({
+      drops: [{ urlPattern: '/api', direction: 'outbound', probability: 0.1 }],
+    }, NEVER);
+    const socket = new Wrapped('ws://test/api');
+    socket.send('ok');
+    expect(socket.sentMessages).toEqual(['ok']);
+  });
+
+  it('direction both fires on either direction independently', () => {
+    const { emitter, Wrapped } = setupPatch({
+      drops: [{ urlPattern: '/api', direction: 'both', probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    const received: unknown[] = [];
+    socket.addEventListener('message', (evt) => received.push((evt as MessageEvent).data));
+    socket.send('out');
+    socket.simulateMessage('in');
+    expect(socket.sentMessages).toEqual([]);
+    expect(received).toEqual([]);
+    expect(emitter.getLog().filter(e => e.type === 'websocket:drop').length).toBe(2);
+  });
+});
+
+describe('delay chaos', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+
+  it('defers outbound send by delayMs', () => {
+    const { Wrapped } = setupPatch({
+      delays: [{ urlPattern: '/api', direction: 'outbound', delayMs: 500, probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.send('hi');
+    expect(socket.sentMessages).toEqual([]);
+    vi.advanceTimersByTime(499);
+    expect(socket.sentMessages).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(socket.sentMessages).toEqual(['hi']);
+  });
+
+  it('defers inbound dispatch by delayMs', () => {
+    const { Wrapped } = setupPatch({
+      delays: [{ urlPattern: '/api', direction: 'inbound', delayMs: 200, probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    const received: unknown[] = [];
+    socket.addEventListener('message', (evt) => received.push((evt as MessageEvent).data));
+    socket.simulateMessage('late');
+    expect(received).toEqual([]);
+    vi.advanceTimersByTime(200);
+    expect(received).toEqual(['late']);
+  });
+
+  it('re-dispatched message has the original origin and lastEventId', () => {
+    const { Wrapped } = setupPatch({
+      delays: [{ urlPattern: '/api', direction: 'inbound', delayMs: 100, probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    const received: MessageEvent[] = [];
+    socket.addEventListener('message', (evt) => received.push(evt as MessageEvent));
+    // Simulate a message; MessageEvent init defaults origin to ''
+    socket.simulateMessage('x');
+    vi.advanceTimersByTime(100);
+    expect(received.length).toBe(1);
+    expect(received[0].data).toBe('x');
+  });
+});
+
+describe('corrupt chaos — text', () => {
+  it.each([
+    ['truncate', 'hello world', 'hello'], // half
+    ['empty', 'hello', ''],
+  ] as const)('%s mutates outbound text', (strategy, input, expected) => {
+    const { emitter, Wrapped } = setupPatch({
+      corruptions: [{ urlPattern: '/api', direction: 'outbound', strategy, probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.send(input);
+    expect(socket.sentMessages).toEqual([expected]);
+    const events = emitter.getLog().filter(e => e.type === 'websocket:corrupt');
+    expect(events[0].applied).toBe(true);
+    expect(events[0].detail.strategy).toBe(strategy);
+  });
+
+  it('malformed-json appends garbage', () => {
+    const { Wrapped } = setupPatch({
+      corruptions: [{ urlPattern: '/api', direction: 'outbound', strategy: 'malformed-json', probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.send('{"a":1}');
+    expect(socket.sentMessages[0]).toContain('{"a":1}');
+    expect(socket.sentMessages[0]).not.toBe('{"a":1}');
+  });
+
+  it('inbound corruption re-dispatches mutated payload', () => {
+    const { Wrapped } = setupPatch({
+      corruptions: [{ urlPattern: '/api', direction: 'inbound', strategy: 'empty', probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    const received: unknown[] = [];
+    socket.addEventListener('message', (evt) => received.push((evt as MessageEvent).data));
+    socket.simulateMessage('original');
+    expect(received).toEqual(['']);
+  });
+});
+
+describe('corrupt chaos — binary', () => {
+  it('truncate halves an ArrayBuffer', () => {
+    const { Wrapped } = setupPatch({
+      corruptions: [{ urlPattern: '/api', direction: 'outbound', strategy: 'truncate', probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    const buf = new ArrayBuffer(8);
+    socket.send(buf);
+    const sent = socket.sentMessages[0] as ArrayBuffer;
+    expect(sent.byteLength).toBe(4);
+  });
+
+  it('empty produces zero-length payload', () => {
+    const { Wrapped } = setupPatch({
+      corruptions: [{ urlPattern: '/api', direction: 'outbound', strategy: 'empty', probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.send(new Uint8Array([1, 2, 3, 4]));
+    const sent = socket.sentMessages[0] as Uint8Array;
+    expect(sent.byteLength).toBe(0);
+  });
+
+  it('malformed-json on binary emits applied:false with reason', () => {
+    const { emitter, Wrapped } = setupPatch({
+      corruptions: [{ urlPattern: '/api', direction: 'outbound', strategy: 'malformed-json', probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.send(new Uint8Array([1, 2]));
+    // Binary payload passed through unchanged
+    expect((socket.sentMessages[0] as Uint8Array).byteLength).toBe(2);
+    const evt = emitter.getLog().find(e => e.type === 'websocket:corrupt');
+    expect(evt?.applied).toBe(false);
+    expect(evt?.detail.reason).toBe('incompatible-payload-type');
+  });
+});
+
+describe('close chaos', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+
+  it('closes the socket immediately on open when afterMs is 0', () => {
+    const { emitter, Wrapped } = setupPatch({
+      closes: [{ urlPattern: '/api', probability: 1, code: 4000, reason: 'chaos' }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.simulateOpen();
+    expect(socket.closedWith).toEqual({ code: 4000, reason: 'chaos' });
+    const closes = emitter.getLog().filter(e => e.type === 'websocket:close');
+    expect(closes.length).toBe(1);
+    expect(closes[0].detail.closeCode).toBe(4000);
+  });
+
+  it('closes after afterMs elapses from open', () => {
+    const { Wrapped } = setupPatch({
+      closes: [{ urlPattern: '/api', probability: 1, afterMs: 1000 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.simulateOpen();
+    expect(socket.closedWith).toBeNull();
+    vi.advanceTimersByTime(1000);
+    expect(socket.closedWith).not.toBeNull();
+  });
+
+  it('defaults to code 1006 and reason "Chaos Maker close"', () => {
+    const { emitter, Wrapped } = setupPatch({
+      closes: [{ urlPattern: '/api', probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.simulateOpen();
+    const closeEvt = emitter.getLog().find(e => e.type === 'websocket:close');
+    expect(closeEvt?.detail.closeCode).toBe(1006);
+    expect(closeEvt?.detail.closeReason).toBe('Chaos Maker close');
+  });
+});
+
+describe('counting', () => {
+  it('onNth: 3 fires drop only on 3rd matching message', () => {
+    const { Wrapped } = setupPatch({
+      drops: [{ urlPattern: '/api', direction: 'outbound', probability: 1, onNth: 3 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.send('1'); socket.send('2'); socket.send('3'); socket.send('4');
+    expect(socket.sentMessages).toEqual(['1', '2', '4']);
+  });
+
+  it('everyNth: 2 fires drop on 2nd, 4th, ...', () => {
+    const { Wrapped } = setupPatch({
+      drops: [{ urlPattern: '/api', direction: 'outbound', probability: 1, everyNth: 2 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    for (let i = 1; i <= 5; i++) socket.send(`m${i}`);
+    expect(socket.sentMessages).toEqual(['m1', 'm3', 'm5']);
+  });
+
+  it('afterN: 2 fires drop from 3rd onward', () => {
+    const { Wrapped } = setupPatch({
+      drops: [{ urlPattern: '/api', direction: 'outbound', probability: 1, afterN: 2 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    for (let i = 1; i <= 4; i++) socket.send(`m${i}`);
+    expect(socket.sentMessages).toEqual(['m1', 'm2']);
+  });
+});
+
+describe('determinism', () => {
+  it('identical seeds produce identical drop patterns', () => {
+    // Use a real mulberry32-like deterministic sequence via counter.
+    const seq = [0.1, 0.9, 0.2, 0.8, 0.3];
+    const makeRandom = () => {
+      let i = 0;
+      return () => seq[i++ % seq.length];
+    };
+    const cfg: WebSocketConfig = {
+      drops: [{ urlPattern: '/api', direction: 'outbound', probability: 0.5 }],
+    };
+    const run = (): string[] => {
+      const emitter = new ChaosEventEmitter();
+      const counters = new Map<object, number>();
+      const handle = patchWebSocket(
+        MockWebSocket as unknown as typeof WebSocket,
+        cfg, emitter, makeRandom(), counters,
+      );
+      const Wrapped = handle.Wrapped as unknown as WSCtor;
+      const socket = new Wrapped('ws://test/api');
+      for (let i = 0; i < 5; i++) socket.send(`m${i}`);
+      return emitter.getLog().filter(e => e.type === 'websocket:drop').map(e => String(e.detail.direction));
+    };
+    const a = run();
+    const b = run();
+    expect(a).toEqual(b);
+  });
+});
+
+describe('lifecycle — uninstall', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+
+  it('clears pending delay timers and emits drop events', () => {
+    const { emitter, handle, Wrapped } = setupPatch({
+      delays: [{ urlPattern: '/api', direction: 'outbound', delayMs: 1000, probability: 1 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.send('buffered');
+    expect(socket.sentMessages).toEqual([]);
+    handle.uninstall();
+    // Timer should not fire after uninstall.
+    vi.advanceTimersByTime(1000);
+    expect(socket.sentMessages).toEqual([]);
+    const drops = emitter.getLog().filter(
+      e => e.type === 'websocket:drop' && e.detail.reason === 'stop-during-delay'
+    );
+    expect(drops.length).toBe(1);
+  });
+});
+
+describe('close interrupts pending delays', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+
+  it('clears delay timers when close-chaos fires', () => {
+    const { emitter, Wrapped } = setupPatch({
+      delays: [{ urlPattern: '/api', direction: 'outbound', delayMs: 5000, probability: 1 }],
+      closes: [{ urlPattern: '/api', probability: 1, afterMs: 100 }],
+    }, ALWAYS);
+    const socket = new Wrapped('ws://test/api');
+    socket.simulateOpen();
+    socket.send('buffered');
+    vi.advanceTimersByTime(100);
+    // Close fired — pending send should never deliver.
+    vi.advanceTimersByTime(5000);
+    expect(socket.sentMessages).toEqual([]);
+    const dropReasons = emitter.getLog()
+      .filter(e => e.type === 'websocket:drop')
+      .map(e => e.detail.reason);
+    expect(dropReasons).toContain('close-interrupt');
+  });
+});

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/playwright",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.1",
   "type": "module",
   "description": "Playwright adapter for @chaos-maker/core — one-line chaos injection in E2E tests",
   "keywords": [

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -93,4 +93,14 @@ const win = globalThis as any;
   });
 }
 
-export type { ChaosConfig, ChaosEvent } from '@chaos-maker/core';
+export type {
+  ChaosConfig,
+  ChaosEvent,
+  WebSocketConfig,
+  WebSocketDropConfig,
+  WebSocketDelayConfig,
+  WebSocketCorruptConfig,
+  WebSocketCloseConfig,
+  WebSocketDirection,
+  WebSocketCorruptionStrategy,
+} from '@chaos-maker/core';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,9 +64,15 @@ importers:
       '@playwright/test':
         specifier: ^1.45.0
         version: 1.56.1
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       http-server:
         specifier: ^14.1.1
         version: 14.1.1
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
 
   packages/core:
     dependencies:
@@ -685,6 +691,9 @@ packages:
 
   '@types/node@20.19.23':
     resolution: {integrity: sha512-yIdlVVVHXpmqRhtyovZAcSy0MiPcYWGkoO4CGe/+jpP0hmNuihm4XhHbADpK++MsiLHP5MVlv+bcgdF99kSiFQ==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.46.2':
     resolution: {integrity: sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==}
@@ -1995,6 +2004,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -2384,6 +2405,10 @@ snapshots:
   '@types/node@20.19.23':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.23
 
   '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
@@ -3759,6 +3784,8 @@ snapshots:
       strip-ansi: 7.1.2
 
   ws@8.18.3: {}
+
+  ws@8.20.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
## Summary

Phase 3 of the v2 roadmap ships **WebSocket chaos**: intercept `window.WebSocket` to drop, delay, corrupt, or force-close messages and connections. Composes with Phase 1 (seeded PRNG) and Phase 2 (per-rule counting), and is fully covered by unit + cross-browser E2E tests.

- New config namespace `websocket` with 4 primitives — `drops`, `delays`, `corruptions`, `closes` — each supporting `direction: inbound | outbound | both`, probability, and counting (`onNth` / `everyNth` / `afterN`).
- Corruption strategies `truncate`, `malformed-json`, `empty`, `wrong-type` (JSON-specific strategies emit `applied: false, reason: 'incompatible-payload-type'` for binary frames).
- Ordering per message: **drop → corrupt → delay**. Close cancels per-socket pending timers so queued delays never fire after close.
- Wrapper preserves `instanceof WebSocket` via prototype aliasing; inbound interception uses capture-phase + `stopImmediatePropagation` + redispatch marked with `Symbol.for('chaos-maker.websocket.intercepted')` to avoid re-entry.
- Builder methods: `.dropMessages()`, `.delayMessages()`, `.corruptMessages()`, `.closeConnection()` plus `.dropMessagesOnNth()` / `.delayMessagesOnNth()` shortcuts.
- New preset `unreliableWebSocket` (10% drop both ways, 500ms inbound delay, 5% inbound truncate).
- Playwright adapter re-exports every new WS type.
- Versions bumped: `@chaos-maker/core` and `@chaos-maker/playwright` → `0.2.0-beta.1`.

## Test plan

- [x] `pnpm lint` clean across the monorepo
- [x] `pnpm build` — core (ESM+CJS+UMD) and playwright (ESM+CJS+DTS) succeed
- [x] `pnpm -C packages/core exec vitest run` — 178/178 tests across 11 files
- [x] `pnpm -C e2e-tests exec playwright test` — 240/240 E2E tests across chromium, firefox, webkit, edge (21.3s); zero browser-specific quirks
- [x] WebSocket spec (`e2e-tests/tests/websocket-chaos.spec.ts`): drop everyNth, delay with relative-baseline assertion, inbound truncation, force-close with custom code+reason, seeded replay determinism, onNth: 3 counting — all 24 pass (6 × 4 browsers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket chaos injection: drop, delay, corrupt, and force-close messages with direction control and counting (onNth/everyNth/afterN).
  * New builder methods and an `unreliableWebSocket` preset.
  * Seeded randomness for reproducible runs and websocket-specific observable events.

* **Documentation**
  * CHANGELOG and README updated with WebSocket chaos usage, event details, and presets.

* **Tests**
  * Expanded unit and E2E WebSocket test coverage and added a local WebSocket echo test server.

* **Chores**
  * Dev/test config and package version updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->