### PR TITLE
feat(puppeteer): add @chaos-maker/puppeteer adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
             packages/playwright/dist/
             packages/cypress/dist/
             packages/webdriverio/dist/
+            packages/puppeteer/dist/
 
   e2e-playwright:
     name: E2E Playwright (${{ matrix.project }})
@@ -268,3 +269,43 @@ jobs:
         env:
           WDIO_BROWSER: ${{ matrix.browser }}
         run: pnpm --filter e2e-tests-webdriverio test
+
+  e2e-puppeteer:
+    name: E2E Puppeteer (headless-new)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: chaos-maker-dist
+          path: packages
+
+      - name: Cache Puppeteer Chrome
+        id: puppeteer-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/puppeteer
+          key: puppeteer-${{ hashFiles('e2e-tests/puppeteer/package.json') }}
+
+      - name: Install Puppeteer Chrome
+        if: steps.puppeteer-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter e2e-tests-puppeteer exec node -e "const p = require('puppeteer'); p.executablePath && console.log(p.executablePath())" 2>/dev/null || pnpm exec puppeteer browsers install chrome
+
+      - name: Run Puppeteer E2E Tests
+        run: pnpm --filter e2e-tests-puppeteer test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,16 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
 
+      - name: Cache Puppeteer Chrome
+        id: puppeteer-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/puppeteer
+          key: puppeteer-${{ hashFiles('e2e-tests/puppeteer/package.json', 'pnpm-lock.yaml') }}
+
       - name: Install Dependencies
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
         run: pnpm install
 
       - name: Download Build Artifact
@@ -296,16 +305,9 @@ jobs:
           name: chaos-maker-dist
           path: packages
 
-      - name: Cache Puppeteer Chrome
-        id: puppeteer-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/puppeteer
-          key: puppeteer-${{ hashFiles('e2e-tests/puppeteer/package.json') }}
-
       - name: Install Puppeteer Chrome
         if: steps.puppeteer-cache.outputs.cache-hit != 'true'
-        run: pnpm --filter e2e-tests-puppeteer exec node -e "const p = require('puppeteer'); p.executablePath && console.log(p.executablePath())" 2>/dev/null || pnpm --filter e2e-tests-puppeteer exec puppeteer browsers install chrome
+        run: pnpm --filter e2e-tests-puppeteer exec puppeteer browsers install chrome
 
       - name: Run Puppeteer E2E Tests
         run: pnpm --filter e2e-tests-puppeteer test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
 
       - name: Install Puppeteer Chrome
         if: steps.puppeteer-cache.outputs.cache-hit != 'true'
-        run: pnpm --filter e2e-tests-puppeteer exec node -e "const p = require('puppeteer'); p.executablePath && console.log(p.executablePath())" 2>/dev/null || pnpm exec puppeteer browsers install chrome
+        run: pnpm --filter e2e-tests-puppeteer exec node -e "const p = require('puppeteer'); p.executablePath && console.log(p.executablePath())" 2>/dev/null || pnpm --filter e2e-tests-puppeteer exec puppeteer browsers install chrome
 
       - name: Run Puppeteer E2E Tests
         run: pnpm --filter e2e-tests-puppeteer test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,20 @@ jobs:
           WDIO_BROWSER: chrome
         run: pnpm --filter e2e-tests-webdriverio test
 
+      - name: Cache Puppeteer Chrome
+        id: puppeteer-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/puppeteer
+          key: puppeteer-${{ hashFiles('e2e-tests/puppeteer/package.json') }}
+
+      - name: Install Puppeteer Chrome
+        if: steps.puppeteer-cache.outputs.cache-hit != 'true'
+        run: pnpm exec puppeteer browsers install chrome
+
+      - name: Puppeteer E2E Tests
+        run: pnpm --filter e2e-tests-puppeteer test
+
   publish-core:
     name: Publish @chaos-maker/core
     runs-on: ubuntu-latest
@@ -200,3 +214,33 @@ jobs:
 
       - name: Publish WebdriverIO Adapter
         run: pnpm --filter @chaos-maker/webdriverio publish --no-git-checks --access public
+
+  publish-puppeteer:
+    name: Publish @chaos-maker/puppeteer
+    runs-on: ubuntu-latest
+    needs: publish-core
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Puppeteer
+        run: pnpm build:core && pnpm build:puppeteer
+
+      - name: Publish Puppeteer Adapter
+        run: pnpm --filter @chaos-maker/puppeteer publish --no-git-checks --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Lint
@@ -86,11 +88,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/puppeteer
-          key: puppeteer-${{ hashFiles('e2e-tests/puppeteer/package.json') }}
+          key: puppeteer-${{ hashFiles('e2e-tests/puppeteer/package.json', 'pnpm-lock.yaml') }}
 
       - name: Install Puppeteer Chrome
         if: steps.puppeteer-cache.outputs.cache-hit != 'true'
-        run: pnpm exec puppeteer browsers install chrome
+        run: pnpm --filter e2e-tests-puppeteer exec puppeteer browsers install chrome
 
       - name: Puppeteer E2E Tests
         run: pnpm --filter e2e-tests-puppeteer test

--- a/e2e-tests/puppeteer/package.json
+++ b/e2e-tests/puppeteer/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "e2e-tests-puppeteer",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@chaos-maker/core": "workspace:*",
+    "@chaos-maker/puppeteer": "workspace:*",
+    "http-server": "^14.1.1",
+    "puppeteer": "^22.0.0",
+    "typescript": "^5.4.5",
+    "vitest": "^3.2.4",
+    "ws": "^8.17.0"
+  }
+}

--- a/e2e-tests/puppeteer/setup/global-setup.ts
+++ b/e2e-tests/puppeteer/setup/global-setup.ts
@@ -1,0 +1,60 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createConnection } from 'node:net';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = resolve(__dirname, '../../fixtures');
+const PNPM_BIN = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+
+let httpServer: ChildProcess | null = null;
+let wsServer: ChildProcess | null = null;
+
+function probeTcp(host: string, port: number, timeoutMs = 500): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port });
+    const done = (ok: boolean) => { socket.destroy(); resolve(ok); };
+    socket.once('connect', () => done(true));
+    socket.once('error', () => done(false));
+    socket.setTimeout(timeoutMs, () => done(false));
+  });
+}
+
+async function waitForTcp(host: string, port: number, timeoutMs = 20_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await probeTcp(host, port)) return;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`Server at ${host}:${port} did not start within ${timeoutMs}ms`);
+}
+
+export async function setup(): Promise<void> {
+  const httpReady = await probeTcp('127.0.0.1', 8080);
+  const wsReady = await probeTcp('127.0.0.1', 8081);
+
+  if (!httpReady) {
+    httpServer = spawn(
+      PNPM_BIN,
+      ['exec', 'http-server', FIXTURES, '-p', '8080', '-s'],
+      { stdio: 'inherit' },
+    );
+    await waitForTcp('127.0.0.1', 8080);
+  }
+
+  if (!wsReady) {
+    wsServer = spawn(
+      'node',
+      [resolve(FIXTURES, 'ws-echo-server.cjs')],
+      { stdio: 'inherit' },
+    );
+    await waitForTcp('127.0.0.1', 8081);
+  }
+}
+
+export async function teardown(): Promise<void> {
+  httpServer?.kill();
+  wsServer?.kill();
+  httpServer = null;
+  wsServer = null;
+}

--- a/e2e-tests/puppeteer/tests/chaos-lifecycle.test.ts
+++ b/e2e-tests/puppeteer/tests/chaos-lifecycle.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Browser, Page } from 'puppeteer';
+import { injectChaos, removeChaos, getChaosLog, getChaosSeed } from '@chaos-maker/puppeteer';
+import { presets } from '@chaos-maker/core';
+import type { ChaosEvent } from '@chaos-maker/core';
+import { launchBrowser, BASE_URL, API_PATTERN, makeRequest } from './helpers';
+
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => { browser = await launchBrowser(); });
+afterAll(async () => { await browser.close(); });
+
+beforeEach(async () => { page = await browser.newPage(); });
+afterEach(async () => { await page.close(); });
+
+describe('Chaos lifecycle', () => {
+  it('removeChaos restores normal fetch behavior', async () => {
+    await injectChaos(page, {
+      network: { failures: [{ urlPattern: API_PATTERN, statusCode: 500, probability: 1.0 }] },
+    });
+    await page.goto(BASE_URL);
+    expect(await makeRequest(page)).toBe('Error!');
+
+    await removeChaos(page);
+
+    await page.click('#fetch-data');
+    await page.waitForFunction(
+      () => document.getElementById('status')?.textContent !== 'Loading...' &&
+            document.getElementById('status')?.textContent !== '',
+      { timeout: 10_000 },
+    );
+    expect(await page.$eval('#status', (el) => el.textContent)).toBe('Success!');
+  });
+
+  it('chaos log captures events with correct structure', async () => {
+    await injectChaos(page, {
+      network: { failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0 }] },
+    });
+    await page.goto(BASE_URL);
+    await makeRequest(page);
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    expect(log.length).toBeGreaterThan(0);
+    for (const event of log) {
+      expect(event).toHaveProperty('type');
+      expect(event).toHaveProperty('timestamp');
+      expect(event).toHaveProperty('applied');
+      expect(event).toHaveProperty('detail');
+      expect(typeof event.timestamp).toBe('number');
+      expect(typeof event.applied).toBe('boolean');
+    }
+  });
+
+  it('chaos log records URL and method in event detail', async () => {
+    await injectChaos(page, {
+      network: { failures: [{ urlPattern: API_PATTERN, statusCode: 500, probability: 1.0 }] },
+    });
+    await page.goto(BASE_URL);
+    await makeRequest(page);
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    const evt = log.find((e) => e.type === 'network:failure' && e.applied);
+    expect(evt).toBeDefined();
+    expect(evt!.detail.url).toContain(API_PATTERN);
+    expect(evt!.detail.method).toBe('GET');
+    expect(evt!.detail.statusCode).toBe(500);
+  });
+
+  it('multiple network chaos rules work simultaneously', async () => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0 }],
+        latencies: [{ urlPattern: '/no-match', delayMs: 100, probability: 1.0 }],
+      },
+    });
+    await page.goto(BASE_URL);
+    await makeRequest(page);
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    expect(log.some((e) => e.type === 'network:failure')).toBe(true);
+  });
+
+  it('getChaosSeed returns a finite number once chaos is injected', async () => {
+    await injectChaos(page, {
+      network: { failures: [{ urlPattern: API_PATTERN, statusCode: 500, probability: 1.0 }] },
+    });
+    await page.goto(BASE_URL);
+
+    const seed = await getChaosSeed(page);
+    expect(seed).not.toBeNull();
+    expect(Number.isFinite(seed)).toBe(true);
+  });
+
+  it('unstableApi preset emits network events', async () => {
+    await injectChaos(page, presets.unstableApi);
+    await page.goto(BASE_URL);
+    await makeRequest(page);
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    expect(log.some((e) => e.type === 'network:failure' || e.type === 'network:latency')).toBe(true);
+  });
+});

--- a/e2e-tests/puppeteer/tests/chaos-lifecycle.test.ts
+++ b/e2e-tests/puppeteer/tests/chaos-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import type { Browser, Page } from 'puppeteer';
 import { injectChaos, removeChaos, getChaosLog, getChaosSeed } from '@chaos-maker/puppeteer';
 import { presets } from '@chaos-maker/core';

--- a/e2e-tests/puppeteer/tests/helpers.ts
+++ b/e2e-tests/puppeteer/tests/helpers.ts
@@ -1,0 +1,61 @@
+import puppeteer, { type Browser, type Page } from 'puppeteer';
+
+export const BASE_URL = 'http://127.0.0.1:8080';
+export const API_PATTERN = '/api/data.json';
+export const WS_URL_PATTERN = '127.0.0.1:8081';
+
+export async function launchBrowser(): Promise<Browser> {
+  return puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  });
+}
+
+export async function getText(page: Page, selector: string): Promise<string> {
+  return page.$eval(selector, (el) => el.textContent ?? '');
+}
+
+export async function waitForText(
+  page: Page,
+  selector: string,
+  text: string,
+  timeout = 10_000,
+): Promise<void> {
+  await page.waitForFunction(
+    (sel: string, t: string) => {
+      const el = document.querySelector(sel);
+      return el?.textContent === t;
+    },
+    { timeout },
+    selector,
+    text,
+  );
+}
+
+export async function waitForNotText(
+  page: Page,
+  selector: string,
+  text: string,
+  timeout = 10_000,
+): Promise<void> {
+  await page.waitForFunction(
+    (sel: string, t: string) => {
+      const el = document.querySelector(sel);
+      return el !== null && el.textContent !== t;
+    },
+    { timeout },
+    selector,
+    text,
+  );
+}
+
+/** Click a fetch/XHR button and wait for the status to leave Loading state. */
+export async function makeRequest(
+  page: Page,
+  buttonSelector = '#fetch-data',
+  statusSelector = '#status',
+): Promise<string> {
+  await page.click(buttonSelector);
+  await waitForNotText(page, statusSelector, 'Loading...');
+  return getText(page, statusSelector);
+}

--- a/e2e-tests/puppeteer/tests/network-fetch.test.ts
+++ b/e2e-tests/puppeteer/tests/network-fetch.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Browser, Page } from 'puppeteer';
+import { injectChaos, getChaosLog } from '@chaos-maker/puppeteer';
+import type { ChaosEvent } from '@chaos-maker/core';
+import { launchBrowser, BASE_URL, API_PATTERN, makeRequest, getText } from './helpers';
+
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => { browser = await launchBrowser(); });
+afterAll(async () => { await browser.close(); });
+
+beforeEach(async () => { page = await browser.newPage(); });
+afterEach(async () => { await page.close(); });
+
+describe('Network failures (fetch)', () => {
+  it('injects 503 failure', async () => {
+    await injectChaos(page, {
+      network: { failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0 }] },
+    });
+    await page.goto(BASE_URL);
+    expect(await makeRequest(page)).toBe('Error!');
+    const result = await getText(page, '#result');
+    expect(result).toContain('503');
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    expect(log.some((e) => e.type === 'network:failure' && e.applied)).toBe(true);
+  });
+
+  it('passes through when probability is 0', async () => {
+    await injectChaos(page, {
+      network: { failures: [{ urlPattern: API_PATTERN, statusCode: 500, probability: 0 }] },
+    });
+    await page.goto(BASE_URL);
+    expect(await makeRequest(page)).toBe('Success!');
+  });
+
+  it('does not affect non-matching URLs', async () => {
+    await injectChaos(page, {
+      network: { failures: [{ urlPattern: '/no-match', statusCode: 500, probability: 1.0 }] },
+    });
+    await page.goto(BASE_URL);
+    expect(await makeRequest(page)).toBe('Success!');
+  });
+
+  it('applies failure only to POST, not GET', async () => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 500, probability: 1.0, methods: ['POST'] }],
+      },
+    });
+    await page.goto(BASE_URL);
+    expect(await makeRequest(page, '#fetch-data', '#status')).toBe('Success!');
+    expect(await makeRequest(page, '#fetch-post', '#status')).toBe('Error!');
+  });
+});
+
+describe('Network latency (fetch)', () => {
+  it('adds delay and logs latency event', async () => {
+    const delayMs = 500;
+    await injectChaos(page, {
+      network: { latencies: [{ urlPattern: API_PATTERN, delayMs, probability: 1.0 }] },
+    });
+    await page.goto(BASE_URL);
+
+    const t0 = Date.now();
+    await makeRequest(page);
+    const elapsed = Date.now() - t0;
+    expect(elapsed).toBeGreaterThanOrEqual(delayMs - 100);
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    const evt = log.find((e) => e.type === 'network:latency' && e.applied);
+    expect(evt).toBeDefined();
+    expect(evt!.detail.delayMs).toBe(delayMs);
+  });
+});
+
+describe('Network abort (fetch)', () => {
+  it('aborts request and logs abort event', async () => {
+    await injectChaos(page, {
+      network: { aborts: [{ urlPattern: API_PATTERN, probability: 1.0 }] },
+    });
+    await page.goto(BASE_URL);
+    expect(await makeRequest(page)).toBe('Error!');
+    const result = await getText(page, '#result');
+    expect(result.toLowerCase()).toMatch(/abort|failed/);
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    expect(log.some((e) => e.type === 'network:abort' && e.applied)).toBe(true);
+  });
+});
+
+describe('Response corruption (fetch)', () => {
+  it('truncates response body', async () => {
+    await injectChaos(page, {
+      network: {
+        corruptions: [{ urlPattern: API_PATTERN, strategy: 'truncate', probability: 1.0 }],
+      },
+    });
+    await page.goto(BASE_URL);
+    expect(await makeRequest(page)).toBe('Parse Error!');
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    expect(log.some((e) => e.type === 'network:corruption' && e.applied)).toBe(true);
+  });
+
+  it('injects malformed JSON', async () => {
+    await injectChaos(page, {
+      network: {
+        corruptions: [{ urlPattern: API_PATTERN, strategy: 'malformed-json', probability: 1.0 }],
+      },
+    });
+    await page.goto(BASE_URL);
+    expect(await makeRequest(page)).toBe('Parse Error!');
+  });
+});

--- a/e2e-tests/puppeteer/tests/network-xhr.test.ts
+++ b/e2e-tests/puppeteer/tests/network-xhr.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Browser, Page } from 'puppeteer';
+import { injectChaos, getChaosLog } from '@chaos-maker/puppeteer';
+import type { ChaosEvent } from '@chaos-maker/core';
+import { launchBrowser, BASE_URL, API_PATTERN, makeRequest } from './helpers';
+
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => { browser = await launchBrowser(); });
+afterAll(async () => { await browser.close(); });
+
+beforeEach(async () => { page = await browser.newPage(); });
+afterEach(async () => { await page.close(); });
+
+describe('Network failures (XHR)', () => {
+  it('injects 500 failure on XHR GET', async () => {
+    await injectChaos(page, {
+      network: { failures: [{ urlPattern: API_PATTERN, statusCode: 500, probability: 1.0 }] },
+    });
+    await page.goto(BASE_URL);
+    expect(await makeRequest(page, '#xhr-get', '#xhr-status')).toBe('Error!');
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    expect(log.some((e) => e.type === 'network:failure' && e.applied)).toBe(true);
+  });
+
+  it('aborts XHR request', async () => {
+    await injectChaos(page, {
+      network: { aborts: [{ urlPattern: API_PATTERN, probability: 1.0 }] },
+    });
+    await page.goto(BASE_URL);
+    const status = await makeRequest(page, '#xhr-get', '#xhr-status');
+    expect(['Error!', 'Aborted!']).toContain(status);
+  });
+
+  it('CORS failure on XHR', async () => {
+    await injectChaos(page, {
+      network: { cors: [{ urlPattern: API_PATTERN, probability: 1.0 }] },
+    });
+    await page.goto(BASE_URL);
+    const status = await makeRequest(page, '#xhr-get', '#xhr-status');
+    expect(status).toBe('Error!');
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    expect(log.some((e) => e.type === 'network:cors' && e.applied)).toBe(true);
+  });
+
+  it('passes through when probability is 0', async () => {
+    await injectChaos(page, {
+      network: { failures: [{ urlPattern: API_PATTERN, statusCode: 500, probability: 0 }] },
+    });
+    await page.goto(BASE_URL);
+    expect(await makeRequest(page, '#xhr-get', '#xhr-status')).toBe('Success!');
+  });
+
+  it('XHR and fetch share the chaos config', async () => {
+    await injectChaos(page, {
+      network: { failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0 }] },
+    });
+    await page.goto(BASE_URL);
+    expect(await makeRequest(page, '#fetch-data', '#status')).toBe('Error!');
+    expect(await makeRequest(page, '#xhr-get', '#xhr-status')).toBe('Error!');
+  });
+});

--- a/e2e-tests/puppeteer/tests/network-xhr.test.ts
+++ b/e2e-tests/puppeteer/tests/network-xhr.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import type { Browser, Page } from 'puppeteer';
 import { injectChaos, getChaosLog } from '@chaos-maker/puppeteer';
 import type { ChaosEvent } from '@chaos-maker/core';

--- a/e2e-tests/puppeteer/tests/nth-counting.test.ts
+++ b/e2e-tests/puppeteer/tests/nth-counting.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Browser, Page } from 'puppeteer';
+import { injectChaos } from '@chaos-maker/puppeteer';
+import { launchBrowser, BASE_URL, API_PATTERN, makeRequest } from './helpers';
+
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => { browser = await launchBrowser(); });
+afterAll(async () => { await browser.close(); });
+
+beforeEach(async () => { page = await browser.newPage(); });
+afterEach(async () => { await page.close(); });
+
+describe('onNth counting', () => {
+  it('fetch: fails only on the 3rd request', async () => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0, onNth: 3 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    const r1 = await makeRequest(page);
+    const r2 = await makeRequest(page);
+    const r3 = await makeRequest(page);
+    const r4 = await makeRequest(page);
+
+    expect(r1).toBe('Success!');
+    expect(r2).toBe('Success!');
+    expect(r3).toBe('Error!');
+    expect(r4).toBe('Success!');
+  });
+
+  it('XHR: fails only on the 2nd request', async () => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0, onNth: 2 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    const r1 = await makeRequest(page, '#xhr-get', '#xhr-status');
+    const r2 = await makeRequest(page, '#xhr-get', '#xhr-status');
+    const r3 = await makeRequest(page, '#xhr-get', '#xhr-status');
+
+    expect(r1).toBe('Success!');
+    expect(r2).toBe('Error!');
+    expect(r3).toBe('Success!');
+  });
+});
+
+describe('everyNth counting', () => {
+  it('fetch: fails on every 2nd request', async () => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0, everyNth: 2 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    const results: string[] = [];
+    for (let i = 0; i < 6; i++) {
+      results.push(await makeRequest(page) as string);
+    }
+
+    expect(results[0]).toBe('Success!');
+    expect(results[1]).toBe('Error!');
+    expect(results[2]).toBe('Success!');
+    expect(results[3]).toBe('Error!');
+    expect(results[4]).toBe('Success!');
+    expect(results[5]).toBe('Error!');
+  });
+});
+
+describe('afterN counting', () => {
+  it('fetch: first 2 succeed, all subsequent fail', async () => {
+    await injectChaos(page, {
+      network: {
+        failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0, afterN: 2 }],
+      },
+    });
+    await page.goto(BASE_URL);
+
+    const results: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      results.push(await makeRequest(page) as string);
+    }
+
+    expect(results[0]).toBe('Success!');
+    expect(results[1]).toBe('Success!');
+    expect(results[2]).toBe('Error!');
+    expect(results[3]).toBe('Error!');
+    expect(results[4]).toBe('Error!');
+  });
+});

--- a/e2e-tests/puppeteer/tests/resilience.test.ts
+++ b/e2e-tests/puppeteer/tests/resilience.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Browser, Page } from 'puppeteer';
+import { launchBrowser, BASE_URL, makeRequest, waitForText } from './helpers';
+
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => { browser = await launchBrowser(); });
+afterAll(async () => { await browser.close(); });
+
+beforeEach(async () => { page = await browser.newPage(); });
+afterEach(async () => { await page.close(); });
+
+describe('Resilience baseline', () => {
+  it('fixture loads and fetch returns Success without chaos', async () => {
+    await page.goto(BASE_URL);
+    const status = await makeRequest(page);
+    expect(status).toBe('Success!');
+  });
+
+  it('WebSocket echo server responds without chaos', async () => {
+    await page.goto(BASE_URL);
+    await page.click('#ws-connect');
+    await waitForText(page, '#ws-status', 'open');
+    await page.click('#ws-send');
+    await page.waitForFunction(
+      () => Number(document.getElementById('ws-inbound-count')?.textContent) === 1,
+      { timeout: 5_000 },
+    );
+    const count = await page.$eval('#ws-inbound-count', (el) => el.textContent);
+    expect(count).toBe('1');
+  });
+});

--- a/e2e-tests/puppeteer/tests/seeded-randomness.test.ts
+++ b/e2e-tests/puppeteer/tests/seeded-randomness.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import type { Browser, Page } from 'puppeteer';
 import { injectChaos, getChaosLog, getChaosSeed } from '@chaos-maker/puppeteer';
 import type { ChaosEvent } from '@chaos-maker/core';
 import { launchBrowser, BASE_URL, API_PATTERN, makeRequest } from './helpers';
 
 const SEED = 42;
+const SEED_TRIALS = 10;
 
 let browser: Browser;
 let page: Page;
@@ -21,7 +22,7 @@ async function runWithSeed(p: Page, seed: number): Promise<boolean[]> {
     network: { failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 0.5 }] },
   });
   await p.goto(BASE_URL);
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < SEED_TRIALS; i++) {
     await makeRequest(p);
   }
   const log = await getChaosLog(p) as ChaosEvent[];
@@ -36,7 +37,7 @@ describe('Seeded randomness', () => {
     const outcomes2 = await runWithSeed(page2, SEED);
     await page2.close();
 
-    expect(outcomes1.length).toBe(5);
+    expect(outcomes1.length).toBe(SEED_TRIALS);
     expect(outcomes1).toEqual(outcomes2);
   });
 
@@ -47,8 +48,7 @@ describe('Seeded randomness', () => {
     const outcomes2 = await runWithSeed(page2, 99);
     await page2.close();
 
-    // With 5 trials at p=0.5 and different seeds, collision probability is ~1/32.
-    // Run 10 trials per seed for < 1/1000 collision chance.
+    // 10 trials at p=0.5 → collision probability ~1/1024 per seed pair.
     expect(outcomes1).not.toEqual(outcomes2);
   });
 

--- a/e2e-tests/puppeteer/tests/seeded-randomness.test.ts
+++ b/e2e-tests/puppeteer/tests/seeded-randomness.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Browser, Page } from 'puppeteer';
+import { injectChaos, getChaosLog, getChaosSeed } from '@chaos-maker/puppeteer';
+import type { ChaosEvent } from '@chaos-maker/core';
+import { launchBrowser, BASE_URL, API_PATTERN, makeRequest } from './helpers';
+
+const SEED = 42;
+
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => { browser = await launchBrowser(); });
+afterAll(async () => { await browser.close(); });
+
+beforeEach(async () => { page = await browser.newPage(); });
+afterEach(async () => { await page.close(); });
+
+async function runWithSeed(p: Page, seed: number): Promise<boolean[]> {
+  await injectChaos(p, {
+    seed,
+    network: { failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 0.5 }] },
+  });
+  await p.goto(BASE_URL);
+  for (let i = 0; i < 5; i++) {
+    await makeRequest(p);
+  }
+  const log = await getChaosLog(p) as ChaosEvent[];
+  return log.filter((e) => e.type === 'network:failure').map((e) => e.applied);
+}
+
+describe('Seeded randomness', () => {
+  it('same seed produces identical chaos outcomes', async () => {
+    const outcomes1 = await runWithSeed(page, SEED);
+
+    const page2 = await browser.newPage();
+    const outcomes2 = await runWithSeed(page2, SEED);
+    await page2.close();
+
+    expect(outcomes1.length).toBe(5);
+    expect(outcomes1).toEqual(outcomes2);
+  });
+
+  it('different seeds produce different outcomes', async () => {
+    const outcomes1 = await runWithSeed(page, 42);
+
+    const page2 = await browser.newPage();
+    const outcomes2 = await runWithSeed(page2, 99);
+    await page2.close();
+
+    // With 5 trials at p=0.5 and different seeds, collision probability is ~1/32.
+    // Run 10 trials per seed for < 1/1000 collision chance.
+    expect(outcomes1).not.toEqual(outcomes2);
+  });
+
+  it('getChaosSeed returns the configured seed', async () => {
+    await injectChaos(page, {
+      seed: 12345,
+      network: { failures: [{ urlPattern: API_PATTERN, statusCode: 503, probability: 1.0 }] },
+    });
+    await page.goto(BASE_URL);
+    const seed = await getChaosSeed(page);
+    expect(seed).toBe(12345);
+  });
+});

--- a/e2e-tests/puppeteer/tests/ui-chaos.test.ts
+++ b/e2e-tests/puppeteer/tests/ui-chaos.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import type { Browser, Page } from 'puppeteer';
 import { injectChaos, getChaosLog } from '@chaos-maker/puppeteer';
 import type { ChaosEvent, ChaosConfig } from '@chaos-maker/core';

--- a/e2e-tests/puppeteer/tests/ui-chaos.test.ts
+++ b/e2e-tests/puppeteer/tests/ui-chaos.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Browser, Page } from 'puppeteer';
+import { injectChaos, getChaosLog } from '@chaos-maker/puppeteer';
+import type { ChaosEvent, ChaosConfig } from '@chaos-maker/core';
+import { launchBrowser, BASE_URL } from './helpers';
+
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => { browser = await launchBrowser(); });
+afterAll(async () => { await browser.close(); });
+
+beforeEach(async () => { page = await browser.newPage(); });
+afterEach(async () => { await page.close(); });
+
+// UI chaos must start AFTER page load — the DOM assailant does an initial scan
+// of existing elements and attaches a MutationObserver to document.body, both of
+// which require the DOM to exist. Inject an empty config pre-nav to load the UMD
+// bundle, then start UI chaos via chaosUtils.start() after goto().
+async function injectUiChaos(p: Page, config: ChaosConfig): Promise<void> {
+  await p.evaluate((cfg) => {
+    (window as unknown as { chaosUtils: { start: (c: unknown) => void } }).chaosUtils.start(cfg);
+  }, config as object);
+}
+
+describe('UI chaos', () => {
+  it('disables target button', async () => {
+    await injectChaos(page, {});
+    await page.goto(BASE_URL);
+    await injectUiChaos(page, {
+      ui: { assaults: [{ selector: '#submit-btn', action: 'disable', probability: 1.0 }] },
+    });
+
+    await page.waitForFunction(
+      () => (document.getElementById('submit-btn') as HTMLButtonElement)?.disabled === true,
+      { timeout: 5_000 },
+    );
+    const disabled = await page.$eval(
+      '#submit-btn',
+      (el) => (el as HTMLButtonElement).disabled,
+    );
+    expect(disabled).toBe(true);
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    expect(log.some((e) => e.type === 'ui:assault' && e.applied)).toBe(true);
+  });
+
+  it('hides target element', async () => {
+    await injectChaos(page, {});
+    await page.goto(BASE_URL);
+    await injectUiChaos(page, {
+      ui: { assaults: [{ selector: '#action-btn', action: 'hide', probability: 1.0 }] },
+    });
+
+    await page.waitForFunction(
+      () => {
+        const el = document.getElementById('action-btn') as HTMLElement | null;
+        return el?.style.display === 'none';
+      },
+      { timeout: 5_000 },
+    );
+    const display = await page.$eval(
+      '#action-btn',
+      (el) => (el as HTMLElement).style.display,
+    );
+    expect(display).toBe('none');
+  });
+
+  it('removes target element from DOM', async () => {
+    await injectChaos(page, {});
+    await page.goto(BASE_URL);
+    await injectUiChaos(page, {
+      ui: { assaults: [{ selector: '#removable-div', action: 'remove', probability: 1.0 }] },
+    });
+
+    await page.waitForFunction(
+      () => document.getElementById('removable-div') === null,
+      { timeout: 5_000 },
+    );
+    const el = await page.$('#removable-div');
+    expect(el).toBeNull();
+  });
+
+  it('probability 0 leaves UI unchanged', async () => {
+    await injectChaos(page, {});
+    await page.goto(BASE_URL);
+    await injectUiChaos(page, {
+      ui: { assaults: [{ selector: '#submit-btn', action: 'disable', probability: 0 }] },
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+    const disabled = await page.$eval(
+      '#submit-btn',
+      (el) => (el as HTMLButtonElement).disabled,
+    );
+    expect(disabled).toBe(false);
+  });
+});

--- a/e2e-tests/puppeteer/tests/websocket-chaos.test.ts
+++ b/e2e-tests/puppeteer/tests/websocket-chaos.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import type { Browser, Page } from 'puppeteer';
 import { injectChaos, getChaosLog } from '@chaos-maker/puppeteer';
 import type { ChaosEvent } from '@chaos-maker/core';

--- a/e2e-tests/puppeteer/tests/websocket-chaos.test.ts
+++ b/e2e-tests/puppeteer/tests/websocket-chaos.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Browser, Page } from 'puppeteer';
+import { injectChaos, getChaosLog } from '@chaos-maker/puppeteer';
+import type { ChaosEvent } from '@chaos-maker/core';
+import { launchBrowser, BASE_URL, WS_URL_PATTERN, waitForText } from './helpers';
+
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => { browser = await launchBrowser(); });
+afterAll(async () => { await browser.close(); });
+
+beforeEach(async () => { page = await browser.newPage(); });
+afterEach(async () => { await page.close(); });
+
+async function connect(p: Page): Promise<void> {
+  await p.click('#ws-connect');
+  await waitForText(p, '#ws-status', 'open');
+}
+
+async function sendMessages(p: Page, n: number): Promise<void> {
+  for (let i = 0; i < n; i++) {
+    await p.click('#ws-send');
+    await new Promise((r) => setTimeout(r, 30));
+  }
+}
+
+async function inboundCount(p: Page): Promise<number> {
+  return p.$eval('#ws-inbound-count', (el) => Number(el.textContent));
+}
+
+describe('WebSocket drop', () => {
+  it('drops every 2nd outbound message — server echoes half', async () => {
+    await injectChaos(page, {
+      websocket: {
+        drops: [{ urlPattern: WS_URL_PATTERN, direction: 'outbound', probability: 1, everyNth: 2 }],
+      },
+    });
+    await page.goto(BASE_URL);
+    await connect(page);
+    await sendMessages(page, 4);
+
+    await page.waitForFunction(
+      () => Number(document.getElementById('ws-inbound-count')?.textContent) === 2,
+      { timeout: 5_000 },
+    );
+    expect(await inboundCount(page)).toBe(2);
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    const drops = log.filter((e) => e.type === 'websocket:drop' && e.detail.direction === 'outbound');
+    expect(drops.length).toBe(2);
+  });
+});
+
+describe('WebSocket delay', () => {
+  it('delays inbound messages by >= 600ms relative to baseline', async () => {
+    // Baseline
+    await injectChaos(page, { websocket: {} });
+    await page.goto(BASE_URL);
+    await connect(page);
+    const t0 = Date.now();
+    await page.click('#ws-send');
+    await page.waitForFunction(
+      () => Number(document.getElementById('ws-inbound-count')?.textContent) === 1,
+    );
+    const baseline = Date.now() - t0;
+
+    // With delay
+    const page2 = await browser.newPage();
+    await injectChaos(page2, {
+      websocket: {
+        delays: [{ urlPattern: WS_URL_PATTERN, direction: 'inbound', delayMs: 800, probability: 1 }],
+      },
+    });
+    await page2.goto(BASE_URL);
+    await page2.click('#ws-connect');
+    await waitForText(page2, '#ws-status', 'open');
+    const t1 = Date.now();
+    await page2.click('#ws-send');
+    await page2.waitForFunction(
+      () => Number(document.getElementById('ws-inbound-count')?.textContent) === 1,
+      { timeout: 10_000 },
+    );
+    const withChaos = Date.now() - t1;
+    await page2.close();
+
+    expect(withChaos - baseline).toBeGreaterThanOrEqual(600);
+  });
+});
+
+describe('WebSocket corrupt', () => {
+  it('truncates inbound text payload', async () => {
+    await injectChaos(page, {
+      websocket: {
+        corruptions: [{ urlPattern: WS_URL_PATTERN, direction: 'inbound', strategy: 'truncate', probability: 1 }],
+      },
+    });
+    await page.goto(BASE_URL);
+    await connect(page);
+    await page.click('#ws-send');
+    await page.waitForFunction(
+      () => Number(document.getElementById('ws-inbound-count')?.textContent) === 1,
+      { timeout: 5_000 },
+    );
+
+    const logText = await page.$eval('#ws-log', (el) => el.textContent ?? '');
+    // 'ping' truncated to half → 'pi'
+    expect(logText).toMatch(/pi/);
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    const corrupted = log.find((e) => e.type === 'websocket:corrupt' && e.applied);
+    expect(corrupted?.detail.strategy).toBe('truncate');
+  });
+});
+
+describe('WebSocket close', () => {
+  it('force-closes connection with configured code and reason', async () => {
+    await injectChaos(page, {
+      websocket: {
+        closes: [{ urlPattern: WS_URL_PATTERN, probability: 1, afterMs: 500, code: 4000, reason: 'chaos' }],
+      },
+    });
+    await page.goto(BASE_URL);
+    await connect(page);
+
+    await page.waitForFunction(
+      () => document.getElementById('ws-status')?.textContent?.includes('closed'),
+      { timeout: 5_000 },
+    );
+    const status = await page.$eval('#ws-status', (el) => el.textContent ?? '');
+    expect(status).toContain('4000');
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    const closes = log.filter((e) => e.type === 'websocket:close' && e.applied);
+    expect(closes.length).toBe(1);
+    expect(closes[0].detail.closeCode).toBe(4000);
+    expect(closes[0].detail.closeReason).toBe('chaos');
+  });
+});
+
+describe('WebSocket direction filter', () => {
+  it('onNth: 3 drops only the 3rd outbound message', async () => {
+    await injectChaos(page, {
+      websocket: {
+        drops: [{ urlPattern: WS_URL_PATTERN, direction: 'outbound', probability: 1, onNth: 3 }],
+      },
+    });
+    await page.goto(BASE_URL);
+    await connect(page);
+    await sendMessages(page, 5);
+
+    await page.waitForFunction(
+      () => Number(document.getElementById('ws-inbound-count')?.textContent) === 4,
+      { timeout: 5_000 },
+    );
+    expect(await inboundCount(page)).toBe(4);
+
+    const log = await getChaosLog(page) as ChaosEvent[];
+    const drops = log.filter((e) => e.type === 'websocket:drop' && e.applied);
+    expect(drops.length).toBe(1);
+  });
+});

--- a/e2e-tests/puppeteer/vitest.config.ts
+++ b/e2e-tests/puppeteer/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    globals: true,
+    globalSetup: resolve(__dirname, 'setup/global-setup.ts'),
+    include: ['tests/**/*.test.ts'],
+    testTimeout: 60_000,
+    hookTimeout: 30_000,
+    // Run files serially — each test file launches its own browser; parallel
+    // launches on CI exhaust memory and create race conditions on ports.
+    fileParallelism: false,
+    sequence: { concurrent: false },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build:playwright": "pnpm --filter @chaos-maker/playwright build",
     "build:cypress": "pnpm --filter @chaos-maker/cypress build",
     "build:webdriverio": "pnpm --filter @chaos-maker/webdriverio build",
-    "build": "pnpm build:core && pnpm build:playwright && pnpm build:cypress && pnpm build:webdriverio",
+    "build:puppeteer": "pnpm --filter @chaos-maker/puppeteer build",
+    "build": "pnpm build:core && pnpm build:playwright && pnpm build:cypress && pnpm build:webdriverio && pnpm build:puppeteer",
     "dev:core": "pnpm --filter @chaos-maker/core dev",
     "test": "pnpm --filter @chaos-maker/core test",
     "test:playwright": "pnpm --filter e2e-tests-playwright exec playwright test",
@@ -22,6 +23,7 @@
     "test:wdio": "pnpm --filter e2e-tests-webdriverio test",
     "test:wdio:chrome": "pnpm --filter e2e-tests-webdriverio test:chrome",
     "test:wdio:firefox": "pnpm --filter e2e-tests-webdriverio test:firefox",
+    "test:puppeteer": "pnpm --filter e2e-tests-puppeteer test",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/puppeteer/CHANGELOG.md
+++ b/packages/puppeteer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @chaos-maker/puppeteer Changelog
+
+## 0.3.0
+
+Initial release. Supports headless-new Chromium (Puppeteer 21+). Trace integration deferred to a future release.

--- a/packages/puppeteer/README.md
+++ b/packages/puppeteer/README.md
@@ -1,0 +1,71 @@
+# @chaos-maker/puppeteer
+
+Puppeteer adapter for [`@chaos-maker/core`](https://github.com/jvjithin/chaos-maker) — inject network failures, UI assaults, and WebSocket chaos into Puppeteer tests with a single function call.
+
+## Install
+
+```bash
+npm install --save-dev @chaos-maker/puppeteer puppeteer
+# or
+pnpm add -D @chaos-maker/puppeteer puppeteer
+```
+
+## Quick start
+
+```ts
+import puppeteer from 'puppeteer';
+import { injectChaos, getChaosLog } from '@chaos-maker/puppeteer';
+
+const browser = await puppeteer.launch({ headless: true });
+const page = await browser.newPage();
+
+// Inject BEFORE goto — uses evaluateOnNewDocument for full-lifecycle coverage
+await injectChaos(page, {
+  network: {
+    failures: [{ urlPattern: '/api', statusCode: 503, probability: 1.0 }],
+  },
+});
+
+await page.goto('http://localhost:3000');
+// ... drive the page ...
+const log = await getChaosLog(page);
+console.log('Chaos events:', log);
+
+await browser.close();
+```
+
+## API
+
+### `injectChaos(page, config)`
+
+Injects chaos into a Puppeteer page via `evaluateOnNewDocument`. Must be called before `page.goto()` so all network requests are intercepted from the start.
+
+### `removeChaos(page)`
+
+Stops chaos and restores original `fetch`, `XMLHttpRequest`, `WebSocket`, and DOM behaviour. Safe to call after page close.
+
+### `getChaosLog(page)`
+
+Returns the full event log (applied + skipped decisions) since `injectChaos` was called.
+
+### `getChaosSeed(page)`
+
+Returns the PRNG seed used by the active chaos instance. Log this on test failure to replay the exact sequence.
+
+### `useChaos(page, config)`
+
+Convenience helper for `afterEach`-style cleanup — injects chaos and returns an async teardown:
+
+```ts
+let teardown: () => Promise<void>;
+beforeEach(async () => {
+  teardown = await useChaos(page, { network: { failures: [...] } });
+});
+afterEach(() => teardown());
+```
+
+## Notes
+
+- **Headless Chromium only** (headless-new mode, Puppeteer 21+). Firefox via `puppeteer-core` is untested.
+- Trace viewer integration (surfacing chaos events in a trace timeline) is not available in this adapter — use `@chaos-maker/playwright` if you need traces.
+- Works with both `puppeteer` and `puppeteer-core` — the type is structural.

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@chaos-maker/puppeteer",
+  "version": "0.3.0",
+  "type": "module",
+  "description": "Puppeteer adapter for @chaos-maker/core — one-line chaos injection in Puppeteer tests",
+  "keywords": [
+    "chaos-engineering",
+    "puppeteer",
+    "headless-chrome",
+    "testing",
+    "e2e-testing",
+    "resilience"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jvjithin/chaos-maker.git",
+    "directory": "packages/puppeteer"
+  },
+  "homepage": "https://github.com/jvjithin/chaos-maker",
+  "engines": {
+    "node": ">=18"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@chaos-maker/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "puppeteer": ">=21.0.0"
+  },
+  "peerDependenciesMeta": {
+    "puppeteer": {
+      "optional": true
+    },
+    "puppeteer-core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "puppeteer": "^22.0.0",
+    "tsup": "^8.5.1",
+    "typescript": "^5.4.5",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -48,7 +48,8 @@
     "@chaos-maker/core": "workspace:*"
   },
   "peerDependencies": {
-    "puppeteer": ">=21.0.0"
+    "puppeteer": ">=21.0.0",
+    "puppeteer-core": ">=21.0.0"
   },
   "peerDependenciesMeta": {
     "puppeteer": {

--- a/packages/puppeteer/src/index.ts
+++ b/packages/puppeteer/src/index.ts
@@ -83,6 +83,14 @@ function loadCoreUmdSource(): string {
 export async function injectChaos(page: ChaosPage, config: ChaosConfig): Promise<void> {
   const umdSource = loadCoreUmdSource();
 
+  // Remove any previously registered init scripts for this page so a repeat
+  // injectChaos call replaces — rather than stacks on top of — the prior pair.
+  const previousIds = registeredInitScripts.get(page) ?? [];
+  const removeScript = page.removeScriptToEvaluateOnNewDocument?.bind(page);
+  if (removeScript && previousIds.length > 0) {
+    await Promise.all(previousIds.map((id) => removeScript(id).catch(() => undefined)));
+  }
+
   // Set config in the page realm before the UMD loads so the auto-bootstrap
   // picks it up. Serialized as an argument — Puppeteer JSON-encodes it.
   const configHandle = await page.evaluateOnNewDocument((cfg: unknown) => {
@@ -96,7 +104,9 @@ export async function injectChaos(page: ChaosPage, config: ChaosConfig): Promise
   const ids = [scriptIdentifier(configHandle), scriptIdentifier(umdHandle)]
     .filter((id): id is string => typeof id === 'string');
   if (ids.length > 0) {
-    registeredInitScripts.set(page, [...(registeredInitScripts.get(page) ?? []), ...ids]);
+    registeredInitScripts.set(page, ids);
+  } else {
+    registeredInitScripts.delete(page);
   }
 }
 

--- a/packages/puppeteer/src/index.ts
+++ b/packages/puppeteer/src/index.ts
@@ -14,12 +14,28 @@ export interface ChaosPage {
     pageFunction: string | ((...args: unknown[]) => void),
     ...args: unknown[]
   ): Promise<unknown>;
+  removeScriptToEvaluateOnNewDocument?(identifier: string): Promise<void>;
   evaluate<T = unknown>(pageFunction: string | ((...args: unknown[]) => T), ...args: unknown[]): Promise<T>;
   goto(url: string, options?: Record<string, unknown>): Promise<unknown>;
 }
 
 let cachedUmdSource: string | null = null;
 let cachedUmdPath: string | null = null;
+
+// Track init-script identifiers per page so removeChaos can tear them down.
+// Without this, evaluateOnNewDocument scripts persist across navigations and
+// re-inject chaos after removeChaos on subsequent page.goto() calls — breaks
+// test frameworks that pool pages across cases.
+const registeredInitScripts = new WeakMap<ChaosPage, string[]>();
+
+function scriptIdentifier(handle: unknown): string | undefined {
+  if (typeof handle === 'string') return handle;
+  if (handle && typeof handle === 'object' && 'identifier' in handle) {
+    const id = (handle as { identifier?: unknown }).identifier;
+    return typeof id === 'string' ? id : undefined;
+  }
+  return undefined;
+}
 
 function getCurrentDir(): string {
   return typeof __dirname !== 'undefined'
@@ -69,13 +85,19 @@ export async function injectChaos(page: ChaosPage, config: ChaosConfig): Promise
 
   // Set config in the page realm before the UMD loads so the auto-bootstrap
   // picks it up. Serialized as an argument — Puppeteer JSON-encodes it.
-  await page.evaluateOnNewDocument((cfg: unknown) => {
+  const configHandle = await page.evaluateOnNewDocument((cfg: unknown) => {
     (globalThis as unknown as Record<string, unknown>)['__CHAOS_CONFIG__'] = cfg;
   }, config as unknown);
 
   // Inject UMD source as a raw script string — fires before any navigation
   // script so all patching happens at document creation time.
-  await page.evaluateOnNewDocument(umdSource);
+  const umdHandle = await page.evaluateOnNewDocument(umdSource);
+
+  const ids = [scriptIdentifier(configHandle), scriptIdentifier(umdHandle)]
+    .filter((id): id is string => typeof id === 'string');
+  if (ids.length > 0) {
+    registeredInitScripts.set(page, [...(registeredInitScripts.get(page) ?? []), ...ids]);
+  }
 }
 
 /**
@@ -83,6 +105,16 @@ export async function injectChaos(page: ChaosPage, config: ChaosConfig): Promise
  * Safe to call even if the page is already closed (rejects are swallowed).
  */
 export async function removeChaos(page: ChaosPage): Promise<void> {
+  // Remove tracked init scripts so subsequent page.goto() does not re-inject
+  // chaos. No-op when the Puppeteer build does not expose the CDP helper
+  // (kept optional on ChaosPage to preserve the structural contract).
+  const scriptIds = registeredInitScripts.get(page) ?? [];
+  registeredInitScripts.delete(page);
+  const removeScript = page.removeScriptToEvaluateOnNewDocument?.bind(page);
+  if (removeScript && scriptIds.length > 0) {
+    await Promise.all(scriptIds.map((id) => removeScript(id).catch(() => undefined)));
+  }
+
   await (page.evaluate(() => {
     const w = globalThis as unknown as { chaosUtils?: { stop: () => void } };
     if (w.chaosUtils && typeof w.chaosUtils.stop === 'function') {

--- a/packages/puppeteer/src/index.ts
+++ b/packages/puppeteer/src/index.ts
@@ -1,0 +1,166 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import type { ChaosConfig, ChaosEvent } from '@chaos-maker/core';
+
+/**
+ * Minimal structural type for a Puppeteer `Page` object. Typed this way so we
+ * don't force a hard dependency on puppeteer's internal types — any object
+ * exposing these methods works (covers both `puppeteer` and `puppeteer-core`).
+ */
+export interface ChaosPage {
+  evaluateOnNewDocument(
+    pageFunction: string | ((...args: unknown[]) => void),
+    ...args: unknown[]
+  ): Promise<unknown>;
+  evaluate<T = unknown>(pageFunction: string | ((...args: unknown[]) => T), ...args: unknown[]): Promise<T>;
+  goto(url: string, options?: Record<string, unknown>): Promise<unknown>;
+}
+
+let cachedUmdSource: string | null = null;
+let cachedUmdPath: string | null = null;
+
+function getCurrentDir(): string {
+  return typeof __dirname !== 'undefined'
+    ? __dirname
+    : dirname(fileURLToPath(import.meta.url));
+}
+
+function resolveCoreUmdPath(): string {
+  if (cachedUmdPath) return cachedUmdPath;
+  const req = createRequire(resolve(getCurrentDir(), 'package.json'));
+  const coreEntry = req.resolve('@chaos-maker/core');
+  const coreDistDir = dirname(coreEntry);
+  cachedUmdPath = resolve(coreDistDir, 'chaos-maker.umd.js');
+  return cachedUmdPath;
+}
+
+function loadCoreUmdSource(): string {
+  if (cachedUmdSource !== null) return cachedUmdSource;
+  cachedUmdSource = readFileSync(resolveCoreUmdPath(), 'utf8');
+  return cachedUmdSource;
+}
+
+/**
+ * Inject chaos into a Puppeteer page. Call **before** `page.goto()` — uses
+ * `evaluateOnNewDocument` to patch `fetch`, `XMLHttpRequest`, and `WebSocket`
+ * before any page script runs.
+ *
+ * **UI chaos note:** The DOM assailant requires the DOM to exist when started.
+ * For UI chaos, inject an empty config pre-nav to load the UMD bundle, navigate,
+ * then call `page.evaluate(() => window.chaosUtils.start(uiConfig))` after goto.
+ *
+ * @example
+ * ```ts
+ * import puppeteer from 'puppeteer';
+ * import { injectChaos, getChaosLog } from '@chaos-maker/puppeteer';
+ *
+ * const browser = await puppeteer.launch();
+ * const page = await browser.newPage();
+ * await injectChaos(page, {
+ *   network: { failures: [{ urlPattern: '/api', statusCode: 503, probability: 1.0 }] },
+ * });
+ * await page.goto('http://localhost:3000');
+ * ```
+ */
+export async function injectChaos(page: ChaosPage, config: ChaosConfig): Promise<void> {
+  const umdSource = loadCoreUmdSource();
+
+  // Set config in the page realm before the UMD loads so the auto-bootstrap
+  // picks it up. Serialized as an argument — Puppeteer JSON-encodes it.
+  await page.evaluateOnNewDocument((cfg: unknown) => {
+    (globalThis as unknown as Record<string, unknown>)['__CHAOS_CONFIG__'] = cfg;
+  }, config as unknown);
+
+  // Inject UMD source as a raw script string — fires before any navigation
+  // script so all patching happens at document creation time.
+  await page.evaluateOnNewDocument(umdSource);
+}
+
+/**
+ * Stop chaos and restore original `fetch`, `XHR`, `WebSocket`, and DOM behavior.
+ * Safe to call even if the page is already closed (rejects are swallowed).
+ */
+export async function removeChaos(page: ChaosPage): Promise<void> {
+  await (page.evaluate(() => {
+    const w = globalThis as unknown as { chaosUtils?: { stop: () => void } };
+    if (w.chaosUtils && typeof w.chaosUtils.stop === 'function') {
+      w.chaosUtils.stop();
+    }
+  }) as Promise<void>).catch(() => {
+    // Page already closed during teardown — not a real error.
+  });
+}
+
+/**
+ * Read the chaos event log from the page. Returns every chaos decision emitted
+ * since `injectChaos` was called, applied or skipped.
+ */
+export async function getChaosLog(page: ChaosPage): Promise<ChaosEvent[]> {
+  return page.evaluate(() => {
+    const w = globalThis as unknown as { chaosUtils?: { getLog: () => unknown[] } };
+    if (w.chaosUtils && typeof w.chaosUtils.getLog === 'function') {
+      return w.chaosUtils.getLog() as ChaosEvent[];
+    }
+    return [] as ChaosEvent[];
+  }) as Promise<ChaosEvent[]>;
+}
+
+/**
+ * Read the PRNG seed used by the active chaos instance. Log this on test
+ * failure to replay the exact sequence of chaos decisions with the same seed.
+ */
+export async function getChaosSeed(page: ChaosPage): Promise<number | null> {
+  return page.evaluate(() => {
+    const w = globalThis as unknown as { chaosUtils?: { getSeed: () => number | null } };
+    if (w.chaosUtils && typeof w.chaosUtils.getSeed === 'function') {
+      return w.chaosUtils.getSeed();
+    }
+    return null;
+  }) as Promise<number | null>;
+}
+
+/**
+ * Helper for test frameworks that use `afterEach`/`afterAll` hooks. Injects
+ * chaos and returns an async teardown function — call the teardown in your
+ * cleanup hook to restore normal browser behavior.
+ *
+ * @example
+ * ```ts
+ * let teardown: () => Promise<void>;
+ * beforeEach(async () => {
+ *   teardown = await useChaos(page, { network: { failures: [...] } });
+ * });
+ * afterEach(() => teardown());
+ * ```
+ */
+export async function useChaos(
+  page: ChaosPage,
+  config: ChaosConfig,
+): Promise<() => Promise<void>> {
+  await injectChaos(page, config);
+  return () => removeChaos(page);
+}
+
+export type {
+  ChaosConfig,
+  ChaosEvent,
+  ChaosEventType,
+  NetworkConfig,
+  NetworkFailureConfig,
+  NetworkLatencyConfig,
+  NetworkAbortConfig,
+  NetworkCorruptionConfig,
+  NetworkCorsConfig,
+  CorruptionStrategy,
+  UiConfig,
+  UiAssaultConfig,
+  WebSocketConfig,
+  WebSocketDropConfig,
+  WebSocketDelayConfig,
+  WebSocketCorruptConfig,
+  WebSocketCloseConfig,
+  WebSocketDirection,
+  WebSocketCorruptionStrategy,
+} from '@chaos-maker/core';

--- a/packages/puppeteer/test/index.test.ts
+++ b/packages/puppeteer/test/index.test.ts
@@ -78,6 +78,35 @@ describe('@chaos-maker/puppeteer', () => {
       };
       await expect(removeChaos(closedPage)).resolves.toBeUndefined();
     });
+
+    it('removes tracked init scripts on cleanup (Puppeteer 22+ handle shape)', async () => {
+      const removed: string[] = [];
+      let next = 0;
+      const page: ChaosPage = {
+        async evaluateOnNewDocument() {
+          return { identifier: `script-${++next}` };
+        },
+        async evaluate() {
+          return undefined as never;
+        },
+        async goto() {
+          return undefined;
+        },
+        async removeScriptToEvaluateOnNewDocument(id: string) {
+          removed.push(id);
+        },
+      };
+      await injectChaos(page, {});
+      await removeChaos(page);
+      expect(removed).toEqual(['script-1', 'script-2']);
+    });
+
+    it('is a no-op when page lacks removeScriptToEvaluateOnNewDocument', async () => {
+      // Older Puppeteer / puppeteer-core forks may not expose the helper —
+      // cleanup must still stop chaos without throwing.
+      await injectChaos(fake.page, {});
+      await expect(removeChaos(fake.page)).resolves.toBeUndefined();
+    });
   });
 
   describe('getChaosLog', () => {

--- a/packages/puppeteer/test/index.test.ts
+++ b/packages/puppeteer/test/index.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  injectChaos,
+  removeChaos,
+  getChaosLog,
+  getChaosSeed,
+  useChaos,
+  type ChaosPage,
+} from '../src/index';
+
+function makeFakePage(): {
+  page: ChaosPage;
+  newDocumentCalls: Array<{ fn: unknown; args: unknown[] }>;
+  evaluateCalls: Array<{ fn: unknown; args: unknown[] }>;
+} {
+  const newDocumentCalls: Array<{ fn: unknown; args: unknown[] }> = [];
+  const evaluateCalls: Array<{ fn: unknown; args: unknown[] }> = [];
+  const page: ChaosPage = {
+    async evaluateOnNewDocument(fn, ...args) {
+      newDocumentCalls.push({ fn, args });
+      return undefined;
+    },
+    async evaluate(fn, ...args) {
+      evaluateCalls.push({ fn, args });
+      return undefined as never;
+    },
+    async goto() {
+      return undefined;
+    },
+  };
+  return { page, newDocumentCalls, evaluateCalls };
+}
+
+describe('@chaos-maker/puppeteer', () => {
+  let fake: ReturnType<typeof makeFakePage>;
+
+  beforeEach(() => {
+    fake = makeFakePage();
+  });
+
+  describe('injectChaos', () => {
+    it('calls evaluateOnNewDocument twice — once for config, once for UMD', async () => {
+      await injectChaos(fake.page, {
+        network: { failures: [{ urlPattern: '/api', statusCode: 500, probability: 1 }] },
+      });
+      expect(fake.newDocumentCalls).toHaveLength(2);
+    });
+
+    it('first call is a function (config injection)', async () => {
+      await injectChaos(fake.page, {});
+      expect(typeof fake.newDocumentCalls[0].fn).toBe('function');
+    });
+
+    it('second call is the UMD source string', async () => {
+      await injectChaos(fake.page, {});
+      expect(typeof fake.newDocumentCalls[1].fn).toBe('string');
+      expect((fake.newDocumentCalls[1].fn as string).length).toBeGreaterThan(100);
+    });
+
+    it('passes config as second argument to first evaluateOnNewDocument call', async () => {
+      const config = { network: { failures: [{ urlPattern: '/api', statusCode: 503, probability: 1 }] } };
+      await injectChaos(fake.page, config);
+      expect(fake.newDocumentCalls[0].args[0]).toEqual(config);
+    });
+  });
+
+  describe('removeChaos', () => {
+    it('calls evaluate once to stop chaos', async () => {
+      await removeChaos(fake.page);
+      expect(fake.evaluateCalls).toHaveLength(1);
+    });
+
+    it('swallows errors when page is closed', async () => {
+      const closedPage: ChaosPage = {
+        evaluateOnNewDocument: vi.fn(),
+        evaluate: vi.fn().mockRejectedValue(new Error('Target closed')),
+        goto: vi.fn(),
+      };
+      await expect(removeChaos(closedPage)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getChaosLog', () => {
+    it('returns evaluate result as-is', async () => {
+      const expected = [{ type: 'network:failure', applied: true }];
+      const page: ChaosPage = {
+        evaluateOnNewDocument: vi.fn(),
+        evaluate: vi.fn().mockResolvedValue(expected),
+        goto: vi.fn(),
+      };
+      const log = await getChaosLog(page);
+      expect(log).toBe(expected);
+    });
+  });
+
+  describe('getChaosSeed', () => {
+    it('returns seed from evaluate result', async () => {
+      const page: ChaosPage = {
+        evaluateOnNewDocument: vi.fn(),
+        evaluate: vi.fn().mockResolvedValue(42),
+        goto: vi.fn(),
+      };
+      const seed = await getChaosSeed(page);
+      expect(seed).toBe(42);
+    });
+
+    it('returns null when chaos not active', async () => {
+      const page: ChaosPage = {
+        evaluateOnNewDocument: vi.fn(),
+        evaluate: vi.fn().mockResolvedValue(null),
+        goto: vi.fn(),
+      };
+      const seed = await getChaosSeed(page);
+      expect(seed).toBeNull();
+    });
+  });
+
+  describe('useChaos', () => {
+    it('returns a teardown function', async () => {
+      const teardown = await useChaos(fake.page, {});
+      expect(typeof teardown).toBe('function');
+    });
+
+    it('teardown calls removeChaos (evaluate)', async () => {
+      const teardown = await useChaos(fake.page, {});
+      await teardown();
+      expect(fake.evaluateCalls).toHaveLength(1);
+    });
+  });
+});

--- a/packages/puppeteer/tsconfig.json
+++ b/packages/puppeteer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/puppeteer/tsup.config.ts
+++ b/packages/puppeteer/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  external: ['puppeteer', 'puppeteer-core', '@chaos-maker/core'],
+});

--- a/packages/puppeteer/vitest.config.ts
+++ b/packages/puppeteer/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,30 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
 
+  e2e-tests/puppeteer:
+    devDependencies:
+      '@chaos-maker/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@chaos-maker/puppeteer':
+        specifier: workspace:*
+        version: link:../../packages/puppeteer
+      http-server:
+        specifier: ^14.1.1
+        version: 14.1.1
+      puppeteer:
+        specifier: ^22.0.0
+        version: 22.15.0(typescript@5.9.3)
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.17)(jsdom@27.0.1(postcss@8.5.10))(tsx@4.21.0)(yaml@2.8.3)
+      ws:
+        specifier: ^8.17.0
+        version: 8.20.0
+
   e2e-tests/webdriverio:
     devDependencies:
       '@chaos-maker/core':
@@ -186,6 +210,25 @@ importers:
       '@playwright/test':
         specifier: ^1.45.0
         version: 1.56.1
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.17)(jsdom@27.0.1(postcss@8.5.10))(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/puppeteer:
+    dependencies:
+      '@chaos-maker/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      puppeteer:
+        specifier: ^22.0.0
+        version: 22.15.0(typescript@5.9.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
@@ -562,6 +605,11 @@ packages:
   '@puppeteer/browsers@1.9.1':
     resolution: {integrity: sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==}
     engines: {node: '>=16.3.0'}
+    hasBin: true
+
+  '@puppeteer/browsers@2.3.0':
+    resolution: {integrity: sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
@@ -1343,6 +1391,11 @@ packages:
     peerDependencies:
       devtools-protocol: '*'
 
+  chromium-bidi@0.6.3:
+    resolution: {integrity: sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==}
+    peerDependencies:
+      devtools-protocol: '*'
+
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -1448,6 +1501,15 @@ packages:
   corser@2.0.1:
     resolution: {integrity: sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==}
     engines: {node: '>= 0.4.0'}
+
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -1580,6 +1642,9 @@ packages:
   devtools-protocol@0.0.1232444:
     resolution: {integrity: sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==}
 
+  devtools-protocol@0.0.1312386:
+    resolution: {integrity: sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==}
+
   devtools-protocol@0.0.1400418:
     resolution: {integrity: sha512-U8j75zDOXF8IP3o0Cgb7K4tFA9uUHEOru2Wx64+EUqL4LNOh9dRe1i8WKR1k3mSpjcCe3aIkTDvEwq0YkI4hfw==}
 
@@ -1651,6 +1716,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -2342,6 +2411,9 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-parse-even-better-errors@3.0.2:
     resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -2753,6 +2825,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
   parse-json@7.1.1:
     resolution: {integrity: sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==}
     engines: {node: '>=16'}
@@ -2898,6 +2974,10 @@ packages:
     resolution: {integrity: sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==}
     engines: {node: '>= 14'}
 
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
   proxy-from-env@1.0.0:
     resolution: {integrity: sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==}
 
@@ -2914,6 +2994,16 @@ packages:
   puppeteer-core@21.11.0:
     resolution: {integrity: sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==}
     engines: {node: '>=16.13.2'}
+
+  puppeteer-core@22.15.0:
+    resolution: {integrity: sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==}
+    engines: {node: '>=18'}
+
+  puppeteer@22.15.0:
+    resolution: {integrity: sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==}
+    engines: {node: '>=18'}
+    deprecated: < 24.15.0 is no longer supported
+    hasBin: true
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -3770,6 +3860,9 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -4079,6 +4172,22 @@ snapshots:
       progress: 2.0.3
       proxy-agent: 6.3.1
       tar-fs: 3.0.4
+      unbzip2-stream: 1.4.3
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
+  '@puppeteer/browsers@2.3.0':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      extract-zip: 2.0.1(supports-color@8.1.1)
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.7.3
+      tar-fs: 3.1.2
       unbzip2-stream: 1.4.3
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -4413,14 +4522,6 @@ snapshots:
       magic-string: 0.30.19
     optionalDependencies:
       vite: 6.4.2(@types/node@20.19.23)(tsx@4.21.0)(yaml@2.8.3)
-
-  '@vitest/mocker@3.2.4(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.19
-    optionalDependencies:
-      vite: 6.4.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -4954,6 +5055,13 @@ snapshots:
       mitt: 3.0.1
       urlpattern-polyfill: 10.0.0
 
+  chromium-bidi@0.6.3(devtools-protocol@0.0.1312386):
+    dependencies:
+      devtools-protocol: 0.0.1312386
+      mitt: 3.0.1
+      urlpattern-polyfill: 10.0.0
+      zod: 3.23.8
+
   ci-info@3.9.0: {}
 
   ci-info@4.4.0: {}
@@ -5041,6 +5149,15 @@ snapshots:
   core-util-is@1.0.2: {}
 
   corser@2.0.1: {}
+
+  cosmiconfig@9.0.1(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   crc-32@1.2.2: {}
 
@@ -5195,6 +5312,8 @@ snapshots:
 
   devtools-protocol@0.0.1232444: {}
 
+  devtools-protocol@0.0.1312386: {}
+
   devtools-protocol@0.0.1400418: {}
 
   diff-sequences@29.6.3: {}
@@ -5265,6 +5384,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   entities@6.0.1: {}
+
+  env-paths@2.2.1: {}
 
   environment@1.1.0: {}
 
@@ -6078,6 +6199,8 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-parse-even-better-errors@3.0.2: {}
 
   json-schema-traverse@0.4.1: {}
@@ -6481,6 +6604,13 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
   parse-json@7.1.1:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -6600,6 +6730,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   proxy-from-env@1.0.0: {}
 
   proxy-from-env@1.1.0: {}
@@ -6626,6 +6769,36 @@ snapshots:
       - encoding
       - react-native-b4a
       - supports-color
+      - utf-8-validate
+
+  puppeteer-core@22.15.0:
+    dependencies:
+      '@puppeteer/browsers': 2.3.0
+      chromium-bidi: 0.6.3(devtools-protocol@0.0.1312386)
+      debug: 4.4.3(supports-color@8.1.1)
+      devtools-protocol: 0.0.1312386
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
+  puppeteer@22.15.0(typescript@5.9.3):
+    dependencies:
+      '@puppeteer/browsers': 2.3.0
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      devtools-protocol: 0.0.1312386
+      puppeteer-core: 22.15.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - typescript
       - utf-8-validate
 
   qs@6.14.2:
@@ -7413,7 +7586,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@20.19.23)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -7652,5 +7825,7 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod@3.23.8: {}
 
   zod@3.25.76: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       '@chaos-maker/core':
         specifier: workspace:*
         version: link:../core
+      puppeteer-core:
+        specifier: '>=21.0.0'
+        version: 22.15.0
     devDependencies:
       puppeteer:
         specifier: ^22.0.0


### PR DESCRIPTION
## Summary

- New `@chaos-maker/puppeteer` package (v0.3.0) with `injectChaos`, `removeChaos`, `getChaosLog`, `getChaosSeed`, and `useChaos` API — structural `ChaosPage` type works with both `puppeteer` and `puppeteer-core`
- Pre-nav injection via `page.evaluateOnNewDocument` for full-lifecycle network + WebSocket chaos coverage
- `e2e-tests/puppeteer/` suite with 37 tests across 8 spec files (resilience, lifecycle, network-fetch, network-xhr, ui-chaos, websocket, nth-counting, seeded-randomness)
- `e2e-puppeteer` CI job + `publish-puppeteer` release job added to workflows
- Root `build:puppeteer` and `test:puppeteer` scripts added

## Key decision: UI chaos is post-nav only

UI chaos (`domAssailant`) requires the DOM to exist when started. Pre-nav injection fires before HTML is parsed, so the DOM assailant's initial scan finds nothing. Pattern for UI chaos in Puppeteer tests:

```ts
await injectChaos(page, {});          // load UMD bundle, no config
await page.goto(url);                  // DOM loads
await page.evaluate(() =>
  window.chaosUtils.start(uiConfig)); // start UI chaos on loaded DOM
```

This matches the pattern Playwright's own UI chaos tests use (see `e2e-tests/playwright/tests/ui-chaos.spec.ts:7-13`). Documented in LEARNINGS.md and adapter JSDoc.

## Test plan

- [x] `pnpm build:puppeteer` → dist produced, types match Playwright surface minus trace types
- [x] `pnpm --filter e2e-tests-puppeteer test` → 37/37 pass locally
- [x] `pnpm lint` → no issues
- [x] CI `e2e-puppeteer` job green on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Puppeteer adapter package for injecting network, UI, and WebSocket chaos into Puppeteer-based tests; includes public APIs for inject/remove/inspect chaos and seeded replay.

* **Tests**
  * Added a comprehensive Puppeteer E2E test suite covering lifecycle, network (fetch/XHR), counting, latency/abort/corruption, UI effects, websockets, seeding, and resilience.

* **Chores**
  * CI updated to build, test, cache browsers, and publish the Puppeteer adapter; top-level build/test scripts extended.

* **Documentation**
  * Added README and changelog for the Puppeteer adapter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->