### PR TITLE
feat(sse): Server-Sent Events chaos across core + 3 adapters (v0.4.0 phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Service Worker chaos (Phase 1 of v0.4.0)**: chaos rules now apply to fetches issued from a service worker. New subpath export `@chaos-maker/core/sw` ships dual ESM (`sw.mjs`) + IIFE (`sw.js`) bundles excluding Zod, the UI assailant, and the builder. Users add one line to their service worker (`importScripts('/path/to/chaos-maker-sw.js')` for classic SWs, or `import { installChaosSW } from '@chaos-maker/core/sw'` for module SWs). New shared `SW_BRIDGE_SOURCE` constant + `injectSWChaos`, `removeSWChaos`, `getSWChaosLog`, and `getSWChaosLogFromSW` helpers in all 4 adapters. Auto-reapply on `controllerchange` so SW updates inherit config.
+- **SSE / EventSource chaos (Phase 2 of v0.4.0)**: new `sse` config block on `ChaosConfig` with `drops`, `delays`, `corruptions`, and `closes`. Mirrors the WebSocket interceptor's wrapper-constructor approach to patch `globalThis.EventSource` — intercepts inbound `MessageEvent`s, supports per-rule `urlPattern`, `eventType` (named events or `'*'` wildcard), `probability`, `onNth`/`everyNth`/`afterN`, and the four standard corruption strategies (`truncate`, `malformed-json`, `empty`, `wrong-type`). New events `sse:drop`, `sse:delay`, `sse:corrupt`, `sse:close`. Builder shortcuts `dropSSE`, `delaySSE`, `corruptSSE`, `closeSSE`. New `unreliableEventStream` preset (5% drops + 200ms delay + 2% close-after-2s). Wildcard rules auto-attach a chaos listener whenever the app subscribes to a new named event type. SSE types re-exported from all 4 adapters; new E2E coverage on Playwright (chromium+firefox+webkit+edge), Cypress (chrome+electron), and Puppeteer.
+
 ### Changed
 
 - **`@chaos-maker/core` — `globalThis` refactor (Phase 0 of v0.4.0)**: interceptors read their targets (`fetch`, `XMLHttpRequest`, `WebSocket`) through `globalThis` instead of `window`, so the same engine code now runs in both browser page contexts and service worker / worker contexts. No public API change beyond a new optional `ChaosMaker(config, { target })` constructor argument that defaults to `globalThis`.

--- a/e2e-tests/cypress/cypress.config.ts
+++ b/e2e-tests/cypress/cypress.config.ts
@@ -9,6 +9,7 @@ const PNPM_BIN = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 
 let httpServer: ChildProcess | null = null;
 let wsServer: ChildProcess | null = null;
+let sseServer: ChildProcess | null = null;
 
 async function waitForHttp(url: string, timeoutMs = 20_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
@@ -64,14 +65,22 @@ export default defineConfig({
           [path.join(FIXTURES, 'ws-echo-server.cjs')],
           { stdio: 'pipe' },
         );
+        sseServer = spawn(
+          'node',
+          [path.join(FIXTURES, 'sse-server.cjs')],
+          { stdio: 'pipe' },
+        );
         await waitForHttp('http://127.0.0.1:8080');
+        await waitForHttp('http://127.0.0.1:8082/healthz');
       }
 
       on('after:run', () => {
         httpServer?.kill();
         wsServer?.kill();
+        sseServer?.kill();
         httpServer = null;
         wsServer = null;
+        sseServer = null;
       });
 
       return config;

--- a/e2e-tests/cypress/tests/sse-chaos.cy.ts
+++ b/e2e-tests/cypress/tests/sse-chaos.cy.ts
@@ -1,0 +1,123 @@
+const SSE_PATTERN = '127.0.0.1:8082';
+
+function connect(): void {
+  cy.get('#sse-connect').click();
+  cy.get('#sse-status').should('have.text', 'open');
+}
+
+function connectNamed(): void {
+  cy.get('#sse-connect-named').click();
+  cy.get('#sse-status').should('have.text', 'open');
+}
+
+// ---------------------------------------------------------------------------
+// Drop — every 2nd inbound message is silently discarded.
+// ---------------------------------------------------------------------------
+describe('SSE drop', () => {
+  it('drops every 2nd inbound event', () => {
+    cy.injectChaos({
+      sse: { drops: [{ urlPattern: SSE_PATTERN, probability: 1, everyNth: 2 }] },
+    });
+    cy.visit('/');
+    connect();
+    cy.wait(1500);
+    cy.get('#sse-message-count').then(($el) => {
+      expect(Number($el.text())).to.be.greaterThan(0);
+    });
+    cy.getChaosLog().then((log) => {
+      const drops = log.filter((e) => e.type === 'sse:drop' && e.applied);
+      expect(drops.length).to.be.greaterThan(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delay — every event is held for delayMs before delivery.
+// ---------------------------------------------------------------------------
+describe('SSE delay', () => {
+  it('delays inbound messages by >= 600ms', () => {
+    cy.injectChaos({
+      sse: { delays: [{ urlPattern: SSE_PATTERN, delayMs: 800, probability: 1 }] },
+    });
+    cy.visit('/');
+    connect();
+    let connectTime: number;
+    cy.get('#sse-status')
+      .should('have.text', 'open')
+      .then(() => { connectTime = Date.now(); });
+    cy.get('#sse-message-count', { timeout: 10_000 })
+      .should(($el) => {
+        expect(Number($el.text())).to.be.gte(1);
+      })
+      .then(() => {
+        // First message arrives 200ms after connect (server tick) plus 800ms
+        // chaos delay = >= 1000ms; allow generous slack for runner jitter.
+        expect(Date.now() - connectTime).to.be.gte(700);
+      });
+    cy.getChaosLog().then((log) => {
+      expect(log.some((e) => e.type === 'sse:delay')).to.be.true;
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Corrupt — truncate strategy halves event.data text.
+// ---------------------------------------------------------------------------
+describe('SSE corrupt', () => {
+  it('truncates inbound text payload', () => {
+    cy.injectChaos({
+      sse: { corruptions: [{ urlPattern: SSE_PATTERN, strategy: 'truncate', probability: 1 }] },
+    });
+    cy.visit('/');
+    connect();
+    cy.get('#sse-message-count', { timeout: 5000 }).should(($el) => {
+      expect(Number($el.text())).to.be.gte(1);
+    });
+    cy.get('#sse-log').invoke('text').should('match', /msg \d+ tic/);
+    cy.getChaosLog().then((log) => {
+      const evt = log.find((e) => e.type === 'sse:corrupt' && e.applied);
+      expect(evt?.detail.strategy).to.equal('truncate');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Close — force-close the EventSource after afterMs.
+// ---------------------------------------------------------------------------
+describe('SSE close', () => {
+  it('force-closes the source after afterMs', () => {
+    cy.injectChaos({
+      sse: { closes: [{ urlPattern: SSE_PATTERN, probability: 1, afterMs: 600 }] },
+    });
+    cy.visit('/');
+    connect();
+    cy.get('#sse-status', { timeout: 5000 }).should('contain', 'error');
+    cy.getChaosLog().then((log) => {
+      const closes = log.filter((e) => e.type === 'sse:close' && e.applied);
+      expect(closes).to.have.length(1);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Named event — eventType filter targets only the named event.
+// ---------------------------------------------------------------------------
+describe('SSE named eventType', () => {
+  it('drops only "tick" events; default messages survive', () => {
+    cy.injectChaos({
+      sse: { drops: [{ urlPattern: '/sse-named', eventType: 'tick', probability: 1 }] },
+    });
+    cy.visit('/');
+    connectNamed();
+    cy.wait(1500);
+    cy.get('#sse-tick-count').should('have.text', '0');
+    cy.get('#sse-message-count').then(($el) => {
+      expect(Number($el.text())).to.be.greaterThan(0);
+    });
+    cy.getChaosLog().then((log) => {
+      const drops = log.filter((e) => e.type === 'sse:drop' && e.applied);
+      expect(drops.length).to.be.greaterThan(0);
+      expect(drops.every((e) => e.detail.eventType === 'tick')).to.be.true;
+    });
+  });
+});

--- a/e2e-tests/fixtures/index.html
+++ b/e2e-tests/fixtures/index.html
@@ -53,6 +53,19 @@
     <pre id="ws-log"></pre>
   </section>
 
+  <!-- Server-Sent Events -->
+  <section>
+    <h2>EventSource (SSE)</h2>
+    <button id="sse-connect">Connect</button>
+    <button id="sse-connect-named">Connect (named events)</button>
+    <button id="sse-close">Close</button>
+    <div id="sse-status">idle</div>
+    <div id="sse-message-count">0</div>
+    <div id="sse-tick-count">0</div>
+    <div id="sse-error-count">0</div>
+    <pre id="sse-log"></pre>
+  </section>
+
   <script>
     var API_URL = '/api/data.json';
 
@@ -208,6 +221,82 @@
     document.getElementById('ws-close').addEventListener('click', function () {
       if (!ws) return;
       ws.close();
+    });
+
+    // --- Server-Sent Events ---
+    var SSE_BASE = 'http://127.0.0.1:8082';
+    var es = null;
+    var sseMessageCount = 0;
+    var sseTickCount = 0;
+    var sseErrorCount = 0;
+
+    function sseLog(line) {
+      var pre = document.getElementById('sse-log');
+      pre.textContent += line + '\n';
+    }
+
+    function setSseStatus(text) {
+      document.getElementById('sse-status').textContent = text;
+    }
+
+    function setSseMessageCount(n) {
+      document.getElementById('sse-message-count').textContent = String(n);
+    }
+
+    function setSseTickCount(n) {
+      document.getElementById('sse-tick-count').textContent = String(n);
+    }
+
+    function setSseErrorCount(n) {
+      document.getElementById('sse-error-count').textContent = String(n);
+    }
+
+    function resetSseCounters() {
+      sseMessageCount = 0;
+      sseTickCount = 0;
+      sseErrorCount = 0;
+      setSseMessageCount(0);
+      setSseTickCount(0);
+      setSseErrorCount(0);
+    }
+
+    function connectSse(url) {
+      if (es && es.readyState !== EventSource.CLOSED) return;
+      resetSseCounters();
+      setSseStatus('connecting');
+      es = new EventSource(url);
+      es.addEventListener('open', function () { setSseStatus('open'); });
+      es.addEventListener('message', function (evt) {
+        sseMessageCount += 1;
+        setSseMessageCount(sseMessageCount);
+        sseLog('msg ' + Date.now() + ' ' + String(evt.data));
+      });
+      es.addEventListener('tick', function (evt) {
+        sseTickCount += 1;
+        setSseTickCount(sseTickCount);
+        sseLog('tick ' + Date.now() + ' ' + String(evt.data));
+      });
+      es.addEventListener('error', function () {
+        sseErrorCount += 1;
+        setSseErrorCount(sseErrorCount);
+        var state = es ? es.readyState : -1;
+        setSseStatus('error ' + state);
+        sseLog('err ' + Date.now() + ' state=' + state);
+      });
+    }
+
+    document.getElementById('sse-connect').addEventListener('click', function () {
+      connectSse(SSE_BASE + '/sse');
+    });
+
+    document.getElementById('sse-connect-named').addEventListener('click', function () {
+      connectSse(SSE_BASE + '/sse-named');
+    });
+
+    document.getElementById('sse-close').addEventListener('click', function () {
+      if (!es) return;
+      es.close();
+      setSseStatus('closed');
     });
   </script>
 </body>

--- a/e2e-tests/fixtures/sse-server.cjs
+++ b/e2e-tests/fixtures/sse-server.cjs
@@ -1,0 +1,78 @@
+// Minimal Server-Sent Events server for chaos-maker E2E tests.
+// Streams `data: tick N` lines every 200 ms on /sse and a mix of named
+// events (`event: tick`, `event: heartbeat`) every 200 ms on /sse-named.
+// Kept as plain JS so Playwright `webServer` can `node` it directly.
+
+const http = require('node:http');
+
+const PORT = Number(process.env.SSE_PORT || 8082);
+
+function writeCorsHeaders(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+}
+
+function startStream(res, makeFrame, intervalMs = 200) {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    'Connection': 'keep-alive',
+    'Access-Control-Allow-Origin': '*',
+  });
+  // Initial flush so the client transitions to OPEN promptly.
+  res.write(': stream-open\n\n');
+
+  let i = 0;
+  const interval = setInterval(() => {
+    i += 1;
+    try {
+      res.write(makeFrame(i));
+    } catch {
+      clearInterval(interval);
+    }
+  }, intervalMs);
+
+  res.on('close', () => clearInterval(interval));
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'OPTIONS') {
+    writeCorsHeaders(res);
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  if (req.url === '/sse' && req.method === 'GET') {
+    startStream(res, (i) => `data: tick ${i}\n\n`);
+    return;
+  }
+
+  if (req.url === '/sse-named' && req.method === 'GET') {
+    startStream(res, (i) => {
+      // Alternate between a named `tick` event and the default unnamed event.
+      if (i % 2 === 1) return `event: tick\ndata: ${i}\n\n`;
+      return `data: heartbeat ${i}\n\n`;
+    });
+    return;
+  }
+
+  if (req.url === '/healthz') {
+    writeCorsHeaders(res);
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('ok');
+    return;
+  }
+
+  writeCorsHeaders(res);
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('not found');
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`[sse] listening on http://127.0.0.1:${PORT}`);
+});
+
+const close = () => server.close(() => process.exit(0));
+process.on('SIGTERM', close);
+process.on('SIGINT', close);

--- a/e2e-tests/playwright/playwright.config.ts
+++ b/e2e-tests/playwright/playwright.config.ts
@@ -38,5 +38,10 @@ export default defineConfig({
       port: 8081,
       reuseExistingServer: !process.env.CI,
     },
+    {
+      command: 'node ../fixtures/sse-server.cjs',
+      url: 'http://127.0.0.1:8082/healthz',
+      reuseExistingServer: !process.env.CI,
+    },
   ],
 });

--- a/e2e-tests/playwright/tests/sse-chaos.spec.ts
+++ b/e2e-tests/playwright/tests/sse-chaos.spec.ts
@@ -34,8 +34,9 @@ test.describe('SSE drop', () => {
     const log = await getChaosLog(page);
     const drops = log.filter(e => e.type === 'sse:drop' && e.applied);
     expect(drops.length).toBeGreaterThan(0);
-    // dropped + delivered should equal total events the engine saw.
-    expect(drops.length + count).toBeGreaterThanOrEqual(drops.length);
+    // everyNth: 2 → drop / deliver should be roughly balanced. Loose bound
+    // tolerates ±1 jitter when a tick happens to land on a window boundary.
+    expect(Math.abs(drops.length - count)).toBeLessThanOrEqual(1);
   });
 });
 
@@ -136,39 +137,72 @@ test.describe('SSE named eventType', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Seeded replay — identical seeds → identical drop patterns.
+// Seeded replay — identical seeds → identical drop sequence.
+//
+// Server emits `tick N` with sequential N. App records delivered ticks in
+// `#sse-log` (`msg <ts> tick N`). The dropped tick numbers = {1..max} minus
+// the delivered set. Same seed + same probability + same engine-event order
+// must produce identical dropped-tick sets.
 // ---------------------------------------------------------------------------
 test.describe('SSE seeded replay', () => {
-  test('same seed produces identical drop outcomes', async ({ page }) => {
+  async function deliveredTickNumbers(page: Page): Promise<number[]> {
+    const text = await page.locator('#sse-log').textContent() ?? '';
+    return [...text.matchAll(/tick (\d+)/g)].map(m => Number(m[1]));
+  }
+
+  async function waitForTotalEvents(page: Page, target: number): Promise<void> {
+    await page.waitForFunction(([t]) => {
+      const win = globalThis as unknown as { chaosUtils?: { getLog: () => { type: string; applied: boolean }[] } };
+      const drops = win.chaosUtils
+        ? win.chaosUtils.getLog().filter(e => e.type === 'sse:drop' && e.applied).length
+        : 0;
+      const delivered = Number(document.getElementById('sse-message-count')?.textContent ?? 0);
+      return drops + delivered >= t;
+    }, [target], { timeout: 10_000 });
+  }
+
+  test('same seed produces identical dropped-tick sets', async ({ page }) => {
     const cfg = {
       seed: 9000,
       sse: { drops: [{ urlPattern: SSE_URL_PATTERN, probability: 0.5 }] },
     };
+    const TARGET = 6;
+
     await injectChaos(page, cfg);
     await page.goto(BASE_URL);
     await connectDefault(page);
-    await page.waitForTimeout(1500);
+    await waitForTotalEvents(page, TARGET);
     const seed1 = await getChaosSeed(page);
-    const drops1 = (await getChaosLog(page))
-      .filter(e => e.type === 'sse:drop')
-      .map(e => e.detail.eventType);
+    const delivered1 = await deliveredTickNumbers(page);
+    const drops1 = (await getChaosLog(page)).filter(e => e.type === 'sse:drop' && e.applied).length;
+    const max1 = Math.max(drops1 + delivered1.length, ...delivered1);
+    const dropped1 = new Set<number>();
+    for (let i = 1; i <= max1; i++) if (!delivered1.includes(i)) dropped1.add(i);
 
     const page2 = await page.context().newPage();
     await injectChaos(page2, cfg);
     await page2.goto(BASE_URL);
     await page2.click('#sse-connect');
     await expect(page2.locator('#sse-status')).toHaveText('open');
-    await page2.waitForTimeout(1500);
+    await waitForTotalEvents(page2, TARGET);
     const seed2 = await getChaosSeed(page2);
-    const drops2 = (await getChaosLog(page2))
-      .filter(e => e.type === 'sse:drop')
-      .map(e => e.detail.eventType);
+    const delivered2 = await deliveredTickNumbers(page2);
+    const drops2 = (await getChaosLog(page2)).filter(e => e.type === 'sse:drop' && e.applied).length;
+    const max2 = Math.max(drops2 + delivered2.length, ...delivered2);
+    const dropped2 = new Set<number>();
+    for (let i = 1; i <= max2; i++) if (!delivered2.includes(i)) dropped2.add(i);
 
     expect(seed1).toBe(9000);
     expect(seed2).toBe(9000);
-    // Server timing varies → counts may differ; assert prefix equality on
-    // the first N decisions where N is min length.
-    const minLen = Math.min(drops1.length, drops2.length);
-    expect(drops1.slice(0, minLen)).toEqual(drops2.slice(0, minLen));
+    // Two runs may stop after a different total tick count, so compare the
+    // shared prefix only — every tick index present in both windows must
+    // have the same drop/deliver outcome.
+    const sharedMax = Math.min(max1, max2);
+    const prefix1 = [...dropped1].filter(n => n <= sharedMax).sort((a, b) => a - b);
+    const prefix2 = [...dropped2].filter(n => n <= sharedMax).sort((a, b) => a - b);
+    expect(prefix1).toEqual(prefix2);
+    // Sanity: at least one drop in the shared window so the assertion isn't
+    // trivially satisfied by an empty set.
+    expect(prefix1.length).toBeGreaterThan(0);
   });
 });

--- a/e2e-tests/playwright/tests/sse-chaos.spec.ts
+++ b/e2e-tests/playwright/tests/sse-chaos.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect, type Page } from '@playwright/test';
+import { injectChaos, getChaosLog, getChaosSeed } from '@chaos-maker/playwright';
+
+const BASE_URL = 'http://127.0.0.1:8080';
+const SSE_URL_PATTERN = '127.0.0.1:8082';
+
+async function connectDefault(page: Page): Promise<void> {
+  await page.click('#sse-connect');
+  await expect(page.locator('#sse-status')).toHaveText('open');
+}
+
+async function messageCount(page: Page): Promise<number> {
+  return Number(await page.locator('#sse-message-count').textContent());
+}
+
+// ---------------------------------------------------------------------------
+// Drop — every 2nd inbound message is silently discarded.
+// ---------------------------------------------------------------------------
+test.describe('SSE drop', () => {
+  test('drops every 2nd inbound event and emits sse:drop', async ({ page }) => {
+    await injectChaos(page, {
+      sse: {
+        drops: [{ urlPattern: SSE_URL_PATTERN, probability: 1, everyNth: 2 }],
+      },
+    });
+    await page.goto(BASE_URL);
+    await connectDefault(page);
+    // Wait for several ticks (server fires every 200ms).
+    await page.waitForTimeout(1500);
+    const count = await messageCount(page);
+    // With everyNth: 2 the app sees roughly half of the emitted ticks.
+    expect(count).toBeGreaterThan(0);
+
+    const log = await getChaosLog(page);
+    const drops = log.filter(e => e.type === 'sse:drop' && e.applied);
+    expect(drops.length).toBeGreaterThan(0);
+    // dropped + delivered should equal total events the engine saw.
+    expect(drops.length + count).toBeGreaterThanOrEqual(drops.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delay — every event is held for delayMs before delivery.
+// ---------------------------------------------------------------------------
+test.describe('SSE delay', () => {
+  test('delays inbound by >= 600ms relative to baseline', async ({ page }) => {
+    await injectChaos(page, { sse: {} });
+    await page.goto(BASE_URL);
+    await connectDefault(page);
+    const t0 = Date.now();
+    await page.waitForFunction(() => Number(document.getElementById('sse-message-count')?.textContent) >= 1);
+    const baseline = Date.now() - t0;
+
+    const page2 = await page.context().newPage();
+    await injectChaos(page2, {
+      sse: { delays: [{ urlPattern: SSE_URL_PATTERN, delayMs: 800, probability: 1 }] },
+    });
+    await page2.goto(BASE_URL);
+    await page2.click('#sse-connect');
+    await expect(page2.locator('#sse-status')).toHaveText('open');
+    const t1 = Date.now();
+    await page2.waitForFunction(() => Number(document.getElementById('sse-message-count')?.textContent) >= 1, null, { timeout: 5000 });
+    const withChaos = Date.now() - t1;
+
+    expect(withChaos - baseline).toBeGreaterThanOrEqual(600);
+
+    const log = await getChaosLog(page2);
+    expect(log.filter(e => e.type === 'sse:delay').length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Corrupt — truncate strategy halves event.data text.
+// ---------------------------------------------------------------------------
+test.describe('SSE corrupt', () => {
+  test('truncates inbound text payload', async ({ page }) => {
+    await injectChaos(page, {
+      sse: { corruptions: [{ urlPattern: SSE_URL_PATTERN, strategy: 'truncate', probability: 1 }] },
+    });
+    await page.goto(BASE_URL);
+    await connectDefault(page);
+    await page.waitForFunction(() => Number(document.getElementById('sse-message-count')?.textContent) >= 1);
+
+    const logText = await page.locator('#sse-log').textContent();
+    // Server emits 'tick N'; truncated to half = 'tic' (length 3) for 'tick 1'.
+    expect(logText).toMatch(/msg \d+ tic/);
+
+    const log = await getChaosLog(page);
+    const corrupted = log.find(e => e.type === 'sse:corrupt' && e.applied);
+    expect(corrupted?.detail.strategy).toBe('truncate');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Close — force-close the EventSource after afterMs.
+// ---------------------------------------------------------------------------
+test.describe('SSE close', () => {
+  test('force-closes the source after afterMs', async ({ page }) => {
+    await injectChaos(page, {
+      sse: { closes: [{ urlPattern: SSE_URL_PATTERN, probability: 1, afterMs: 600 }] },
+    });
+    await page.goto(BASE_URL);
+    await connectDefault(page);
+
+    await expect(page.locator('#sse-status')).toContainText('error', { timeout: 3000 });
+
+    const log = await getChaosLog(page);
+    const closes = log.filter(e => e.type === 'sse:close' && e.applied);
+    expect(closes.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Named event — eventType filter targets only the named event.
+// ---------------------------------------------------------------------------
+test.describe('SSE named eventType', () => {
+  test('drops only named "tick" events; default messages survive', async ({ page }) => {
+    await injectChaos(page, {
+      sse: { drops: [{ urlPattern: '/sse-named', eventType: 'tick', probability: 1 }] },
+    });
+    await page.goto(BASE_URL);
+    await page.click('#sse-connect-named');
+    await expect(page.locator('#sse-status')).toHaveText('open');
+    await page.waitForTimeout(1500);
+
+    const tickCount = Number(await page.locator('#sse-tick-count').textContent());
+    const msgCount = Number(await page.locator('#sse-message-count').textContent());
+    expect(tickCount).toBe(0);
+    expect(msgCount).toBeGreaterThan(0);
+
+    const log = await getChaosLog(page);
+    const drops = log.filter(e => e.type === 'sse:drop' && e.applied);
+    expect(drops.length).toBeGreaterThan(0);
+    expect(drops.every(e => e.detail.eventType === 'tick')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Seeded replay — identical seeds → identical drop patterns.
+// ---------------------------------------------------------------------------
+test.describe('SSE seeded replay', () => {
+  test('same seed produces identical drop outcomes', async ({ page }) => {
+    const cfg = {
+      seed: 9000,
+      sse: { drops: [{ urlPattern: SSE_URL_PATTERN, probability: 0.5 }] },
+    };
+    await injectChaos(page, cfg);
+    await page.goto(BASE_URL);
+    await connectDefault(page);
+    await page.waitForTimeout(1500);
+    const seed1 = await getChaosSeed(page);
+    const drops1 = (await getChaosLog(page))
+      .filter(e => e.type === 'sse:drop')
+      .map(e => e.detail.eventType);
+
+    const page2 = await page.context().newPage();
+    await injectChaos(page2, cfg);
+    await page2.goto(BASE_URL);
+    await page2.click('#sse-connect');
+    await expect(page2.locator('#sse-status')).toHaveText('open');
+    await page2.waitForTimeout(1500);
+    const seed2 = await getChaosSeed(page2);
+    const drops2 = (await getChaosLog(page2))
+      .filter(e => e.type === 'sse:drop')
+      .map(e => e.detail.eventType);
+
+    expect(seed1).toBe(9000);
+    expect(seed2).toBe(9000);
+    // Server timing varies → counts may differ; assert prefix equality on
+    // the first N decisions where N is min length.
+    const minLen = Math.min(drops1.length, drops2.length);
+    expect(drops1.slice(0, minLen)).toEqual(drops2.slice(0, minLen));
+  });
+});

--- a/e2e-tests/puppeteer/setup/global-setup.ts
+++ b/e2e-tests/puppeteer/setup/global-setup.ts
@@ -9,6 +9,7 @@ const PNPM_BIN = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 
 let httpServer: ChildProcess | null = null;
 let wsServer: ChildProcess | null = null;
+let sseServer: ChildProcess | null = null;
 
 function probeTcp(host: string, port: number, timeoutMs = 500): Promise<boolean> {
   return new Promise((resolve) => {
@@ -32,6 +33,7 @@ async function waitForTcp(host: string, port: number, timeoutMs = 20_000): Promi
 export async function setup(): Promise<void> {
   const httpReady = await probeTcp('127.0.0.1', 8080);
   const wsReady = await probeTcp('127.0.0.1', 8081);
+  const sseReady = await probeTcp('127.0.0.1', 8082);
 
   if (!httpReady) {
     httpServer = spawn(
@@ -50,11 +52,22 @@ export async function setup(): Promise<void> {
     );
     await waitForTcp('127.0.0.1', 8081);
   }
+
+  if (!sseReady) {
+    sseServer = spawn(
+      'node',
+      [resolve(FIXTURES, 'sse-server.cjs')],
+      { stdio: 'inherit' },
+    );
+    await waitForTcp('127.0.0.1', 8082);
+  }
 }
 
 export async function teardown(): Promise<void> {
   httpServer?.kill();
   wsServer?.kill();
+  sseServer?.kill();
   httpServer = null;
   wsServer = null;
+  sseServer = null;
 }

--- a/e2e-tests/puppeteer/tests/sse-chaos.test.ts
+++ b/e2e-tests/puppeteer/tests/sse-chaos.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import type { Browser, Page } from 'puppeteer';
+import { injectChaos, getChaosLog } from '@chaos-maker/puppeteer';
+import type { ChaosEvent } from '@chaos-maker/core';
+import { launchBrowser, BASE_URL, waitForText } from './helpers';
+
+const SSE_URL_PATTERN = '127.0.0.1:8082';
+
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => { browser = await launchBrowser(); });
+afterAll(async () => { await browser.close(); });
+
+beforeEach(async () => { page = await browser.newPage(); });
+afterEach(async () => { await page.close(); });
+
+async function connectDefault(p: Page): Promise<void> {
+  await p.click('#sse-connect');
+  await waitForText(p, '#sse-status', 'open');
+}
+
+async function connectNamed(p: Page): Promise<void> {
+  await p.click('#sse-connect-named');
+  await waitForText(p, '#sse-status', 'open');
+}
+
+async function messageCount(p: Page): Promise<number> {
+  return p.$eval('#sse-message-count', (el) => Number(el.textContent));
+}
+
+async function tickCount(p: Page): Promise<number> {
+  return p.$eval('#sse-tick-count', (el) => Number(el.textContent));
+}
+
+describe('SSE drop', () => {
+  it('drops every 2nd inbound event', async () => {
+    await injectChaos(page, {
+      sse: { drops: [{ urlPattern: SSE_URL_PATTERN, probability: 1, everyNth: 2 }] },
+    });
+    await page.goto(BASE_URL);
+    await connectDefault(page);
+
+    await new Promise((r) => setTimeout(r, 1500));
+    expect(await messageCount(page)).toBeGreaterThan(0);
+
+    const log = (await getChaosLog(page)) as ChaosEvent[];
+    const drops = log.filter((e) => e.type === 'sse:drop' && e.applied);
+    expect(drops.length).toBeGreaterThan(0);
+  });
+});
+
+describe('SSE delay', () => {
+  it('delays inbound messages by >= 600ms relative to baseline', async () => {
+    await injectChaos(page, { sse: {} });
+    await page.goto(BASE_URL);
+    await connectDefault(page);
+    const t0 = Date.now();
+    await page.waitForFunction(
+      () => Number(document.getElementById('sse-message-count')?.textContent) >= 1,
+    );
+    const baseline = Date.now() - t0;
+
+    const page2 = await browser.newPage();
+    await injectChaos(page2, {
+      sse: { delays: [{ urlPattern: SSE_URL_PATTERN, delayMs: 800, probability: 1 }] },
+    });
+    await page2.goto(BASE_URL);
+    await page2.click('#sse-connect');
+    await waitForText(page2, '#sse-status', 'open');
+    const t1 = Date.now();
+    await page2.waitForFunction(
+      () => Number(document.getElementById('sse-message-count')?.textContent) >= 1,
+      { timeout: 10_000 },
+    );
+    const withChaos = Date.now() - t1;
+    await page2.close();
+
+    expect(withChaos - baseline).toBeGreaterThanOrEqual(600);
+  });
+});
+
+describe('SSE corrupt', () => {
+  it('truncates inbound text payload', async () => {
+    await injectChaos(page, {
+      sse: { corruptions: [{ urlPattern: SSE_URL_PATTERN, strategy: 'truncate', probability: 1 }] },
+    });
+    await page.goto(BASE_URL);
+    await connectDefault(page);
+    await page.waitForFunction(
+      () => Number(document.getElementById('sse-message-count')?.textContent) >= 1,
+      { timeout: 5_000 },
+    );
+    const logText = await page.$eval('#sse-log', (el) => el.textContent ?? '');
+    expect(logText).toMatch(/tic/);
+
+    const log = (await getChaosLog(page)) as ChaosEvent[];
+    const corrupted = log.find((e) => e.type === 'sse:corrupt' && e.applied);
+    expect(corrupted?.detail.strategy).toBe('truncate');
+  });
+});
+
+describe('SSE close', () => {
+  it('force-closes the source after afterMs', async () => {
+    await injectChaos(page, {
+      sse: { closes: [{ urlPattern: SSE_URL_PATTERN, probability: 1, afterMs: 600 }] },
+    });
+    await page.goto(BASE_URL);
+    await connectDefault(page);
+
+    await page.waitForFunction(
+      () => document.getElementById('sse-status')?.textContent?.includes('error'),
+      { timeout: 5_000 },
+    );
+
+    const log = (await getChaosLog(page)) as ChaosEvent[];
+    const closes = log.filter((e) => e.type === 'sse:close' && e.applied);
+    expect(closes.length).toBe(1);
+  });
+});
+
+describe('SSE named eventType', () => {
+  it('drops only named "tick" events; default messages survive', async () => {
+    await injectChaos(page, {
+      sse: { drops: [{ urlPattern: '/sse-named', eventType: 'tick', probability: 1 }] },
+    });
+    await page.goto(BASE_URL);
+    await connectNamed(page);
+
+    await new Promise((r) => setTimeout(r, 1500));
+    expect(await tickCount(page)).toBe(0);
+    expect(await messageCount(page)).toBeGreaterThan(0);
+
+    const log = (await getChaosLog(page)) as ChaosEvent[];
+    const drops = log.filter((e) => e.type === 'sse:drop' && e.applied);
+    expect(drops.length).toBeGreaterThan(0);
+    expect(drops.every((e) => e.detail.eventType === 'tick')).toBe(true);
+  });
+});

--- a/e2e-tests/webdriverio/wdio.conf.ts
+++ b/e2e-tests/webdriverio/wdio.conf.ts
@@ -12,6 +12,7 @@ const browserName = process.env.WDIO_BROWSER || 'chrome';
 
 let httpServer: ChildProcess | null = null;
 let wsServer: ChildProcess | null = null;
+let sseServer: ChildProcess | null = null;
 
 async function waitForHttp(url: string, timeoutMs = 20_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
@@ -96,6 +97,7 @@ export const config: WebdriverIO.Config = {
       /* will start HTTP fixture below */
     }
     const wsReady = await probeTcp('127.0.0.1', 8081);
+    const sseReady = await probeTcp('127.0.0.1', 8082);
 
     if (!httpReady) {
       httpServer = spawn(
@@ -111,14 +113,24 @@ export const config: WebdriverIO.Config = {
         { stdio: 'inherit' },
       );
     }
+    if (!sseReady) {
+      sseServer = spawn(
+        'node',
+        [resolve(FIXTURES, 'sse-server.cjs')],
+        { stdio: 'inherit' },
+      );
+    }
     if (!httpReady) await waitForHttp('http://127.0.0.1:8080');
     if (!wsReady) await waitForTcp('127.0.0.1', 8081);
+    if (!sseReady) await waitForTcp('127.0.0.1', 8082);
   },
   onComplete() {
     httpServer?.kill();
     wsServer?.kill();
+    sseServer?.kill();
     httpServer = null;
     wsServer = null;
+    sseServer = null;
   },
   async before() {
     registerChaosCommands(browser as never);

--- a/packages/core/src/ChaosMaker.ts
+++ b/packages/core/src/ChaosMaker.ts
@@ -6,6 +6,7 @@ import { patchFetch } from './interceptors/networkFetch';
 import { patchXHR, patchXHROpen } from './interceptors/networkXHR';
 import { attachDomAssailant } from './interceptors/domAssailant';
 import { patchWebSocket, WebSocketPatchHandle } from './interceptors/websocket';
+import { patchEventSource, EventSourceLikeStatic, EventSourcePatchHandle } from './interceptors/eventSource';
 
 /**
  * Global context ChaosMaker patches against. Must expose at minimum `fetch`
@@ -37,6 +38,8 @@ export class ChaosMaker {
   private domObserver?: MutationObserver;
   private originalWebSocket?: typeof WebSocket;
   private webSocketHandle?: WebSocketPatchHandle;
+  private originalEventSource?: typeof EventSource;
+  private eventSourceHandle?: EventSourcePatchHandle;
   /** Shared counters keyed by config rule object reference. Shared across fetch + XHR + WS. */
   private requestCounters: Map<object, number> = new Map();
 
@@ -123,6 +126,18 @@ export class ChaosMaker {
       );
       target.WebSocket = this.webSocketHandle.Wrapped;
     }
+
+    if (this.config.sse && typeof target.EventSource !== 'undefined') {
+      this.originalEventSource = target.EventSource;
+      this.eventSourceHandle = patchEventSource(
+        this.originalEventSource as unknown as EventSourceLikeStatic,
+        this.config.sse,
+        this.emitter,
+        this.random,
+        this.requestCounters,
+      );
+      target.EventSource = this.eventSourceHandle.Wrapped;
+    }
   }
 
   public stop(): void {
@@ -151,6 +166,14 @@ export class ChaosMaker {
     if (this.webSocketHandle) {
       this.webSocketHandle.uninstall();
       this.webSocketHandle = undefined;
+    }
+    if (this.originalEventSource) {
+      target.EventSource = this.originalEventSource;
+      this.originalEventSource = undefined;
+    }
+    if (this.eventSourceHandle) {
+      this.eventSourceHandle.uninstall();
+      this.eventSourceHandle = undefined;
     }
   }
 }

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -1,4 +1,4 @@
-import { ChaosConfig, CorruptionStrategy, RequestCountingOptions, WebSocketDirection, WebSocketCorruptionStrategy } from './config';
+import { ChaosConfig, CorruptionStrategy, RequestCountingOptions, SSECorruptionStrategy, WebSocketDirection, WebSocketCorruptionStrategy } from './config';
 
 function cloneConfig(config: ChaosConfig): ChaosConfig {
   return JSON.parse(JSON.stringify(config));
@@ -8,10 +8,11 @@ export class ChaosConfigBuilder {
   private config: ChaosConfig;
 
   constructor(initialConfig?: ChaosConfig) {
-    this.config = initialConfig ? cloneConfig(initialConfig) : { network: {}, ui: {}, websocket: {} };
+    this.config = initialConfig ? cloneConfig(initialConfig) : { network: {}, ui: {}, websocket: {}, sse: {} };
     if (!this.config.network) this.config.network = {};
     if (!this.config.ui) this.config.ui = {};
     if (!this.config.websocket) this.config.websocket = {};
+    if (!this.config.sse) this.config.sse = {};
   }
 
   failRequests(urlPattern: string, statusCode: number, probability: number, methods?: string[], body?: string, headers?: Record<string, string>, counting?: RequestCountingOptions) {
@@ -150,6 +151,32 @@ export class ChaosConfigBuilder {
 
   delayMessagesOnNth(urlPattern: string, direction: WebSocketDirection, delayMs: number, n: number) {
     return this.delayMessages(urlPattern, direction, delayMs, 1, { onNth: n });
+  }
+
+  // --- SSE / EventSource chaos ---
+
+  dropSSE(urlPattern: string, probability: number, eventType?: string, counting?: RequestCountingOptions) {
+    if (!this.config.sse!.drops) this.config.sse!.drops = [];
+    this.config.sse!.drops.push({ urlPattern, probability, ...(eventType ? { eventType } : {}), ...counting });
+    return this;
+  }
+
+  delaySSE(urlPattern: string, delayMs: number, probability: number, eventType?: string, counting?: RequestCountingOptions) {
+    if (!this.config.sse!.delays) this.config.sse!.delays = [];
+    this.config.sse!.delays.push({ urlPattern, delayMs, probability, ...(eventType ? { eventType } : {}), ...counting });
+    return this;
+  }
+
+  corruptSSE(urlPattern: string, strategy: SSECorruptionStrategy, probability: number, eventType?: string, counting?: RequestCountingOptions) {
+    if (!this.config.sse!.corruptions) this.config.sse!.corruptions = [];
+    this.config.sse!.corruptions.push({ urlPattern, strategy, probability, ...(eventType ? { eventType } : {}), ...counting });
+    return this;
+  }
+
+  closeSSE(urlPattern: string, probability: number, opts?: { afterMs?: number }, counting?: RequestCountingOptions) {
+    if (!this.config.sse!.closes) this.config.sse!.closes = [];
+    this.config.sse!.closes.push({ urlPattern, probability, ...opts, ...counting });
+    return this;
   }
 
   /** Set the PRNG seed for reproducible chaos. */

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -130,10 +130,60 @@ export interface WebSocketConfig {
   closes?: WebSocketCloseConfig[];
 }
 
+/** Strategies for corrupting Server-Sent Event payloads.
+ *  All four strategies operate on `event.data` (always a string per the SSE
+ *  spec). Mirrors the fetch / WebSocket corruption shape so the same
+ *  vocabulary applies across protocols.
+ */
+export type SSECorruptionStrategy = 'truncate' | 'malformed-json' | 'empty' | 'wrong-type';
+
+/** Filter SSE chaos to a specific event type.
+ *  - `'message'` (default in the spec) targets unnamed events fired via
+ *    `onmessage` / `addEventListener('message', …)`.
+ *  - Any other string targets named events dispatched with `event:` lines.
+ *  - `'*'` matches every event regardless of name.
+ */
+export type SSEEventTypeMatcher = string | '*';
+
+export interface SSEDropConfig extends RequestCountingOptions {
+  urlPattern: string;
+  eventType?: SSEEventTypeMatcher;
+  probability: number;
+}
+
+export interface SSEDelayConfig extends RequestCountingOptions {
+  urlPattern: string;
+  eventType?: SSEEventTypeMatcher;
+  delayMs: number;
+  probability: number;
+}
+
+export interface SSECorruptConfig extends RequestCountingOptions {
+  urlPattern: string;
+  eventType?: SSEEventTypeMatcher;
+  strategy: SSECorruptionStrategy;
+  probability: number;
+}
+
+export interface SSECloseConfig extends RequestCountingOptions {
+  urlPattern: string;
+  /** Delay after `open` before dispatching `error` + closing, in ms. Default 0. */
+  afterMs?: number;
+  probability: number;
+}
+
+export interface SSEConfig {
+  drops?: SSEDropConfig[];
+  delays?: SSEDelayConfig[];
+  corruptions?: SSECorruptConfig[];
+  closes?: SSECloseConfig[];
+}
+
 export interface ChaosConfig {
   network?: NetworkConfig;
   ui?: UiConfig;
   websocket?: WebSocketConfig;
+  sse?: SSEConfig;
   /**
    * Seed for Chaos Maker's PRNG.
    *

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -8,7 +8,11 @@ export type ChaosEventType =
   | 'websocket:drop'
   | 'websocket:delay'
   | 'websocket:corrupt'
-  | 'websocket:close';
+  | 'websocket:close'
+  | 'sse:drop'
+  | 'sse:delay'
+  | 'sse:corrupt'
+  | 'sse:close';
 
 export interface ChaosEvent {
   type: ChaosEventType;
@@ -31,6 +35,8 @@ export interface ChaosEvent {
     closeCode?: number;
     /** WebSocket close reason (for `websocket:close` events). */
     closeReason?: string;
+    /** SSE event type (for `sse:*` events). `'message'` is the spec default. */
+    eventType?: string;
     /** Reason string for diagnostic `applied: false` events. */
     reason?: string;
   };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 import { ChaosMaker } from './ChaosMaker';
-import { ChaosConfig, CorruptionStrategy, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig, WebSocketConfig, WebSocketDropConfig, WebSocketDelayConfig, WebSocketCorruptConfig, WebSocketCloseConfig, WebSocketDirection, WebSocketCorruptionStrategy } from './config';
+import { ChaosConfig, CorruptionStrategy, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig, WebSocketConfig, WebSocketDropConfig, WebSocketDelayConfig, WebSocketCorruptConfig, WebSocketCloseConfig, WebSocketDirection, WebSocketCorruptionStrategy, SSEConfig, SSEDropConfig, SSEDelayConfig, SSECorruptConfig, SSECloseConfig, SSECorruptionStrategy, SSEEventTypeMatcher } from './config';
 import { ChaosConfigError } from './errors';
 import { validateConfig } from './validation';
 import { ChaosEvent, ChaosEventType, ChaosEventListener, ChaosEventEmitter } from './events';
@@ -9,7 +9,7 @@ import { createPrng, generateSeed } from './prng';
 
 export { ChaosMaker, ChaosConfigError, validateConfig, ChaosEventEmitter, ChaosConfigBuilder, presets, createPrng, generateSeed };
 export { SW_BRIDGE_SOURCE } from './sw-bridge-source';
-export type { ChaosConfig, CorruptionStrategy, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig, WebSocketConfig, WebSocketDropConfig, WebSocketDelayConfig, WebSocketCorruptConfig, WebSocketCloseConfig, WebSocketDirection, WebSocketCorruptionStrategy, ChaosEvent, ChaosEventType, ChaosEventListener };
+export type { ChaosConfig, CorruptionStrategy, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, UiAssaultConfig, UiConfig, WebSocketConfig, WebSocketDropConfig, WebSocketDelayConfig, WebSocketCorruptConfig, WebSocketCloseConfig, WebSocketDirection, WebSocketCorruptionStrategy, SSEConfig, SSEDropConfig, SSEDelayConfig, SSECorruptConfig, SSECloseConfig, SSECorruptionStrategy, SSEEventTypeMatcher, ChaosEvent, ChaosEventType, ChaosEventListener };
 
 // --- NEW INTERFACE ---
 interface ChaosUtilsApi {

--- a/packages/core/src/interceptors/eventSource.ts
+++ b/packages/core/src/interceptors/eventSource.ts
@@ -208,6 +208,12 @@ export function patchEventSource(
           untrackTimer(source, timer);
           // After stop, swallow the deferred dispatch; the wrapper is disarmed.
           if (!running) return;
+          // App may have called source.close() while the message was queued.
+          // EventTarget.dispatchEvent still fires synchronously on a closed
+          // source, which would deliver a ghost message past close().
+          // CLOSED = 2 per spec; check via constant on the source instance to
+          // avoid hard-coding the literal here.
+          if (source.readyState === source.CLOSED) return;
           redispatch(source, msgEvt, payload);
         }, delayRule.delayMs),
         url, eventType,

--- a/packages/core/src/interceptors/eventSource.ts
+++ b/packages/core/src/interceptors/eventSource.ts
@@ -249,15 +249,18 @@ export function patchEventSource(
       if (!running) return;
       clearSourceTimers(source, 'close-interrupt');
       emitClose(emitter, url, 'chaos-maker-close');
-      try {
-        source.dispatchEvent(new Event('error'));
-      } catch {
-        // never thrown by EventTarget.dispatchEvent in practice; swallow defensively
-      }
+      // WHATWG SSE: on permanent failure, readyState must transition to
+      // CLOSED *before* the error dispatch — so app onerror handlers that
+      // branch on `readyState === CLOSED` see the correct state.
       try {
         source.close();
       } catch {
         // already closed
+      }
+      try {
+        source.dispatchEvent(new Event('error'));
+      } catch {
+        // never thrown by EventTarget.dispatchEvent in practice; swallow defensively
       }
     };
 

--- a/packages/core/src/interceptors/eventSource.ts
+++ b/packages/core/src/interceptors/eventSource.ts
@@ -1,0 +1,357 @@
+/**
+ * EventSource (Server-Sent Events) chaos interceptor.
+ *
+ * Mirrors the WebSocket interceptor's wrapper-constructor strategy: replace
+ * `globalThis.EventSource` with a chaos wrapper that owns a hidden real
+ * `EventSource` instance, intercepts inbound `MessageEvent`s on the capture
+ * phase via `stopImmediatePropagation`, and re-dispatches mutated payloads.
+ *
+ * Design notes:
+ * - SSE is inbound-only (the spec defines no client → server channel beyond
+ *   the initial GET), so direction/payloadType fields are absent vs. WS.
+ * - `event.data` is always a string per the spec — corruption strategies
+ *   reuse the four text strategies from network/WS chaos.
+ * - Counting (onNth/everyNth/afterN) is per-rule, per-event, identical to WS.
+ * - Per-rule ordering on a matched event: drop → corrupt → delay. A dropped
+ *   event short-circuits the rest.
+ * - Close chaos dispatches an `error` event then calls `.close()` on the
+ *   underlying EventSource. Delivery of `error` mirrors what browsers do
+ *   when the upstream connection drops; the app's reconnection logic (if any)
+ *   re-runs the original `new EventSource(url)` path, so a fresh wrapper is
+ *   created and chaos continues.
+ * - On `uninstall()`, every pending delay timer is cleared and an
+ *   `sse:drop` is emitted for it with `reason: 'stop-during-delay'`. Pending
+ *   close timers cancel silently (they had not fired anything yet).
+ */
+
+import {
+  SSEConfig,
+  SSEDropConfig,
+  SSEDelayConfig,
+  SSECorruptConfig,
+  SSECloseConfig,
+  SSECorruptionStrategy,
+  RequestCountingOptions,
+} from '../config';
+import { ChaosEventEmitter } from '../events';
+import { shouldApplyChaos, matchUrl, incrementCounter, checkCountingCondition, corruptText } from '../utils';
+
+const INTERCEPT_MARKER = Symbol.for('chaos-maker.eventsource.intercepted');
+
+type WildcardOrString = string | undefined;
+
+interface PendingDelayTimer {
+  kind: 'delay';
+  handle: ReturnType<typeof setTimeout>;
+  url: string;
+  eventType: string;
+}
+
+interface PendingCloseTimer {
+  kind: 'close';
+  handle: ReturnType<typeof setTimeout>;
+}
+
+type PendingTimer = PendingDelayTimer | PendingCloseTimer;
+
+export interface EventSourceLikeStatic {
+  readonly CONNECTING: 0;
+  readonly OPEN: 1;
+  readonly CLOSED: 2;
+  new (url: string | URL, init?: EventSourceInit): EventSource;
+  prototype: EventSource;
+}
+
+export interface EventSourcePatchHandle {
+  /** Wrapped EventSource constructor suitable for `globalThis.EventSource = …`. */
+  readonly Wrapped: typeof EventSource;
+  /** Cancel pending timers and disarm wrapped instances. Call on ChaosMaker.stop(). */
+  uninstall(): void;
+}
+
+function eventTypeMatches(rule: WildcardOrString, actual: string): boolean {
+  if (rule === undefined || rule === '*') return true;
+  return rule === actual;
+}
+
+function findFiringRule<T extends RequestCountingOptions & { urlPattern: string; eventType?: WildcardOrString; probability: number }>(
+  rules: T[] | undefined,
+  url: string,
+  eventType: string,
+  random: () => number,
+  counters: Map<object, number>,
+): T | null {
+  if (!rules) return null;
+  for (const rule of rules) {
+    if (!matchUrl(url, rule.urlPattern)) continue;
+    if (!eventTypeMatches(rule.eventType, eventType)) continue;
+    const count = incrementCounter(rule, counters);
+    if (!checkCountingCondition(rule, count)) continue;
+    if (!shouldApplyChaos(rule.probability, random)) continue;
+    return rule;
+  }
+  return null;
+}
+
+function emitDrop(emitter: ChaosEventEmitter, url: string, eventType: string, reason?: string): void {
+  emitter.emit({
+    type: 'sse:drop',
+    timestamp: Date.now(),
+    applied: true,
+    detail: { url, eventType, ...(reason ? { reason } : {}) },
+  });
+}
+
+function emitDelay(emitter: ChaosEventEmitter, url: string, eventType: string, delayMs: number): void {
+  emitter.emit({
+    type: 'sse:delay',
+    timestamp: Date.now(),
+    applied: true,
+    detail: { url, eventType, delayMs },
+  });
+}
+
+function emitCorrupt(emitter: ChaosEventEmitter, url: string, eventType: string, strategy: SSECorruptionStrategy): void {
+  emitter.emit({
+    type: 'sse:corrupt',
+    timestamp: Date.now(),
+    applied: true,
+    detail: { url, eventType, strategy },
+  });
+}
+
+function emitClose(emitter: ChaosEventEmitter, url: string, reason: string): void {
+  emitter.emit({
+    type: 'sse:close',
+    timestamp: Date.now(),
+    applied: true,
+    detail: { url, reason },
+  });
+}
+
+export function patchEventSource(
+  OriginalEventSource: EventSourceLikeStatic,
+  config: SSEConfig,
+  emitter: ChaosEventEmitter,
+  random: () => number,
+  counters: Map<object, number>,
+): EventSourcePatchHandle {
+  const pendingTimersBySource = new Map<EventSource, Set<PendingTimer>>();
+  let running = true;
+
+  const trackTimer = (source: EventSource, timer: PendingTimer): void => {
+    let set = pendingTimersBySource.get(source);
+    if (!set) {
+      set = new Set();
+      pendingTimersBySource.set(source, set);
+    }
+    set.add(timer);
+  };
+
+  const untrackTimer = (source: EventSource, timer: PendingTimer): void => {
+    pendingTimersBySource.get(source)?.delete(timer);
+  };
+
+  const clearSourceTimers = (source: EventSource, reason: string): void => {
+    const set = pendingTimersBySource.get(source);
+    if (!set) return;
+    for (const timer of set) {
+      clearTimeout(timer.handle);
+      if (timer.kind === 'delay') {
+        emitDrop(emitter, timer.url, timer.eventType, reason);
+      }
+    }
+    pendingTimersBySource.delete(source);
+  };
+
+  const redispatch = (source: EventSource, original: MessageEvent, data: string): void => {
+    const newEvent = new MessageEvent(original.type || 'message', {
+      data,
+      origin: original.origin,
+      lastEventId: original.lastEventId,
+    });
+    (newEvent as unknown as Record<symbol, unknown>)[INTERCEPT_MARKER] = true;
+    source.dispatchEvent(newEvent);
+  };
+
+  const handleInbound = (source: EventSource, url: string, msgEvt: MessageEvent): void => {
+    if ((msgEvt as unknown as Record<symbol, unknown>)[INTERCEPT_MARKER]) return;
+    if (!running) return;
+
+    // `MessageEvent.type` reflects the SSE event name, defaulting to 'message'
+    // for unnamed events.
+    const eventType = msgEvt.type || 'message';
+
+    if (findFiringRule<SSEDropConfig>(config.drops, url, eventType, random, counters)) {
+      msgEvt.stopImmediatePropagation();
+      emitDrop(emitter, url, eventType);
+      return;
+    }
+
+    let payload = typeof msgEvt.data === 'string' ? msgEvt.data : String(msgEvt.data);
+    let mutated = false;
+
+    const corruptRule = findFiringRule<SSECorruptConfig>(config.corruptions, url, eventType, random, counters);
+    if (corruptRule) {
+      payload = corruptText(payload, corruptRule.strategy);
+      mutated = true;
+      emitCorrupt(emitter, url, eventType, corruptRule.strategy);
+    }
+
+    const delayRule = findFiringRule<SSEDelayConfig>(config.delays, url, eventType, random, counters);
+    if (delayRule) {
+      msgEvt.stopImmediatePropagation();
+      emitDelay(emitter, url, eventType, delayRule.delayMs);
+      const timer: PendingDelayTimer = {
+        kind: 'delay',
+        handle: setTimeout(() => {
+          untrackTimer(source, timer);
+          // After stop, swallow the deferred dispatch; the wrapper is disarmed.
+          if (!running) return;
+          redispatch(source, msgEvt, payload);
+        }, delayRule.delayMs),
+        url, eventType,
+      };
+      trackTimer(source, timer);
+      return;
+    }
+
+    if (mutated) {
+      msgEvt.stopImmediatePropagation();
+      redispatch(source, msgEvt, payload);
+    }
+  };
+
+  const findCloseRule = (url: string): SSECloseConfig | null => {
+    if (!config.closes) return null;
+    for (const rule of config.closes) {
+      if (!matchUrl(url, rule.urlPattern)) continue;
+      const count = incrementCounter(rule, counters);
+      if (!checkCountingCondition(rule, count)) continue;
+      if (!shouldApplyChaos(rule.probability, random)) continue;
+      return rule;
+    }
+    return null;
+  };
+
+  const scheduleCloseChaos = (source: EventSource, url: string): void => {
+    const rule = findCloseRule(url);
+    if (!rule) return;
+    const afterMs = rule.afterMs ?? 0;
+
+    const fire = (): void => {
+      if (!running) return;
+      clearSourceTimers(source, 'close-interrupt');
+      emitClose(emitter, url, 'chaos-maker-close');
+      try {
+        source.dispatchEvent(new Event('error'));
+      } catch {
+        // never thrown by EventTarget.dispatchEvent in practice; swallow defensively
+      }
+      try {
+        source.close();
+      } catch {
+        // already closed
+      }
+    };
+
+    if (afterMs <= 0) {
+      // Schedule on next tick so app code that attaches listeners
+      // synchronously after `new EventSource(...)` still sees the close.
+      const timer: PendingCloseTimer = { kind: 'close', handle: setTimeout(fire, 0) };
+      trackTimer(source, timer);
+    } else {
+      const timer: PendingCloseTimer = { kind: 'close', handle: setTimeout(fire, afterMs) };
+      trackTimer(source, timer);
+    }
+  };
+
+  function ChaosEventSource(this: unknown, url: string | URL, init?: EventSourceInit): EventSource {
+    const source = new OriginalEventSource(url, init);
+    const urlStr = typeof url === 'string' ? url : url.toString();
+
+    // Capture-phase listener so we run before any user-attached message
+    // handler; `stopImmediatePropagation` then prevents the raw event from
+    // reaching the app when we drop / delay / corrupt.
+    const messageHandler = (evt: Event): void => {
+      handleInbound(source, urlStr, evt as MessageEvent);
+    };
+    const installedChaosTypes = new Set<string>();
+    const realAddEventListener = source.addEventListener.bind(source);
+    const installChaosListenerFor = (type: string): void => {
+      if (installedChaosTypes.has(type)) return;
+      installedChaosTypes.add(type);
+      realAddEventListener(type, messageHandler, { capture: true });
+    };
+
+    installChaosListenerFor('message');
+
+    // Pre-attach for any specific eventType named in a rule so chaos still
+    // fires even if the app never listens for it (matches WS interceptor's
+    // unconditional inbound interception).
+    const collect = (rules?: { eventType?: WildcardOrString }[]): void => {
+      if (!rules) return;
+      for (const r of rules) {
+        if (r.eventType && r.eventType !== '*' && r.eventType !== 'message') {
+          installChaosListenerFor(r.eventType);
+        }
+      }
+    };
+    collect(config.drops);
+    collect(config.delays);
+    collect(config.corruptions);
+
+    // Wildcard rules ('*') need to see every event the app subscribes to, but
+    // we can't enumerate event names upfront. Wrap addEventListener so any
+    // app-side subscription for a named event auto-installs the chaos
+    // capture listener for that same type. 'open' and 'error' are control
+    // events; never message-bearing, so skip them.
+    const patchedAddEventListener = (
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: boolean | AddEventListenerOptions,
+    ): void => {
+      if (type !== 'open' && type !== 'error') {
+        installChaosListenerFor(type);
+      }
+      // Cast back through the EventSource overloaded signature; the runtime
+      // call is forwarded unchanged.
+      (realAddEventListener as unknown as (
+        t: string,
+        l: EventListenerOrEventListenerObject | null,
+        o?: boolean | AddEventListenerOptions,
+      ) => void)(type, listener, options);
+    };
+    (source as unknown as { addEventListener: typeof patchedAddEventListener }).addEventListener =
+      patchedAddEventListener;
+
+    scheduleCloseChaos(source, urlStr);
+
+    return source;
+  }
+
+  Object.defineProperty(ChaosEventSource, 'prototype', {
+    value: OriginalEventSource.prototype,
+    writable: false,
+  });
+  for (const key of ['CONNECTING', 'OPEN', 'CLOSED'] as const) {
+    (ChaosEventSource as unknown as Record<string, unknown>)[key] =
+      (OriginalEventSource as unknown as Record<string, unknown>)[key];
+  }
+
+  return {
+    Wrapped: ChaosEventSource as unknown as typeof EventSource,
+    uninstall(): void {
+      running = false;
+      for (const [, timers] of pendingTimersBySource) {
+        for (const timer of timers) {
+          clearTimeout(timer.handle);
+          if (timer.kind === 'delay') {
+            emitDrop(emitter, timer.url, timer.eventType, 'stop-during-delay');
+          }
+        }
+      }
+      pendingTimersBySource.clear();
+    },
+  };
+}

--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -50,4 +50,11 @@ export const presets: Readonly<Record<string, ChaosConfig>> = deepFreeze({
       corruptions: [{ urlPattern: MATCH_ALL_URLS, direction: 'inbound', strategy: 'truncate', probability: 0.05 }],
     },
   },
+  unreliableEventStream: {
+    sse: {
+      drops: [{ urlPattern: MATCH_ALL_URLS, probability: 0.05 }],
+      delays: [{ urlPattern: MATCH_ALL_URLS, delayMs: 200, probability: 1.0 }],
+      closes: [{ urlPattern: MATCH_ALL_URLS, probability: 0.02, afterMs: 2000 }],
+    },
+  },
 });

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -137,10 +137,53 @@ const webSocketConfigSchema = z.object({
   closes: z.array(webSocketCloseSchema).optional(),
 }).strict();
 
+// SSE event-type matcher: either '*' (all events), 'message' (default
+// unnamed events), or any other named event string. Empty strings are
+// rejected because they would silently never match.
+const sseEventType = z.string().min(1, 'eventType must not be empty');
+
+const sseDropSchema = z.object({
+  urlPattern: z.string().min(1, 'urlPattern must not be empty'),
+  eventType: sseEventType.optional(),
+  probability,
+  ...countingFields,
+}).strict().refine(...countingRefinement);
+
+const sseDelaySchema = z.object({
+  urlPattern: z.string().min(1, 'urlPattern must not be empty'),
+  eventType: sseEventType.optional(),
+  delayMs: z.number().min(0, 'delayMs must be >= 0'),
+  probability,
+  ...countingFields,
+}).strict().refine(...countingRefinement);
+
+const sseCorruptSchema = z.object({
+  urlPattern: z.string().min(1, 'urlPattern must not be empty'),
+  eventType: sseEventType.optional(),
+  strategy: z.enum(['truncate', 'malformed-json', 'empty', 'wrong-type']),
+  probability,
+  ...countingFields,
+}).strict().refine(...countingRefinement);
+
+const sseCloseSchema = z.object({
+  urlPattern: z.string().min(1, 'urlPattern must not be empty'),
+  afterMs: z.number().min(0, 'afterMs must be >= 0').optional(),
+  probability,
+  ...countingFields,
+}).strict().refine(...countingRefinement);
+
+const sseConfigSchema = z.object({
+  drops: z.array(sseDropSchema).optional(),
+  delays: z.array(sseDelaySchema).optional(),
+  corruptions: z.array(sseCorruptSchema).optional(),
+  closes: z.array(sseCloseSchema).optional(),
+}).strict();
+
 const chaosConfigSchema = z.object({
   network: networkConfigSchema.optional(),
   ui: uiConfigSchema.optional(),
   websocket: webSocketConfigSchema.optional(),
+  sse: sseConfigSchema.optional(),
   seed: z.number().int('Seed must be an integer').optional(),
 }).strict();
 

--- a/packages/core/test/eventSource.test.ts
+++ b/packages/core/test/eventSource.test.ts
@@ -254,6 +254,24 @@ describe('counting (onNth / everyNth / afterN)', () => {
   });
 });
 
+describe('user-initiated close while a delay is pending', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+
+  it('does not redispatch a delayed message after source.close()', () => {
+    const { Wrapped } = setupPatch({
+      delays: [{ urlPattern: '/sse', delayMs: 500, probability: 1 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    const received: unknown[] = [];
+    es.addEventListener('message', (e) => received.push((e as MessageEvent).data));
+    es.simulateMessage('queued');
+    // App closes while delay timer is still pending.
+    es.close();
+    vi.advanceTimersByTime(500);
+    expect(received).toEqual([]);
+  });
+});
+
 describe('uninstall', () => {
   beforeEach(() => { vi.useFakeTimers(); });
 

--- a/packages/core/test/eventSource.test.ts
+++ b/packages/core/test/eventSource.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { patchEventSource, type EventSourceLikeStatic } from '../src/interceptors/eventSource';
+import { ChaosEventEmitter } from '../src/events';
+import type { SSEConfig } from '../src/config';
+
+// ---------------------------------------------------------------------------
+// MockEventSource — minimal stand-in for the browser's EventSource. No real
+// network. Tests drive inbound events with `simulateMessage(type?, data)`.
+// ---------------------------------------------------------------------------
+class MockEventSource extends EventTarget {
+  static CONNECTING = 0 as const;
+  static OPEN = 1 as const;
+  static CLOSED = 2 as const;
+
+  CONNECTING = 0;
+  OPEN = 1;
+  CLOSED = 2;
+
+  readyState: number = MockEventSource.CONNECTING;
+  url: string;
+  withCredentials: boolean;
+  closed = false;
+
+  constructor(url: string | URL, init?: EventSourceInit) {
+    super();
+    this.url = typeof url === 'string' ? url : url.toString();
+    this.withCredentials = init?.withCredentials ?? false;
+  }
+
+  close(): void {
+    this.readyState = MockEventSource.CLOSED;
+    this.closed = true;
+  }
+
+  simulateOpen(): void {
+    this.readyState = MockEventSource.OPEN;
+    this.dispatchEvent(new Event('open'));
+  }
+
+  simulateMessage(data: string, type = 'message'): MessageEvent {
+    const evt = new MessageEvent(type, { data });
+    this.dispatchEvent(evt);
+    return evt;
+  }
+}
+
+function setupPatch(config: SSEConfig, random: () => number = () => 0) {
+  const emitter = new ChaosEventEmitter();
+  const counters = new Map<object, number>();
+  const handle = patchEventSource(
+    MockEventSource as unknown as EventSourceLikeStatic,
+    config, emitter, random, counters,
+  );
+  type Ctor = new (url: string | URL, init?: EventSourceInit) => MockEventSource;
+  const Wrapped = handle.Wrapped as unknown as Ctor;
+  return { emitter, counters, handle, Wrapped };
+}
+
+const ALWAYS = () => 0;
+const NEVER = () => 0.99;
+
+describe('patchEventSource — wrapper constructor', () => {
+  it('returns a real MockEventSource (instanceof compatibility)', () => {
+    const { Wrapped } = setupPatch({});
+    const es = new Wrapped('http://test/sse');
+    expect(es).toBeInstanceOf(MockEventSource);
+  });
+
+  it('passes through unmatched messages untouched', () => {
+    const { Wrapped } = setupPatch({
+      drops: [{ urlPattern: '/other', probability: 1 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    const received: unknown[] = [];
+    es.addEventListener('message', (e) => received.push((e as MessageEvent).data));
+    es.simulateMessage('payload');
+    expect(received).toEqual(['payload']);
+  });
+});
+
+describe('drop chaos', () => {
+  it('drops messages matching the rule', () => {
+    const { emitter, Wrapped } = setupPatch({
+      drops: [{ urlPattern: '/sse', probability: 1 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    const received: unknown[] = [];
+    es.addEventListener('message', (e) => received.push((e as MessageEvent).data));
+    es.simulateMessage('a');
+    es.simulateMessage('b');
+    expect(received).toEqual([]);
+    const drops = emitter.getLog().filter(e => e.type === 'sse:drop');
+    expect(drops.length).toBe(2);
+    expect(drops.every(e => e.applied)).toBe(true);
+  });
+
+  it('does not drop when probability roll fails', () => {
+    const { Wrapped } = setupPatch({
+      drops: [{ urlPattern: '/sse', probability: 0.1 }],
+    }, NEVER);
+    const es = new Wrapped('http://test/sse');
+    const received: unknown[] = [];
+    es.addEventListener('message', (e) => received.push((e as MessageEvent).data));
+    es.simulateMessage('ok');
+    expect(received).toEqual(['ok']);
+  });
+
+  it('eventType filter matches only the named event', () => {
+    const { Wrapped, emitter } = setupPatch({
+      drops: [{ urlPattern: '/sse', eventType: 'tick', probability: 1 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    const tickReceived: unknown[] = [];
+    const msgReceived: unknown[] = [];
+    es.addEventListener('tick', (e) => tickReceived.push((e as MessageEvent).data));
+    es.addEventListener('message', (e) => msgReceived.push((e as MessageEvent).data));
+    es.simulateMessage('1', 'tick');
+    es.simulateMessage('2', 'message');
+    expect(tickReceived).toEqual([]);
+    expect(msgReceived).toEqual(['2']);
+    const drops = emitter.getLog().filter(e => e.type === 'sse:drop');
+    expect(drops.length).toBe(1);
+    expect(drops[0].detail.eventType).toBe('tick');
+  });
+
+  it("'*' eventType matches every event regardless of name", () => {
+    const { Wrapped, emitter } = setupPatch({
+      drops: [{ urlPattern: '/sse', eventType: '*', probability: 1 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    es.addEventListener('tick', () => undefined);
+    es.simulateMessage('a');
+    es.simulateMessage('b', 'tick');
+    expect(emitter.getLog().filter(e => e.type === 'sse:drop').length).toBe(2);
+  });
+});
+
+describe('delay chaos', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+
+  it('defers dispatch by delayMs', () => {
+    const { Wrapped } = setupPatch({
+      delays: [{ urlPattern: '/sse', delayMs: 200, probability: 1 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    const received: unknown[] = [];
+    es.addEventListener('message', (e) => received.push((e as MessageEvent).data));
+    es.simulateMessage('late');
+    expect(received).toEqual([]);
+    vi.advanceTimersByTime(200);
+    expect(received).toEqual(['late']);
+  });
+
+  it('emits sse:delay event when scheduled', () => {
+    const { Wrapped, emitter } = setupPatch({
+      delays: [{ urlPattern: '/sse', delayMs: 100, probability: 1 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    es.simulateMessage('x');
+    const delays = emitter.getLog().filter(e => e.type === 'sse:delay');
+    expect(delays.length).toBe(1);
+    expect(delays[0].detail.delayMs).toBe(100);
+  });
+});
+
+describe('corrupt chaos', () => {
+  it.each([
+    ['truncate', 'hello world', 'hello'],
+    ['empty', 'hello', ''],
+  ] as const)('%s mutates inbound text', (strategy, input, expected) => {
+    const { Wrapped } = setupPatch({
+      corruptions: [{ urlPattern: '/sse', strategy, probability: 1 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    const received: unknown[] = [];
+    es.addEventListener('message', (e) => received.push((e as MessageEvent).data));
+    es.simulateMessage(input);
+    expect(received).toEqual([expected]);
+  });
+
+  it('malformed-json appends garbage', () => {
+    const { Wrapped } = setupPatch({
+      corruptions: [{ urlPattern: '/sse', strategy: 'malformed-json', probability: 1 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    const received: string[] = [];
+    es.addEventListener('message', (e) => received.push((e as MessageEvent).data as string));
+    es.simulateMessage('{"a":1}');
+    expect(received[0]).toContain('{"a":1}');
+    expect(received[0]).not.toBe('{"a":1}');
+  });
+
+  it('emits sse:corrupt event with strategy', () => {
+    const { Wrapped, emitter } = setupPatch({
+      corruptions: [{ urlPattern: '/sse', strategy: 'empty', probability: 1 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    es.simulateMessage('payload');
+    const corrupted = emitter.getLog().filter(e => e.type === 'sse:corrupt');
+    expect(corrupted.length).toBe(1);
+    expect(corrupted[0].detail.strategy).toBe('empty');
+  });
+});
+
+describe('close chaos', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+
+  it('closes the source after afterMs and emits sse:close', () => {
+    const { Wrapped, emitter } = setupPatch({
+      closes: [{ urlPattern: '/sse', probability: 1, afterMs: 1000 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    let errorSeen = false;
+    es.addEventListener('error', () => { errorSeen = true; });
+    expect(es.closed).toBe(false);
+    vi.advanceTimersByTime(1000);
+    expect(errorSeen).toBe(true);
+    expect(es.closed).toBe(true);
+    const closes = emitter.getLog().filter(e => e.type === 'sse:close');
+    expect(closes.length).toBe(1);
+  });
+
+  it('afterMs=0 closes on next tick (still after constructor)', () => {
+    const { Wrapped } = setupPatch({
+      closes: [{ urlPattern: '/sse', probability: 1 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    expect(es.closed).toBe(false);
+    vi.advanceTimersByTime(0);
+    expect(es.closed).toBe(true);
+  });
+});
+
+describe('counting (onNth / everyNth / afterN)', () => {
+  it('onNth fires exactly once on the Nth message', () => {
+    const { Wrapped, emitter } = setupPatch({
+      drops: [{ urlPattern: '/sse', probability: 1, onNth: 3 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    const received: unknown[] = [];
+    es.addEventListener('message', (e) => received.push((e as MessageEvent).data));
+    for (let i = 1; i <= 5; i++) es.simulateMessage(`m${i}`);
+    expect(received).toEqual(['m1', 'm2', 'm4', 'm5']);
+    expect(emitter.getLog().filter(e => e.type === 'sse:drop').length).toBe(1);
+  });
+
+  it('everyNth fires on multiples of N', () => {
+    const { Wrapped, emitter } = setupPatch({
+      drops: [{ urlPattern: '/sse', probability: 1, everyNth: 2 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    for (let i = 1; i <= 4; i++) es.simulateMessage(`m${i}`);
+    expect(emitter.getLog().filter(e => e.type === 'sse:drop').length).toBe(2);
+  });
+});
+
+describe('uninstall', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+
+  it('cancels pending delay timers and emits stop-during-delay drops', () => {
+    const { Wrapped, emitter, handle } = setupPatch({
+      delays: [{ urlPattern: '/sse', delayMs: 1000, probability: 1 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    const received: unknown[] = [];
+    es.addEventListener('message', (e) => received.push((e as MessageEvent).data));
+    es.simulateMessage('queued');
+    handle.uninstall();
+    vi.advanceTimersByTime(2000);
+    expect(received).toEqual([]);
+    const drops = emitter.getLog().filter(e => e.type === 'sse:drop');
+    expect(drops.length).toBe(1);
+    expect(drops[0].detail.reason).toBe('stop-during-delay');
+  });
+
+  it('after uninstall, new messages on a wrapped source pass through', () => {
+    const { Wrapped, handle } = setupPatch({
+      drops: [{ urlPattern: '/sse', probability: 1 }],
+    }, ALWAYS);
+    const es = new Wrapped('http://test/sse');
+    const received: unknown[] = [];
+    es.addEventListener('message', (e) => received.push((e as MessageEvent).data));
+    handle.uninstall();
+    es.simulateMessage('after-stop');
+    expect(received).toEqual(['after-stop']);
+  });
+});

--- a/packages/core/test/eventSource.test.ts
+++ b/packages/core/test/eventSource.test.ts
@@ -211,11 +211,18 @@ describe('close chaos', () => {
     }, ALWAYS);
     const es = new Wrapped('http://test/sse');
     let errorSeen = false;
-    es.addEventListener('error', () => { errorSeen = true; });
+    let readyStateAtError = -1;
+    es.addEventListener('error', () => {
+      errorSeen = true;
+      readyStateAtError = es.readyState;
+    });
     expect(es.closed).toBe(false);
     vi.advanceTimersByTime(1000);
     expect(errorSeen).toBe(true);
     expect(es.closed).toBe(true);
+    // SSE spec compliance: readyState must already be CLOSED when onerror fires
+    // for a permanently-failed connection.
+    expect(readyStateAtError).toBe(MockEventSource.CLOSED);
     const closes = emitter.getLog().filter(e => e.type === 'sse:close');
     expect(closes.length).toBe(1);
   });

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -397,4 +397,81 @@ describe('validateConfig', () => {
       expect(() => validateConfig(config)).toThrow(ChaosConfigError);
     });
   });
+
+  describe('sse config', () => {
+    it('accepts valid drop/delay/corrupt/close rules', () => {
+      const config = {
+        sse: {
+          drops: [{ urlPattern: '/sse', probability: 0.5 }],
+          delays: [{ urlPattern: '/sse', delayMs: 100, probability: 1 }],
+          corruptions: [{ urlPattern: '/sse', strategy: 'truncate' as const, probability: 0.2 }],
+          closes: [{ urlPattern: '/sse', afterMs: 500, probability: 1 }],
+        },
+      };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('accepts a named eventType', () => {
+      const config = {
+        sse: { drops: [{ urlPattern: '/sse', eventType: 'tick', probability: 1 }] },
+      };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it("accepts '*' eventType wildcard", () => {
+      const config = {
+        sse: { drops: [{ urlPattern: '/sse', eventType: '*', probability: 1 }] },
+      };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('rejects empty eventType string', () => {
+      const config = {
+        sse: { drops: [{ urlPattern: '/sse', eventType: '', probability: 1 }] },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects empty urlPattern', () => {
+      const config = {
+        sse: { drops: [{ urlPattern: '', probability: 1 }] },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects negative delayMs', () => {
+      const config = {
+        sse: { delays: [{ urlPattern: '/sse', delayMs: -1, probability: 1 }] },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects negative afterMs on close', () => {
+      const config = {
+        sse: { closes: [{ urlPattern: '/sse', probability: 1, afterMs: -5 }] },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects multiple counting fields on a single sse rule', () => {
+      const config = {
+        sse: { drops: [{ urlPattern: '/sse', probability: 1, onNth: 1, everyNth: 2 }] },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects unknown corruption strategy', () => {
+      const config = {
+        sse: { corruptions: [{ urlPattern: '/sse', strategy: 'shred' as unknown as 'truncate', probability: 1 }] },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects unknown top-level keys (strict)', () => {
+      const config = {
+        sse: { drops: [], extra: true } as unknown as Record<string, unknown>,
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+  });
 });

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -467,7 +467,7 @@ describe('validateConfig', () => {
       expect(() => validateConfig(config)).toThrow(ChaosConfigError);
     });
 
-    it('rejects unknown top-level keys (strict)', () => {
+    it('rejects unknown keys inside sse (strict)', () => {
       const config = {
         sse: { drops: [], extra: true } as unknown as Record<string, unknown>,
       };

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -28,6 +28,13 @@ export type {
   WebSocketCloseConfig,
   WebSocketDirection,
   WebSocketCorruptionStrategy,
+  SSEConfig,
+  SSEDropConfig,
+  SSEDelayConfig,
+  SSECorruptConfig,
+  SSECloseConfig,
+  SSECorruptionStrategy,
+  SSEEventTypeMatcher,
 } from '@chaos-maker/core';
 
 // Augment Cypress's Chainable interface so `cy.injectChaos(...)` etc. get

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -187,6 +187,13 @@ export type {
   WebSocketCloseConfig,
   WebSocketDirection,
   WebSocketCorruptionStrategy,
+  SSEConfig,
+  SSEDropConfig,
+  SSEDelayConfig,
+  SSECorruptConfig,
+  SSECloseConfig,
+  SSECorruptionStrategy,
+  SSEEventTypeMatcher,
 } from '@chaos-maker/core';
 
 export type { TraceReporterOptions, ChaosTraceAttachment } from './trace';

--- a/packages/puppeteer/src/index.ts
+++ b/packages/puppeteer/src/index.ts
@@ -205,6 +205,13 @@ export type {
   WebSocketCloseConfig,
   WebSocketDirection,
   WebSocketCorruptionStrategy,
+  SSEConfig,
+  SSEDropConfig,
+  SSEDelayConfig,
+  SSECorruptConfig,
+  SSECloseConfig,
+  SSECorruptionStrategy,
+  SSEEventTypeMatcher,
 } from '@chaos-maker/core';
 
 export {

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -186,6 +186,13 @@ export type {
   WebSocketCloseConfig,
   WebSocketDirection,
   WebSocketCorruptionStrategy,
+  SSEConfig,
+  SSEDropConfig,
+  SSEDelayConfig,
+  SSECorruptConfig,
+  SSECloseConfig,
+  SSECorruptionStrategy,
+  SSEEventTypeMatcher,
 } from '@chaos-maker/core';
 
 export {


### PR DESCRIPTION
## Summary

Phase 2 of v0.4.0 — closes the SSE/EventSource silent-failure gap. Apps using `EventSource` (AI chat streams, dashboards, notifications) can now have their event stream chaos-ed: drop messages, delay messages, corrupt payloads, or force-close the connection.

- **Core**: new `interceptors/eventSource.ts` patches `globalThis.EventSource` with a wrapper constructor; capture-phase `message` listener + `stopImmediatePropagation` + `dispatchEvent` re-dispatch on mutation/delay. Mirrors the WebSocket interceptor's structure.
- **Config**: `ChaosConfig.sse = { drops, delays, corruptions, closes }`. Per-rule `urlPattern`, `eventType` (`'message'` default, named, or `'*'` wildcard), `probability`, `onNth`/`everyNth`/`afterN`. Same four corruption strategies as fetch/WS chaos.
- **Wildcard auto-attach**: `'*'` rules don't know event names upfront, so the wrapper monkey-patches `addEventListener` on the source — any app subscription to a new named event auto-installs a chaos capture listener for that type. `open` / `error` are skipped.
- **Builder + preset**: `.dropSSE()`, `.delaySSE()`, `.corruptSSE()`, `.closeSSE()`; new `unreliableEventStream` preset (5% drops + 200ms delay + 2% close-after-2s).
- **Events**: `sse:drop`, `sse:delay`, `sse:corrupt`, `sse:close` with `eventType` in `detail`. Stop emits `sse:drop` with `reason: 'stop-during-delay'` for any pending delay timers.
- **Fixture**: `e2e-tests/fixtures/sse-server.cjs` (Node `http`) on port 8082 — `/sse` (default ticks every 200ms) and `/sse-named` (alternates `event: tick` / default events). Wired into Playwright `webServer`, Cypress `setupNodeEvents`, Puppeteer `globalSetup`, WDIO `onPrepare`. Fixture `index.html` UI section for connect/close + counters.
- **E2E**: Playwright (6 specs × 4 projects), Cypress (5 specs), Puppeteer (5 specs). WDIO skipped to mirror existing WS-coverage decision.
- **Unit**: 16 SSE interceptor tests + 9 SSE schema tests.

## Test plan

- [x] `pnpm build` — all packages
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 225 unit tests pass
- [x] Playwright SSE — 24 tests pass (chromium + firefox + webkit)
- [x] Playwright full chromium suite — 74/74 pass
- [x] Cypress full chrome suite — 68/68 pass (including 5 new SSE)
- [x] Puppeteer suite — 44/44 pass (including 5 new SSE)
- [x] WDIO chrome suite — 6 spec files pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Server-Sent Events (SSE) chaos: drop, delay, corrupt, and close rules with event-type filtering (named events + `*`), builder shortcuts, and an `unreliableEventStream` preset
  * Service-worker–origin fetch chaos support and shared SW bridge helpers

* **Tests**
  * Comprehensive new E2E and unit test coverage and fixture/server support for SSE behaviors

* **Documentation**
  * CHANGELOG updated with these additions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->