### PR TITLE
chore(spike): isolate SW-chaos spike artifacts from main CI suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,10 @@ pnpm test:cypress:all     # Cypress e2e tests across chrome + electron (120 test
                           # Playwright's firefox job covers the Firefox engine.
 ```
 
+### Spikes
+
+The `spike/` directory and any `tests/spike/**` files are intentional out-of-tree experiments preserved for historical reference. They are excluded from the default Playwright run via `testIgnore` and are not part of CI. Run them on demand with `pnpm --filter e2e-tests exec playwright test tests/spike/`.
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first.

--- a/e2e-tests/fixtures/sw-app/index.html
+++ b/e2e-tests/fixtures/sw-app/index.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Chaos Maker SW Fixture</title>
+  <style>
+    body { font-family: sans-serif; max-width: 720px; margin: 0 auto; padding: 20px; }
+    section { margin-bottom: 16px; padding: 10px; border: 1px solid #ddd; border-radius: 4px; }
+    pre { background: #f5f5f5; padding: 8px; overflow-x: auto; min-height: 1em; }
+    .row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+  </style>
+</head>
+<body>
+  <h1>Chaos Maker SW Fixture</h1>
+
+  <section>
+    <h2>Service Worker</h2>
+    <div class="row">
+      <button id="sw-register">Register SW</button>
+      <button id="sw-unregister">Unregister</button>
+      <span id="sw-state">idle</span>
+    </div>
+    <pre id="sw-log"></pre>
+  </section>
+
+  <section>
+    <h2>Fetch via Service Worker</h2>
+    <div class="row">
+      <button id="sw-fetch">Fetch /sw-api/data via SW</button>
+      <span id="sw-fetch-status"></span>
+    </div>
+    <pre id="sw-fetch-result"></pre>
+  </section>
+
+  <section>
+    <h2>Page-side fetch (control)</h2>
+    <div class="row">
+      <button id="page-fetch">Fetch /api/data.json from page</button>
+      <span id="page-fetch-status"></span>
+    </div>
+    <pre id="page-fetch-result"></pre>
+  </section>
+
+  <script>
+    var stateEl = document.getElementById('sw-state');
+    var swLog = document.getElementById('sw-log');
+
+    function log(line) {
+      swLog.textContent += line + '\n';
+    }
+
+    // Bridge: SW posts chaos events back via postMessage; mirror to window
+    // for the spike test to read via page.evaluate.
+    window.__SW_CHAOS_EVENTS__ = [];
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.addEventListener('message', function (evt) {
+        if (evt.data && evt.data.__chaosMakerSWEvent) {
+          window.__SW_CHAOS_EVENTS__.push(evt.data.event);
+          log('chaos: ' + JSON.stringify(evt.data.event));
+        }
+      });
+    }
+
+    // Allow test to pre-set chaos config; pass it via search param so the SW
+    // can read it at install time (SW has no access to window).
+    window.__registerChaosSW = async function (chaosConfig) {
+      if (!('serviceWorker' in navigator)) throw new Error('unsupported');
+      stateEl.textContent = 'registering';
+      var encoded = btoa(JSON.stringify(chaosConfig || {}));
+      var url = '/sw-app/sw-chaos.js?config=' + encodeURIComponent(encoded);
+      var reg = await navigator.serviceWorker.register(url, { scope: '/sw-app/' });
+      await navigator.serviceWorker.ready;
+      stateEl.textContent = 'ready';
+      log('registered scope=' + reg.scope);
+      return true;
+    };
+
+    document.getElementById('sw-register').addEventListener('click', async function () {
+      try {
+        await window.__registerChaosSW({});
+      } catch (err) {
+        stateEl.textContent = 'error';
+        log('register error: ' + err.message);
+      }
+    });
+
+    document.getElementById('sw-unregister').addEventListener('click', async function () {
+      var regs = await navigator.serviceWorker.getRegistrations();
+      for (var r of regs) await r.unregister();
+      stateEl.textContent = 'unregistered';
+      log('unregistered');
+    });
+
+    document.getElementById('sw-fetch').addEventListener('click', async function () {
+      var statusEl = document.getElementById('sw-fetch-status');
+      var resEl = document.getElementById('sw-fetch-result');
+      statusEl.textContent = 'loading';
+      resEl.textContent = '';
+      try {
+        var res = await fetch('/sw-app/sw-api/data');
+        statusEl.textContent = String(res.status);
+        resEl.textContent = await res.text();
+      } catch (err) {
+        statusEl.textContent = 'error';
+        resEl.textContent = err.message;
+      }
+    });
+
+    document.getElementById('page-fetch').addEventListener('click', async function () {
+      var statusEl = document.getElementById('page-fetch-status');
+      var resEl = document.getElementById('page-fetch-result');
+      statusEl.textContent = 'loading';
+      resEl.textContent = '';
+      try {
+        var res = await fetch('/api/data.json');
+        statusEl.textContent = String(res.status);
+        resEl.textContent = await res.text();
+      } catch (err) {
+        statusEl.textContent = 'error';
+        resEl.textContent = err.message;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/e2e-tests/fixtures/sw-app/sw-chaos.js
+++ b/e2e-tests/fixtures/sw-app/sw-chaos.js
@@ -1,0 +1,100 @@
+// Spike: SW with chaos shim baked in. Reads config from URL search param
+// `?config=<base64-encoded JSON>` so the test can pass arbitrary chaos config
+// at registration time without needing Playwright route interception.
+(function () {
+  try {
+    var search = (self.location && self.location.search) || '';
+    var match = /[?&]config=([^&]+)/.exec(search);
+    if (match) {
+      var json = atob(decodeURIComponent(match[1]));
+      self.__CHAOS_CONFIG__ = JSON.parse(json);
+    }
+  } catch {
+    self.__CHAOS_CONFIG__ = {};
+  }
+})();
+
+// --- Inlined chaos shim (mirrors spike/sw-chaos/sw-chaos-shim.js) ---
+(function () {
+  if (typeof self === 'undefined' || typeof self.fetch !== 'function') return;
+  if (self.__CHAOS_SW_INSTALLED__) return;
+  self.__CHAOS_SW_INSTALLED__ = true;
+
+  var config = self.__CHAOS_CONFIG__ || {};
+  var network = config.network || {};
+  var failures = Array.isArray(network.failures) ? network.failures : [];
+  var latencies = Array.isArray(network.latencies) ? network.latencies : [];
+
+  function urlMatches(rule, url) {
+    return typeof rule.urlPattern === 'string' && url.indexOf(rule.urlPattern) !== -1;
+  }
+  function methodMatches(rule, method) {
+    if (!rule.methods || !rule.methods.length) return true;
+    return rule.methods.indexOf(method.toUpperCase()) !== -1;
+  }
+  function shouldApply(rule) {
+    var p = typeof rule.probability === 'number' ? rule.probability : 1;
+    return Math.random() < p;
+  }
+  function emit(event) {
+    event.timestamp = Date.now();
+    event.context = 'service-worker';
+    self.clients.matchAll({ includeUncontrolled: true }).then(function (clients) {
+      clients.forEach(function (c) {
+        c.postMessage({ __chaosMakerSWEvent: true, event: event });
+      });
+    });
+  }
+
+  var originalFetch = self.fetch.bind(self);
+  self.fetch = function (input, init) {
+    var req = (input instanceof Request) ? input : new Request(input, init);
+    var url = req.url;
+    var method = req.method || 'GET';
+
+    for (var i = 0; i < failures.length; i++) {
+      var f = failures[i];
+      if (urlMatches(f, url) && methodMatches(f, method)) {
+        if (shouldApply(f)) {
+          emit({ type: 'network:failure', applied: true, detail: { url: url, method: method, statusCode: f.statusCode } });
+          return Promise.resolve(new Response(typeof f.body === 'string' ? f.body : '', {
+            status: f.statusCode,
+            statusText: f.statusText || 'Chaos',
+            headers: f.headers || {},
+          }));
+        } else {
+          emit({ type: 'network:failure', applied: false, detail: { url: url, method: method, reason: 'probability-skip' } });
+        }
+      }
+    }
+
+    var delayMs = 0;
+    for (var j = 0; j < latencies.length; j++) {
+      var l = latencies[j];
+      if (urlMatches(l, url) && methodMatches(l, method) && shouldApply(l)) {
+        delayMs = Math.max(delayMs, l.delayMs || 0);
+        emit({ type: 'network:latency', applied: true, detail: { url: url, method: method, delayMs: l.delayMs } });
+      }
+    }
+    if (delayMs > 0) {
+      return new Promise(function (resolve) { setTimeout(function () { resolve(originalFetch(input, init)); }, delayMs); });
+    }
+    return originalFetch(input, init);
+  };
+})();
+
+// --- Standard SW lifecycle + fetch routing ---
+self.addEventListener('install', function (event) {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', function (event) {
+  var url = new URL(event.request.url);
+  if (url.pathname.startsWith('/sw-app/sw-api/')) {
+    event.respondWith(self.fetch('/api/data.json'));
+  }
+});

--- a/e2e-tests/fixtures/sw-app/sw.js
+++ b/e2e-tests/fixtures/sw-app/sw.js
@@ -1,0 +1,22 @@
+// Plain service worker fixture. Intercepts fetches under /sw-app/sw-api/* and
+// proxies them upstream to the real fixture endpoint at /api/data.json.
+// Spike chaos shim is injected by the test runner via Playwright route rewrite
+// (prepended above this file's contents at request time).
+
+self.addEventListener('install', function (event) {
+  // Activate immediately so the spike test doesn't have to wait a refresh.
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', function (event) {
+  var url = new URL(event.request.url);
+  if (url.pathname.startsWith('/sw-app/sw-api/')) {
+    // Re-issue as a real fetch so chaos shim (which patches self.fetch) sees
+    // the call. Strip the SW namespace and hit the canonical fixture file.
+    event.respondWith(self.fetch('/api/data.json'));
+  }
+});

--- a/e2e-tests/playwright/playwright.config.ts
+++ b/e2e-tests/playwright/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
+  testIgnore: '**/spike/**',
   fullyParallel: true,
   reporter: [['html', { open: 'never' }]],
   use: {

--- a/e2e-tests/playwright/tests/spike/spike-sw-chaos.spec.ts
+++ b/e2e-tests/playwright/tests/spike/spike-sw-chaos.spec.ts
@@ -1,0 +1,91 @@
+// SPIKE — Service Worker chaos feasibility.
+//
+// Pivoted approach (after PW context.route fails to intercept SW script
+// registration on chromium): bake the chaos shim into a dedicated SW script
+// (`/sw-app/sw-chaos.js`) and pass chaos config via URL search param at
+// register time. This proves the in-SW interception mechanism works; the
+// production injection mechanism (importScripts vs build-time plugin vs
+// runtime route) is captured in SPIKE_NOTES_sw_chaos.md.
+//
+// Goal: a fetch issued from inside a Service Worker is intercepted by chaos
+// and returned as a synthetic 503; the chaos event is bridged back to the
+// page via postMessage.
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = 'http://127.0.0.1:8080';
+const SW_APP_URL = `${BASE_URL}/sw-app/`;
+
+const CHAOS_CONFIG = {
+  network: {
+    failures: [
+      { urlPattern: '/api/data.json', statusCode: 503, probability: 1.0, body: '{"chaos":true}' },
+    ],
+  },
+};
+
+async function ensureCleanSW(page: import('@playwright/test').Page) {
+  await page.evaluate(async () => {
+    if (!('serviceWorker' in navigator)) return;
+    const regs = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(regs.map(r => r.unregister()));
+    if ('caches' in self) {
+      const keys = await caches.keys();
+      await Promise.all(keys.map(k => caches.delete(k)));
+    }
+  }).catch(() => { /* page may not have SW API */ });
+}
+
+test.describe('SPIKE: Service Worker chaos via baked-in shim', () => {
+  test.afterEach(async ({ page }) => {
+    await ensureCleanSW(page);
+  });
+
+  test('SW-originated fetch is intercepted with synthetic 503', async ({ page, browserName }) => {
+    await page.goto(SW_APP_URL);
+    await ensureCleanSW(page);
+    await page.reload();
+
+    await page.evaluate(async (cfg) => {
+      await (window as any).__registerChaosSW(cfg);
+    }, CHAOS_CONFIG);
+    await expect(page.locator('#sw-state')).toHaveText('ready', { timeout: 10_000 });
+
+    await page.click('#sw-fetch');
+
+    await expect(page.locator('#sw-fetch-status')).toHaveText('503', { timeout: 5_000 });
+    await expect(page.locator('#sw-fetch-result')).toContainText('chaos');
+
+    const events = await page.evaluate(() => (window as any).__SW_CHAOS_EVENTS__ || []);
+    const failureEvents = events.filter((e: any) => e.type === 'network:failure' && e.applied);
+    expect(failureEvents.length, `browser=${browserName}, events=${JSON.stringify(events)}`).toBeGreaterThanOrEqual(1);
+    expect(failureEvents[0].context).toBe('service-worker');
+  });
+
+  test('SW-originated fetch latency is delayed', async ({ page }) => {
+    await page.goto(SW_APP_URL);
+    await ensureCleanSW(page);
+    await page.reload();
+
+    const latencyConfig = {
+      network: {
+        latencies: [{ urlPattern: '/api/data.json', delayMs: 1000, probability: 1.0 }],
+      },
+    };
+
+    await page.evaluate(async (cfg) => {
+      await (window as any).__registerChaosSW(cfg);
+    }, latencyConfig);
+    await expect(page.locator('#sw-state')).toHaveText('ready', { timeout: 10_000 });
+
+    const start = Date.now();
+    await page.click('#sw-fetch');
+    await expect(page.locator('#sw-fetch-status')).toHaveText('200', { timeout: 5_000 });
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+
+    const events = await page.evaluate(() => (window as any).__SW_CHAOS_EVENTS__ || []);
+    expect(events.some((e: any) => e.type === 'network:latency' && e.applied)).toBe(true);
+  });
+});

--- a/spike/sw-chaos/SPIKE_NOTES_sw_chaos.md
+++ b/spike/sw-chaos/SPIKE_NOTES_sw_chaos.md
@@ -1,7 +1,7 @@
 # Spike — Service Worker chaos feasibility
 
 **Date:** 2026-04-18
-**Branch:** `fix-playwright-webserver-npm-warnings`
+**Branch:** `chore/spike-cleanup` (merged to `main` via Phase 0 of v0.3.0)
 **Decision:** ✅ **GO for v0.4.0** with caveats below.
 
 ---
@@ -18,7 +18,7 @@ Determine whether chaos-maker can intercept `fetch` calls issued from inside a S
 Test artifacts:
 - Shim: `spike/sw-chaos/sw-chaos-shim.js` (standalone) and `e2e-tests/fixtures/sw-app/sw-chaos.js` (baked into fixture SW)
 - Fixture: `e2e-tests/fixtures/sw-app/{index.html, sw.js, sw-chaos.js}`
-- Test: `e2e-tests/playwright/tests/spike-sw-chaos.spec.ts` (2 tests × 4 browsers = 8 passes)
+- Test: `e2e-tests/playwright/tests/spike/spike-sw-chaos.spec.ts` (2 tests × 4 browsers = 8 passes)
 
 ## Approaches tried
 
@@ -115,10 +115,8 @@ Fits in v0.4.0 alongside SSE chaos and GraphQL matching if SSE = M and GraphQL =
 
 These become test cases in the real implementation, not blockers for the go/no-go.
 
-## Cleanup before merge to main
+## Disposition (merged to main)
 
-Spike artifacts to keep / remove:
-- ✅ Keep `spike/sw-chaos/sw-chaos-shim.js` + this notes file as historical record
-- ❌ Remove `e2e-tests/fixtures/sw-app/` after porting fixture into v0.4.0 implementation branch
-- ❌ Remove `e2e-tests/playwright/tests/spike-sw-chaos.spec.ts` after real SW chaos tests land
-- Spike test currently lives in main test dir → will run in CI. Either tag with `test.fixme` or move under separate spike testMatch before pushing if you want to keep CI green without committing to ship.
+- ✅ Kept `spike/sw-chaos/sw-chaos-shim.js` + this notes file as historical record.
+- ✅ Kept `e2e-tests/fixtures/sw-app/` as historical reference; to be superseded (not necessarily removed) when the v0.4.0 implementation lands.
+- ✅ Moved the spike spec to `e2e-tests/playwright/tests/spike/spike-sw-chaos.spec.ts` and excluded `**/spike/**` from default Playwright discovery via `testIgnore` in `e2e-tests/playwright/playwright.config.ts`. Spike is out of CI but runnable on demand: `pnpm --filter e2e-tests exec playwright test tests/spike/`.

--- a/spike/sw-chaos/SPIKE_NOTES_sw_chaos.md
+++ b/spike/sw-chaos/SPIKE_NOTES_sw_chaos.md
@@ -1,0 +1,124 @@
+# Spike — Service Worker chaos feasibility
+
+**Date:** 2026-04-18
+**Branch:** `fix-playwright-webserver-npm-warnings`
+**Decision:** ✅ **GO for v0.4.0** with caveats below.
+
+---
+
+## Goal
+Determine whether chaos-maker can intercept `fetch` calls issued from inside a Service Worker (SW) execution context, with the same observability guarantees as page-context chaos.
+
+## Result
+- All four browsers pass (chromium, firefox, webkit, edge — Playwright 1.45)
+- Both `network:failure` and `network:latency` rules apply correctly to fetches issued by SW
+- Chaos events bridge from SW → page via `postMessage` and are observable on `window.__SW_CHAOS_EVENTS__`
+- No JSON-parse / scope / lifecycle issues encountered
+
+Test artifacts:
+- Shim: `spike/sw-chaos/sw-chaos-shim.js` (standalone) and `e2e-tests/fixtures/sw-app/sw-chaos.js` (baked into fixture SW)
+- Fixture: `e2e-tests/fixtures/sw-app/{index.html, sw.js, sw-chaos.js}`
+- Test: `e2e-tests/playwright/tests/spike-sw-chaos.spec.ts` (2 tests × 4 browsers = 8 passes)
+
+## Approaches tried
+
+### Option B (PW route rewrite of SW script) — REJECTED
+Tried `page.route('**/sw.js')` then `context.route('**/sw.js')`. Neither intercepted the SW registration request in chromium under Playwright 1.45 — `route` callback never fired (`routeHits === 0`). SW script registration goes through a network path Playwright's request interception does not cover.
+
+**Implication:** chaos-maker cannot transparently inject its shim into a user's existing SW at test runtime via Playwright routing. Must ship a user-facing injection mechanism.
+
+### Option (chosen) — Baked-in shim + URL-encoded config
+SW script (`sw-chaos.js`) inlines the chaos shim. Config passed via `?config=<base64-JSON>` URL search param so SW can read it at install time without window access. Page registers the SW and triggers fetches; SW's patched `self.fetch` short-circuits with synthetic responses or applies delays; chaos events postMessage back to page.
+
+This proves the **interception mechanism** works. The **injection mechanism** is the open product question (see Recommendation).
+
+## Cross-browser notes
+| Browser | Failure test | Latency test | Notes |
+|---|---|---|---|
+| chromium | ✅ | ✅ | Sometimes serves `/sw-app/` from 304; cleared via `ensureCleanSW` + reload |
+| firefox  | ✅ | ✅ | No issues |
+| webkit   | ✅ | ✅ | No issues |
+| edge     | ✅ | ✅ | Identical behavior to chromium |
+
+Total run: 8 passes in ~10s wall time (chromium 2.7s + ff/wk 3.9s + edge 2.6s).
+
+## Production design — Recommendation
+
+### Shape of the v0.4.0 SW chaos package
+
+**Refactor required:** core uses `window.fetch`/`window.XMLHttpRequest`/`window.WebSocket` directly. SW global is `self`, no `window`. Need a build target that uses `globalThis` (or `self`) — split build or runtime guard.
+
+**Proposed packages:**
+- `@chaos-maker/core` — refactor interceptors to read globals from `globalThis` so the same code runs in window and SW contexts. Keep public API identical for window users.
+- `@chaos-maker/core/sw` — published subpath export. Bundle of just network interceptors (no UI, no DOM-dependent code). Exposes `installChaosSW({ source: 'message' | 'self.__CHAOS_CONFIG__' })`.
+- `@chaos-maker/playwright` (and `@chaos-maker/cypress`) — adds `injectSWChaos(page, config)` helper that:
+  1. Waits for `navigator.serviceWorker.controller` to exist
+  2. `controller.postMessage({ __chaosMakerConfig: config })`
+  3. Returns when SW acks (also via postMessage) — so first chaos-relevant fetch isn't lost
+
+### User integration (one line in their SW)
+```js
+// user's sw.js
+importScripts('https://cdn.jsdelivr.net/npm/@chaos-maker/core/dist/sw.js');
+// or vendored locally, served same-origin
+```
+Then in test:
+```ts
+await injectSWChaos(page, config);
+```
+
+### Why not transparent injection?
+Three options considered, all rejected for v0.4.0:
+
+1. **PW route rewrite** — proven not to fire for SW script registration (this spike).
+2. **Patch `navigator.serviceWorker.register` via addInitScript** to wrap the script source through a Blob URL — Blob URLs cannot register SWs with custom scopes; the `Service-Worker-Allowed` header workaround requires HTTP response headers, not blob URLs.
+3. **Build-time plugin** (Webpack/Vite/Rollup) — viable but adds 3+ adapter packages to maintain and ties chaos to user's build pipeline. Defer to v0.5.0 if demand emerges.
+
+The one-line `importScripts` requirement is honest, well-scoped, and matches how MSW handles SW. Documentation can stress that this is a test-build-only change.
+
+## Risks for production
+
+| Risk | Mitigation |
+|---|---|
+| Config arrives async via `postMessage` after SW install — first fetches race | Buffer events until first config message; document `await injectSWChaos()` must precede `page.goto` |
+| Module workers (`type: 'module'`) reject `importScripts` | Ship parallel ESM-import shim variant; document both |
+| Cross-origin SWs (third-party widgets) | Out of scope — document; chaos is opt-in per origin |
+| SW lifecycle (skipWaiting / claim / update) eats config | Re-emit config on `controllerchange`; ack required |
+| Caches API hides chaos (cached responses bypass `self.fetch`) | Also patch `caches.match` / `cache.match`? Document as later work |
+| Large bundle in SW (Zod, etc.) | Strip Zod at runtime in SW build; config validated on page side before postMessage |
+| User's existing `self.fetch` patches collide with chaos | Document precedence: install chaos last, restore on stop |
+
+## Effort estimate for v0.4.0
+
+| Work | Effort |
+|---|---|
+| Refactor core globals to `globalThis` (window-aware paths gated by `typeof window`) | M (2-3 days, careful — touches fetch + xhr + ws interceptors) |
+| New `@chaos-maker/core/sw` subpath build (rollup config, separate entry) | S (1 day) |
+| `installChaosSW` API + postMessage protocol + ack handshake | M (2 days) |
+| Playwright `injectSWChaos` helper + `getSWChaosLog` | S (1 day) |
+| Cypress `cy.injectSWChaos` command | S (1 day) |
+| E2E suite (port spike to real packages, add cache + lifecycle + module-worker tests) | M (2-3 days) |
+| Docs section + recipe | S (1 day) |
+| **Total** | **~10 dev days** |
+
+Fits in v0.4.0 alongside SSE chaos and GraphQL matching if SSE = M and GraphQL = S. Tight but doable.
+
+## What this spike did NOT cover (deferred)
+
+- `caches` API interaction (cached SW responses bypass `self.fetch`)
+- Module SWs (`type: 'module'`) — `importScripts` unsupported, need ESM path
+- SW updates with new chaos config (`controllerchange` event handling)
+- Multiple controlled clients (one config to N pages)
+- `WebSocket` chaos in SW (does SW even use WS? yes via `self.WebSocket`)
+- Push events / sync events (out of scope for v0.4.0)
+- CSP `worker-src` restrictions
+
+These become test cases in the real implementation, not blockers for the go/no-go.
+
+## Cleanup before merge to main
+
+Spike artifacts to keep / remove:
+- ✅ Keep `spike/sw-chaos/sw-chaos-shim.js` + this notes file as historical record
+- ❌ Remove `e2e-tests/fixtures/sw-app/` after porting fixture into v0.4.0 implementation branch
+- ❌ Remove `e2e-tests/playwright/tests/spike-sw-chaos.spec.ts` after real SW chaos tests land
+- Spike test currently lives in main test dir → will run in CI. Either tag with `test.fixme` or move under separate spike testMatch before pushing if you want to keep CI green without committing to ship.

--- a/spike/sw-chaos/sw-chaos-shim.js
+++ b/spike/sw-chaos/sw-chaos-shim.js
@@ -1,0 +1,98 @@
+// SPIKE: minimal Service Worker chaos shim.
+// Patches `self.fetch` inside a Service Worker context. Reads config from
+// `self.__CHAOS_CONFIG__`, supports network.failures + network.latencies only
+// (enough to prove feasibility). Bridges chaos events back to all controlled
+// clients via postMessage so the test runner can read them via window.
+//
+// This is NOT a production module — the goal is feasibility validation for
+// v0.4.0 planning. Do not import from packages/.
+(function () {
+  if (typeof self === 'undefined' || typeof self.fetch !== 'function') return;
+  if (self.__CHAOS_SW_INSTALLED__) return;
+  self.__CHAOS_SW_INSTALLED__ = true;
+
+  var config = self.__CHAOS_CONFIG__ || {};
+  var network = config.network || {};
+  var failures = Array.isArray(network.failures) ? network.failures : [];
+  var latencies = Array.isArray(network.latencies) ? network.latencies : [];
+
+  function urlMatches(rule, url) {
+    return typeof rule.urlPattern === 'string' && url.indexOf(rule.urlPattern) !== -1;
+  }
+
+  function methodMatches(rule, method) {
+    if (!rule.methods || !rule.methods.length) return true;
+    return rule.methods.indexOf(method.toUpperCase()) !== -1;
+  }
+
+  function shouldApply(rule) {
+    var p = typeof rule.probability === 'number' ? rule.probability : 1;
+    return Math.random() < p;
+  }
+
+  function emit(event) {
+    event.timestamp = Date.now();
+    event.context = 'service-worker';
+    self.clients.matchAll({ includeUncontrolled: true }).then(function (clients) {
+      clients.forEach(function (c) {
+        c.postMessage({ __chaosMakerSWEvent: true, event: event });
+      });
+    });
+  }
+
+  var originalFetch = self.fetch.bind(self);
+
+  self.fetch = function (input, init) {
+    var req = (input instanceof Request) ? input : new Request(input, init);
+    var url = req.url;
+    var method = req.method || 'GET';
+
+    // Failure rules
+    for (var i = 0; i < failures.length; i++) {
+      var f = failures[i];
+      if (urlMatches(f, url) && methodMatches(f, method)) {
+        if (shouldApply(f)) {
+          emit({
+            type: 'network:failure',
+            applied: true,
+            detail: { url: url, method: method, statusCode: f.statusCode },
+          });
+          var body = typeof f.body === 'string' ? f.body : '';
+          return Promise.resolve(new Response(body, {
+            status: f.statusCode,
+            statusText: f.statusText || 'Chaos',
+            headers: f.headers || {},
+          }));
+        } else {
+          emit({
+            type: 'network:failure',
+            applied: false,
+            detail: { url: url, method: method, reason: 'probability-skip' },
+          });
+        }
+      }
+    }
+
+    // Latency rules
+    var delayMs = 0;
+    for (var j = 0; j < latencies.length; j++) {
+      var l = latencies[j];
+      if (urlMatches(l, url) && methodMatches(l, method) && shouldApply(l)) {
+        delayMs = Math.max(delayMs, l.delayMs || 0);
+        emit({
+          type: 'network:latency',
+          applied: true,
+          detail: { url: url, method: method, delayMs: l.delayMs },
+        });
+      }
+    }
+
+    if (delayMs > 0) {
+      return new Promise(function (resolve) {
+        setTimeout(function () { resolve(originalFetch(input, init)); }, delayMs);
+      });
+    }
+
+    return originalFetch(input, init);
+  };
+})();


### PR DESCRIPTION
## Summary
- Moves `spike-sw-chaos.spec.ts` into `tests/spike/` and adds `testIgnore: '**/spike/**'` to `playwright.config.ts` so spike tests never run in CI.
- Commits SW-chaos spike fixtures (`e2e-tests/fixtures/sw-app/`) and notes (`spike/sw-chaos/`) as historical reference (documented feasibility for v0.4.0 SW chaos).
- README `Development` section grows a short `Spikes` note describing the convention.

## Context
Phase 0 of [RELEASE_PLAN_v0.3.0.md](./RELEASE_PLAN_v0.3.0.md). Prereq for all subsequent v0.3.0 phases (WDIO adapter, Puppeteer adapter, docs site, determinism audit).

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 187/187 unit tests pass
- [x] `pnpm build` green across core/playwright/cypress
- [x] Playwright chromium project: 62/62 passed; spike test absent from list (`testIgnore` works)
- [ ] CI: all 4 browser projects + cypress + build green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added experimental service worker chaos testing infrastructure with test fixtures and E2E test suite.
  * Updated test configuration to exclude experimental spike tests from default test runs.

* **Documentation**
  * Added documentation and setup guidance for experimental service worker chaos testing, including design notes and on-demand execution instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->