### PR TITLE
fix: ignore playwright test artifacts from linting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,13 @@ import vitest from "@vitest/eslint-plugin";
 
 export default [
   {
-    ignores: ["node_modules", "**/dist", "**/*.cjs"],
+    ignores: [
+      "node_modules",
+      "**/dist",
+      "**/*.cjs",
+      "**/playwright-report",
+      "**/test-results"
+    ],
   },
   ...tseslint.configs.recommended,
   {


### PR DESCRIPTION
This PR updates the ESLint configuration to ignore the playwright-report and test-results directories.

Previously, running pnpm lint locally would fail after executing E2E tests because ESLint was scanning the generated, minified third-party assets (such as the CodeMirror bundle) inside the Playwright trace reports. These files are auto-generated during local test runs and naturally violate strict TypeScript linting rules, so they need to be excluded from static analysis.

This change ensures that local linting behaves exactly like our CI pipeline, keeping the checks green and preventing false positive errors.

Changes:

Added **/playwright-report to the eslint.config.js ignores array.

Added **/test-results to the eslint.config.js ignores array.