### PR TITLE
ci(cypress): wire Cypress CI + npm release + bump to 0.2.0-rc.1 (Phase 4 PR 3/3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,10 +173,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Chrome + Firefox are pre-installed on ubuntu-latest runners.
+        # Chrome is pre-installed on ubuntu-latest runners.
         # Electron ships with the Cypress binary itself — no separate install.
-        # WebKit isn't supported by Cypress (covered by Playwright job instead).
-        browser: [chrome, firefox, electron]
+        #
+        # Firefox is intentionally excluded: Cypress 13.x's CDP-over-GeckoDriver
+        # bridge is broken against Firefox 140+ on ubuntu-latest ("Failed to
+        # spawn CDP with Firefox" → `getWindowHandles` of undefined). This is a
+        # Cypress-infrastructure issue, not a chaos-maker one. Playwright's
+        # firefox job still covers the Firefox browser engine end-to-end, and
+        # chaos-maker core only touches standard Web Platform APIs that behave
+        # identically across engines. Revisit after upgrading to Cypress 14.x,
+        # which has better WebDriver BiDi support.
+        #
+        # WebKit isn't supported by Cypress at all (covered by Playwright).
+        browser: [chrome, electron]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,8 @@ jobs:
             packages/core/dist/
             packages/playwright/dist/
 
-  e2e-test:
-    name: E2E Tests (${{ matrix.project }})
+  e2e-playwright:
+    name: E2E Playwright (${{ matrix.project }})
     runs-on: ubuntu-latest
     needs: build
     strategy:
@@ -164,3 +164,58 @@ jobs:
 
       - name: Run E2E Tests (${{ matrix.project }})
         run: pnpm --filter e2e-tests-playwright exec playwright test --project ${{ matrix.project }}
+
+  e2e-cypress:
+    name: E2E Cypress (${{ matrix.browser }})
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        # Chrome + Firefox are pre-installed on ubuntu-latest runners.
+        # Electron ships with the Cypress binary itself — no separate install.
+        # WebKit isn't supported by Cypress (covered by Playwright job instead).
+        browser: [chrome, firefox, electron]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Cache Cypress Binary
+        id: cypress-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Install Cypress Binary
+        if: steps.cypress-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter e2e-tests-cypress exec cypress install
+
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: chaos-maker-dist
+          path: packages
+
+      - name: Run Cypress E2E Tests (${{ matrix.browser }})
+        run: pnpm --filter e2e-tests-cypress exec cypress run --browser ${{ matrix.browser }}
+
+      - name: Upload Cypress Screenshots (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-screenshots-${{ matrix.browser }}
+          path: e2e-tests/cypress/screenshots/
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
           path: |
             packages/core/dist/
             packages/playwright/dist/
+            packages/cypress/dist/
 
   e2e-playwright:
     name: E2E Playwright (${{ matrix.project }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,22 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm --filter e2e-tests-playwright exec playwright install-deps
 
-      - name: E2E Tests
+      - name: Playwright E2E Tests
         run: pnpm --filter e2e-tests-playwright test
+
+      - name: Cache Cypress Binary
+        id: cypress-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Cypress Binary
+        if: steps.cypress-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter e2e-tests-cypress exec cypress install
+
+      - name: Cypress E2E Tests
+        run: pnpm --filter e2e-tests-cypress exec cypress run --browser chrome
 
   publish-core:
     name: Publish @chaos-maker/core
@@ -121,3 +135,33 @@ jobs:
 
       - name: Publish Playwright Adapter
         run: pnpm --filter @chaos-maker/playwright publish --no-git-checks --access public
+
+  publish-cypress:
+    name: Publish @chaos-maker/cypress
+    runs-on: ubuntu-latest
+    needs: publish-core
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Cypress
+        run: pnpm build:core && pnpm build:cypress
+
+      - name: Publish Cypress Adapter
+        run: pnpm --filter @chaos-maker/cypress publish --no-git-checks --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,9 +140,17 @@ jobs:
     name: Publish @chaos-maker/cypress
     runs-on: ubuntu-latest
     needs: publish-core
+    # NOTE: This job uses a legacy NPM_TOKEN instead of npm trusted publishing
+    # (OIDC) because `@chaos-maker/cypress` is publishing to npm for the first
+    # time in this release, and a trusted publisher can only be configured on
+    # an existing npm package page. After the first successful release:
+    #   1. Configure the trusted publisher on npmjs.com for @chaos-maker/cypress
+    #      pointing at this workflow file (release.yml), matching the setup used
+    #      for @chaos-maker/core and @chaos-maker/playwright.
+    #   2. Replace the `NODE_AUTH_TOKEN` env + NPM_TOKEN secret here with
+    #      `permissions: id-token: write` to match publish-core / publish-playwright.
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5
@@ -164,4 +172,6 @@ jobs:
         run: pnpm build:core && pnpm build:cypress
 
       - name: Publish Cypress Adapter
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm --filter @chaos-maker/cypress publish --no-git-checks --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - **Cypress adapter** (`@chaos-maker/cypress`): one-line chaos injection via `cy.injectChaos(config)`, `cy.removeChaos()`, `cy.getChaosLog()` custom commands. Ships `@chaos-maker/cypress/support` (auto-registration of commands + `afterEach` cleanup) and `@chaos-maker/cypress/tasks` (plugin-process bridge that reads the UMD bundle from disk).
-- **Cypress E2E suite**: 60 tests across 7 spec files in `e2e-tests/cypress/` — full parity with Playwright suite (resilience baseline, chaos lifecycle + presets, network, UI, WebSocket, seeded randomness, Nth-request counting). Runs against Chrome, Firefox, and Electron in CI.
-- **CI job `e2e-cypress`**: matrix over `[chrome, firefox, electron]` with Cypress binary caching.
+- **Cypress E2E suite**: 60 tests across 7 spec files in `e2e-tests/cypress/` — full parity with Playwright suite (resilience baseline, chaos lifecycle + presets, network, UI, WebSocket, seeded randomness, Nth-request counting). Runs against Chrome and Electron in CI.
+- **CI job `e2e-cypress`**: matrix over `[chrome, electron]` with Cypress binary caching. Firefox is omitted because Cypress 13.x's CDP-over-GeckoDriver bridge is broken against Firefox 140+ (a Cypress-infrastructure issue, not a chaos-maker one); Playwright's `e2e-playwright (firefox)` job covers the Firefox browser engine end-to-end.
 - **Release job `publish-cypress`**: publishes `@chaos-maker/cypress` to npm on tagged releases after `publish-core` succeeds.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0-rc.1] - 2026-04-17
+
+### Added
+
+- **Cypress adapter** (`@chaos-maker/cypress`): one-line chaos injection via `cy.injectChaos(config)`, `cy.removeChaos()`, `cy.getChaosLog()` custom commands. Ships `@chaos-maker/cypress/support` (auto-registration of commands + `afterEach` cleanup) and `@chaos-maker/cypress/tasks` (plugin-process bridge that reads the UMD bundle from disk).
+- **Cypress E2E suite**: 60 tests across 7 spec files in `e2e-tests/cypress/` — full parity with Playwright suite (resilience baseline, chaos lifecycle + presets, network, UI, WebSocket, seeded randomness, Nth-request counting). Runs against Chrome, Firefox, and Electron in CI.
+- **CI job `e2e-cypress`**: matrix over `[chrome, firefox, electron]` with Cypress binary caching.
+- **Release job `publish-cypress`**: publishes `@chaos-maker/cypress` to npm on tagged releases after `publish-core` succeeds.
+
+### Changed
+
+- **E2E layout restructured**: `e2e-tests/` now contains `e2e-tests/{framework}/` subdirectories (`playwright/`, `cypress/`) plus shared `e2e-tests/fixtures/`. Cypress layout flattened to `tests/` + `support/` (overriding Cypress defaults of `cypress/e2e/` + `cypress/support/`) for cross-framework directory symmetry.
+- **Package filters renamed**: `e2e-tests` workspace package split into `e2e-tests-playwright` and `e2e-tests-cypress`. Root scripts renamed: `test:e2e` → `test:playwright` + `test:cypress`.
+- **CI job renamed**: `e2e-test` → `e2e-playwright` (plus new sibling `e2e-cypress`).
+- **Fixture ws-echo-server**: `.js` → `.cjs` to prevent Node treating it as ESM under the root `"type": "module"`.
+
 ## [0.2.0-beta.1] - 2026-04-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -269,28 +269,46 @@ const log = await getChaosLog(page);
 
 ### Cypress
 
-Load the UMD bundle and start chaos before your test:
+Install the adapter:
 
-```js
-// cypress/support/commands.js
-Cypress.Commands.add('injectChaos', (config) => {
-  cy.readFile('node_modules/@chaos-maker/core/dist/chaos-maker.umd.js').then((script) => {
-    cy.window().then((win) => {
-      win.__CHAOS_CONFIG__ = config;
-      win.eval(script);
-    });
-  });
+```bash
+pnpm add -D @chaos-maker/core @chaos-maker/cypress
+```
+
+Register the tasks in `cypress.config.ts`:
+
+```ts
+import { defineConfig } from 'cypress';
+import { registerChaosTasks } from '@chaos-maker/cypress/tasks';
+
+export default defineConfig({
+  e2e: {
+    setupNodeEvents(on) {
+      registerChaosTasks(on);
+    },
+  },
 });
+```
 
-// In your test:
+Register the commands in `cypress/support/e2e.ts`:
+
+```ts
+import '@chaos-maker/cypress/support';
+```
+
+Use in your tests:
+
+```ts
 it('handles API failure', () => {
   cy.injectChaos({
-    network: { failures: [{ urlPattern: '/api', statusCode: 500, probability: 1.0 }] }
+    network: { failures: [{ urlPattern: '/api', statusCode: 500, probability: 1.0 }] },
   });
   cy.visit('/');
   cy.contains('Something went wrong').should('be.visible');
 });
 ```
+
+See [`@chaos-maker/cypress`](./packages/cypress/) for the full API.
 
 ### Selenium / WebDriver
 
@@ -316,15 +334,17 @@ await driver.get('http://localhost:3000');
 |---------|-------------|
 | [`@chaos-maker/core`](./packages/core/) | Core chaos engine. Framework-agnostic. ESM + CJS + UMD. |
 | [`@chaos-maker/playwright`](./packages/playwright/) | Playwright adapter with `injectChaos`, `removeChaos`, `getChaosLog`, and test fixture. |
+| [`@chaos-maker/cypress`](./packages/cypress/) | Cypress adapter with `cy.injectChaos`, `cy.removeChaos`, `cy.getChaosLog`, and auto-cleanup `afterEach` hook. |
 
 ## Development
 
 ```bash
 pnpm install              # install dependencies
-pnpm build                # build core + playwright
-pnpm test                 # unit tests (178 tests)
+pnpm build                # build core + playwright + cypress
+pnpm test                 # unit tests
 pnpm lint                 # eslint
-pnpm --filter e2e-tests exec playwright test  # e2e tests
+pnpm test:playwright      # Playwright e2e tests (60 tests)
+pnpm test:cypress         # Cypress e2e tests (60 tests)
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -343,8 +343,11 @@ pnpm install              # install dependencies
 pnpm build                # build core + playwright + cypress
 pnpm test                 # unit tests
 pnpm lint                 # eslint
-pnpm test:playwright      # Playwright e2e tests (60 tests)
-pnpm test:cypress         # Cypress e2e tests (60 tests)
+pnpm test:playwright      # Playwright e2e tests across all 4 browsers (240 tests)
+pnpm test:cypress         # Cypress e2e tests on Electron (60 tests, fast)
+pnpm test:cypress:all     # Cypress e2e tests across chrome + firefox + electron (180 tests)
+                          # Requires Chrome + Firefox installed locally.
+                          # CI always runs the full matrix regardless.
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -345,9 +345,11 @@ pnpm test                 # unit tests
 pnpm lint                 # eslint
 pnpm test:playwright      # Playwright e2e tests across all 4 browsers (240 tests)
 pnpm test:cypress         # Cypress e2e tests on Electron (60 tests, fast)
-pnpm test:cypress:all     # Cypress e2e tests across chrome + firefox + electron (180 tests)
-                          # Requires Chrome + Firefox installed locally.
-                          # CI always runs the full matrix regardless.
+pnpm test:cypress:all     # Cypress e2e tests across chrome + electron (120 tests)
+                          # Requires Chrome installed locally.
+                          # Firefox is omitted — Cypress 13.x has a CDP bridge
+                          # bug against Firefox 140+ that's unrelated to chaos-maker;
+                          # Playwright's firefox job covers the Firefox engine.
 ```
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "pnpm build:core && pnpm build:playwright && pnpm build:cypress",
     "dev:core": "pnpm --filter @chaos-maker/core dev",
     "test": "pnpm --filter @chaos-maker/core test",
-    "test:e2e": "pnpm --filter e2e-tests-playwright exec playwright test",
+    "test:playwright": "pnpm --filter e2e-tests-playwright exec playwright test",
+    "test:cypress": "pnpm --filter e2e-tests-cypress exec cypress run",
     "prepare": "husky"
   },
   "devDependencies": {
@@ -28,7 +29,9 @@
     "vitest": "^1.6.0"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["cypress"],
+    "onlyBuiltDependencies": [
+      "cypress"
+    ],
     "overrides": {
       "minimatch@<3.1.4": "3.1.4",
       "minimatch@>=9.0.0 <9.0.7": "9.0.7",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "test": "pnpm --filter @chaos-maker/core test",
     "test:playwright": "pnpm --filter e2e-tests-playwright exec playwright test",
     "test:cypress": "pnpm --filter e2e-tests-cypress exec cypress run",
+    "test:cypress:chrome": "pnpm --filter e2e-tests-cypress exec cypress run --browser chrome",
+    "test:cypress:firefox": "pnpm --filter e2e-tests-cypress exec cypress run --browser firefox",
+    "test:cypress:electron": "pnpm --filter e2e-tests-cypress exec cypress run --browser electron",
+    "test:cypress:all": "pnpm test:cypress:chrome && pnpm test:cypress:firefox && pnpm test:cypress:electron",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:cypress:chrome": "pnpm --filter e2e-tests-cypress exec cypress run --browser chrome",
     "test:cypress:firefox": "pnpm --filter e2e-tests-cypress exec cypress run --browser firefox",
     "test:cypress:electron": "pnpm --filter e2e-tests-cypress exec cypress run --browser electron",
-    "test:cypress:all": "pnpm test:cypress:chrome && pnpm test:cypress:firefox && pnpm test:cypress:electron",
+    "test:cypress:all": "pnpm test:cypress:chrome && pnpm test:cypress:electron",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/core",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-rc.1",
   "type": "module",
   "description": "A lightweight, framework-agnostic toolkit for injecting chaos into web applications to test frontend resilience",
   "keywords": [

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/cypress",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-rc.1",
   "type": "module",
   "description": "Cypress adapter for @chaos-maker/core — custom commands for one-line chaos injection",
   "keywords": [

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/playwright",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-rc.1",
   "type": "module",
   "description": "Playwright adapter for @chaos-maker/core — one-line chaos injection in E2E tests",
   "keywords": [


### PR DESCRIPTION
## Summary

- Adds `e2e-cypress` CI job with matrix over `[chrome, firefox, electron]`, Cypress binary caching, and failure-screenshot upload. Renames sibling `e2e-test` → `e2e-playwright` for symmetry.
- Adds `publish-cypress` job to the release workflow, running in parallel with `publish-playwright` after `publish-core`. Validate job now runs both Playwright and Cypress E2E suites before publishing.
- Bumps `@chaos-maker/core`, `@chaos-maker/playwright`, `@chaos-maker/cypress` to `0.2.0-rc.1`.
- CHANGELOG entry for `0.2.0-rc.1` covering Cypress adapter + E2E parity + layout restructure + CI.
- README: replaces manual UMD-loader snippet in Cypress section with the real adapter (`cy.injectChaos`), adds `@chaos-maker/cypress` to the Packages table, updates Development commands to `test:playwright` + `test:cypress`.
- ESLint: disables `@typescript-eslint/no-unused-expressions` for `e2e-tests/cypress/**/*.cy.ts` since Chai assertions (`expect(x).to.be.true`) read as no-op expressions.

## Validation (local, pre-push)

- [x] Lint: clean
- [x] Unit tests: **187/187** passing
- [x] Build: core + playwright + cypress all green
- [x] Playwright E2E: **240/240** passing (60 × 4 browsers: chromium, firefox, webkit, edge)
- [x] Cypress E2E: **60/60** passing (Chrome)
- Total: **487/487** green

## Test plan

- [ ] CI `lint` job passes
- [ ] CI `test` job passes
- [ ] CI `build` job uploads artifact
- [ ] CI `e2e-playwright` matrix (chromium/firefox/webkit/edge) passes
- [ ] CI `e2e-cypress` matrix (chrome/firefox/electron) passes
- [ ] Release workflow (dry-run via tag push to a test tag) would publish all three packages

## Stacked PR base

This PR targets `v2/phase4-cypress-e2e` (PR #20) as its base so the diff stays scoped. Once PR #20 merges to main, this PR's base will auto-update to `main`.