### PR TITLE
chore: v0.3.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-23
+
+### Added
+
+- **WebdriverIO adapter** (`@chaos-maker/webdriverio`): one-line injection via `injectChaos(browser, config)`, `getChaosLog(browser)`, `getChaosSeed(browser)`, `useChaos(browser, config)`. Embeds the UMD bundle in an injected script tag so Firefox geckodriver still sees the config during initial page load.
+  - E2E suite: 49 tests across Chrome and Firefox covering resilience baseline, presets, network/WebSocket/UI chaos, seeded reproducibility, and Nth-request counting.
+  - New CI jobs `e2e-webdriverio (chrome)` and `e2e-webdriverio (firefox)`.
+- **Puppeteer adapter** (`@chaos-maker/puppeteer`): one-line injection via `injectChaos(page, config)`, `removeChaos(page)`, `getChaosLog(page)`, `getChaosSeed(page)`, `useChaos(page, config)`. Uses `page.evaluateOnNewDocument` to patch `fetch`, `XMLHttpRequest`, and `WebSocket` before any page script runs; tracks init-script identifiers in a `WeakMap<ChaosPage>` so `removeChaos` + repeat `injectChaos` tear down cleanly without stacking.
+  - E2E suite: 37 tests on headless Chromium, mirroring the Playwright suite where applicable.
+  - New CI job `e2e-puppeteer (headless-new)`.
+- **Documentation site** (Starlight-powered, published to GitHub Pages at <https://jvjithin.github.io/chaos-maker/>): 28 pages covering Install, per-adapter Getting Started, Concepts (chaos types, presets, builder, seeded reproducibility, Nth counting, observability), eight Recipes, API reference, and a Rationale section. Search via Pagefind.
+- **Seeded determinism enforcement**: `Math.random` is now an ESLint error across `packages/**` (via `no-restricted-syntax` AST rule, exempt only in `prng.ts`). Every chaos probability decision must flow through `createPrng(seed)` so replays are bit-exact.
+
+### Changed
+
+- `@chaos-maker/core` bumped to 0.3.0 — emits a bit-exact event log for a given seed; any accidental `Math.random` usage now fails CI.
+- `@chaos-maker/playwright` bumped to 0.3.0 to pick up core 0.3.0.
+- `@chaos-maker/cypress` bumped to 0.3.0 to pick up core 0.3.0.
+- Release workflow: new adapters (`webdriverio`, `puppeteer`) publish via classic `NPM_TOKEN` on first release because npm Trusted Publishing requires a pre-existing package. Existing adapters (`core`, `playwright`, `cypress`) continue using OIDC Trusted Publishing.
+
+### Fixed
+
+- **Puppeteer re-injection**: `injectChaos` now removes the prior page's init scripts before registering new ones, preventing double-patching when pages are reused across test cases.
+- **Docs site base path**: inline markdown links and hero actions on the Starlight site are now prefixed with `/chaos-maker/` so they resolve under the GitHub Pages base instead of 404ing.
+- **Deterministic replay test**: reverted an ill-fitting event-based wait — chaos events are probabilistic so `waitForChaosLogGrowth` could hang when the rolled probability said "no chaos"; reverted to fixed `waitForTimeout` since the seeded PRNG already guarantees reproducibility.
+
+### Security
+
+- Upgraded Astro (4 → 6) and Starlight (0.21 → 0.38) in the docs workspace, clearing 19 transitive CVEs.
+- Added `pnpm.overrides` for `diff`, `tar-fs`, `tmp`, `ws`, `serialize-javascript`, `fast-xml-parser` to patch 8 more transitive CVEs across the repo.
+- One residual Dependabot alert (`uuid < 14.0.0` via `@cypress/request@3.0.10`) is accepted as tolerable: dev-only transitive, no patched version in range, exploit path (user-controlled `buf` into `v3/v5/v6`) not reachable from Cypress's usage.
+
 ## [0.2.0] - 2026-04-17
 
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "A lightweight, framework-agnostic toolkit for injecting chaos into web applications to test frontend resilience",
   "keywords": [

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/cypress",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Cypress adapter for @chaos-maker/core — custom commands for one-line chaos injection",
   "keywords": [

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/playwright",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Playwright adapter for @chaos-maker/core — one-line chaos injection in E2E tests",
   "keywords": [


### PR DESCRIPTION
## Summary
- Bump `@chaos-maker/core`, `@chaos-maker/playwright`, `@chaos-maker/cypress` from 0.2.0 → 0.3.0 (webdriverio + puppeteer are already at 0.3.0 from their introduction PRs)
- Move the empty CHANGELOG `[Unreleased]` section into a full `[0.3.0] - 2026-04-23` entry with Added / Changed / Fixed / Security subsections

## Why
Without these bumps, tagging `v0.3.0` would trigger publish jobs for already-existing versions and the release workflow would fail on `publish-core` with 403 Forbidden (version already published).

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 187 passed
- [x] `pnpm build` — all 5 packages build
- [ ] CI full matrix (E2E Playwright, Cypress, WebdriverIO, Puppeteer, Docs)