### PR TITLE
chore(release): remove NPM_TOKEN fallback for new adapters

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,8 +215,6 @@ jobs:
         run: pnpm build:core && pnpm build:webdriverio
 
       - name: Publish WebdriverIO Adapter
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm --filter @chaos-maker/webdriverio publish --no-git-checks --access public
 
   publish-puppeteer:
@@ -247,6 +245,4 @@ jobs:
         run: pnpm build:core && pnpm build:puppeteer
 
       - name: Publish Puppeteer Adapter
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm --filter @chaos-maker/puppeteer publish --no-git-checks --access public


### PR DESCRIPTION
## Summary
- Trusted Publisher is now configured on npmjs.com for `@chaos-maker/webdriverio` and `@chaos-maker/puppeteer` (done manually post-v0.3.0)
- Remove the `NODE_AUTH_TOKEN` env fallback so both adapters publish via OIDC like the other three packages
- No change to `core`, `playwright`, `cypress` — they were already on OIDC

## Test plan
- [ ] Release workflow runs on next tag without needing `NPM_TOKEN` secret