### PR TITLE
fix(playwright): use pnpm exec for fixture web server

### DIFF
--- a/e2e-tests/playwright/playwright.config.ts
+++ b/e2e-tests/playwright/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
   webServer: [
     {
       command: process.env.CI
-        ? 'npx http-server ../fixtures -p 8080 -s'
+        ? 'pnpm exec http-server ../fixtures -p 8080 -s'
         : 'python3 -m http.server 8080 -d ../fixtures',
       url: 'http://127.0.0.1:8080',
       reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
## Summary
- Replace `npx http-server` with `pnpm exec http-server` in the Playwright `webServer` command used in CI mode.
- Avoid npm 11 warning spam from pnpm-inherited `npm_config_*` env vars during Playwright fixture server startup.

## Why
Running Playwright from a `pnpm`-launched parent process currently routes the CI fixture server startup through `npx`, which invokes npm. npm 11 then warns about inherited env config keys like `verify-deps-before-run`, `npm-globalconfig`, `recursive`, and `_jsr-registry` before `http-server` starts. `pnpm exec` resolves the existing workspace dependency directly and keeps test output clean.

## Test plan
- [x] Local repro: `env npm_config_recursive=true npm_config_npm_globalconfig=/tmp/fake-npmrc npm_config__jsr_registry=https://example.test npm_config_verify_deps_before_run=false npx http-server --help` emits the npm warnings
- [x] Local verify: `env npm_config_recursive=true npm_config_npm_globalconfig=/tmp/fake-npmrc npm_config__jsr_registry=https://example.test npm_config_verify_deps_before_run=false pnpm exec http-server --help` runs cleanly with no warnings
- [x] Full Playwright suite

## Out of scope
- Changing the non-CI fixture server path (`python3 -m http.server ...`)
- Broader cleanup of ignored local note files such as `LEARNINGS.md` and plan markdowns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure configuration for continuous integration environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->