### PR TITLE
fix: docs base-prefix internal links; NPM_TOKEN fallback for new adapter first publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,8 @@ jobs:
         run: pnpm build:core && pnpm build:webdriverio
 
       - name: Publish WebdriverIO Adapter
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm --filter @chaos-maker/webdriverio publish --no-git-checks --access public
 
   publish-puppeteer:
@@ -245,4 +247,6 @@ jobs:
         run: pnpm build:core && pnpm build:puppeteer
 
       - name: Publish Puppeteer Adapter
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm --filter @chaos-maker/puppeteer publish --no-git-checks --access public

--- a/docs/src/content/docs/getting-started/cypress.mdx
+++ b/docs/src/content/docs/getting-started/cypress.mdx
@@ -56,6 +56,6 @@ Cypress command log entries include the same event types returned by `cy.getChao
 
 ## Next steps
 
-- [Cypress adapter API](/adapters/cypress/)
-- [Flaky API with retries](/recipes/flaky-api-with-retries/)
-- [Observability](/concepts/observability/)
+- [Cypress adapter API](/chaos-maker/adapters/cypress/)
+- [Flaky API with retries](/chaos-maker/recipes/flaky-api-with-retries/)
+- [Observability](/chaos-maker/concepts/observability/)

--- a/docs/src/content/docs/getting-started/playwright.mdx
+++ b/docs/src/content/docs/getting-started/playwright.mdx
@@ -42,6 +42,6 @@ The fixture entry point can also wire tracing automatically for suites that pref
 
 ## Next steps
 
-- [Playwright adapter API](/adapters/playwright/)
-- [Slow checkout recipe](/recipes/slow-checkout/)
-- [Seeded reproducibility](/concepts/seeded-reproducibility/)
+- [Playwright adapter API](/chaos-maker/adapters/playwright/)
+- [Slow checkout recipe](/chaos-maker/recipes/slow-checkout/)
+- [Seeded reproducibility](/chaos-maker/concepts/seeded-reproducibility/)

--- a/docs/src/content/docs/getting-started/puppeteer.mdx
+++ b/docs/src/content/docs/getting-started/puppeteer.mdx
@@ -50,6 +50,6 @@ await page.evaluate((config) => (window as any).chaosUtils.start(config), {
 
 ## Next steps
 
-- [Puppeteer adapter API](/adapters/puppeteer/)
-- [Degraded UI buttons](/recipes/degraded-ui-buttons/)
-- [Chaos types](/concepts/chaos-types/)
+- [Puppeteer adapter API](/chaos-maker/adapters/puppeteer/)
+- [Degraded UI buttons](/chaos-maker/recipes/degraded-ui-buttons/)
+- [Chaos types](/chaos-maker/concepts/chaos-types/)

--- a/docs/src/content/docs/getting-started/webdriverio.mdx
+++ b/docs/src/content/docs/getting-started/webdriverio.mdx
@@ -38,6 +38,6 @@ Call `registerChaosCommands(browser)` in a WDIO setup hook if you prefer `browse
 
 ## Next steps
 
-- [WebdriverIO adapter API](/adapters/webdriverio/)
-- [Nth request fails](/recipes/nth-request-fails/)
-- [Adapter comparison](/adapters/playwright/)
+- [WebdriverIO adapter API](/chaos-maker/adapters/webdriverio/)
+- [Nth request fails](/chaos-maker/recipes/nth-request-fails/)
+- [Adapter comparison](/chaos-maker/adapters/playwright/)

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: Inject network failures, latency, UI assaults, and WebSocket chaos into your E2E tests without touching your backend.
   actions:
     - text: Get started
-      link: /getting-started/install/
+      link: /chaos-maker/getting-started/install/
       icon: right-arrow
       variant: primary
     - text: View on GitHub
@@ -72,7 +72,7 @@ npm install @chaos-maker/core @chaos-maker/puppeteer
 
 ## Where to go next
 
-- [Install by framework](/getting-started/install/)
-- [Chaos types](/concepts/chaos-types/)
-- [Recipes](/recipes/slow-checkout/)
-- [Config reference](/api/config-reference/)
+- [Install by framework](/chaos-maker/getting-started/install/)
+- [Chaos types](/chaos-maker/concepts/chaos-types/)
+- [Recipes](/chaos-maker/recipes/slow-checkout/)
+- [Config reference](/chaos-maker/api/config-reference/)


### PR DESCRIPTION
## Summary
- Prefix 16 inline docs links + 1 hero action link with `/chaos-maker/` so they resolve under the GitHub Pages base path (was 404ing for all internal navigation from landing + getting-started pages)
- Add `NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}` env to the WebdriverIO and Puppeteer publish steps in [release.yml](.github/workflows/release.yml) — required because npm Trusted Publishing needs a pre-existing package; new packages need a classic token on first publish

## Why
- Root cause of 404s: Astro auto-prefixes assets + Starlight sidebar slugs under `base: '/chaos-maker'`, but does NOT prefix inline markdown links or hero `action.link` fields. Verified with a local build
- The existing adapter publishes (core/playwright/cypress) stay on OIDC Trusted Publishing untouched

## Post-release TODO
After v0.3.0 ships, configure Trusted Publisher on npmjs.com for `@chaos-maker/webdriverio` and `@chaos-maker/puppeteer`, then drop the `NODE_AUTH_TOKEN` env for parity with the other adapters.

## Test plan
- [x] Local `pnpm build:docs` — all links resolve to `/chaos-maker/...`
- [ ] Docs Deploy on main after merge — click through landing "Get started" + "Where to go next" + getting-started "Next steps"
- [ ] First release (v0.3.0 tag) successfully publishes `@chaos-maker/webdriverio` and `@chaos-maker/puppeteer`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation navigation links to reflect reorganized route structure across getting-started guides and homepage.

* **Chores**
  * Enhanced npm package publishing workflow with secure authentication setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->