### PR TITLE
chore: update repo URLs after transfer to chaos-maker-dev org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.
 - **Puppeteer adapter** (`@chaos-maker/puppeteer`): one-line injection via `injectChaos(page, config)`, `removeChaos(page)`, `getChaosLog(page)`, `getChaosSeed(page)`, `useChaos(page, config)`. Uses `page.evaluateOnNewDocument` to patch `fetch`, `XMLHttpRequest`, and `WebSocket` before any page script runs; tracks init-script identifiers in a `WeakMap<ChaosPage>` so `removeChaos` + repeat `injectChaos` tear down cleanly without stacking.
   - E2E suite: 37 tests on headless Chromium, mirroring the Playwright suite where applicable.
   - New CI job `e2e-puppeteer (headless-new)`.
-- **Documentation site** (Starlight-powered, published to GitHub Pages at <https://jvjithin.github.io/chaos-maker/>): 28 pages covering Install, per-adapter Getting Started, Concepts (chaos types, presets, builder, seeded reproducibility, Nth counting, observability), eight Recipes, API reference, and a Rationale section. Search via Pagefind.
+- **Documentation site** (Starlight-powered, published to GitHub Pages at <https://chaos-maker-dev.github.io/chaos-maker/>): 28 pages covering Install, per-adapter Getting Started, Concepts (chaos types, presets, builder, seeded reproducibility, Nth counting, observability), eight Recipes, API reference, and a Rationale section. Search via Pagefind.
 - **Seeded determinism enforcement**: `Math.random` is now an ESLint error across `packages/**` (via `no-restricted-syntax` AST rule, exempt only in `prng.ts`). Every chaos probability decision must flow through `createPrng(seed)` so replays are bit-exact.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chaos Maker
 
-[![Build Status](https://github.com/jvjithin/chaos-maker/actions/workflows/ci.yml/badge.svg)](https://github.com/jvjithin/chaos-maker/actions)
+[![Build Status](https://github.com/chaos-maker-dev/chaos-maker/actions/workflows/ci.yml/badge.svg)](https://github.com/chaos-maker-dev/chaos-maker/actions)
 [![npm](https://img.shields.io/npm/v/@chaos-maker/core)](https://www.npmjs.com/package/@chaos-maker/core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -55,7 +55,7 @@ Page-side: `injectSWChaos` / `removeSWChaos` / `getSWChaosLog` in each adapter. 
 
 ## Full docs
 
-[Getting started](https://jvjithin.github.io/chaos-maker/getting-started/install) | [Concepts](https://jvjithin.github.io/chaos-maker/concepts/chaos-types) | [Recipes](https://jvjithin.github.io/chaos-maker/recipes/slow-checkout) | [API](https://jvjithin.github.io/chaos-maker/api/core)
+[Getting started](https://chaos-maker-dev.github.io/chaos-maker/getting-started/install) | [Concepts](https://chaos-maker-dev.github.io/chaos-maker/concepts/chaos-types) | [Recipes](https://chaos-maker-dev.github.io/chaos-maker/recipes/slow-checkout) | [API](https://chaos-maker-dev.github.io/chaos-maker/api/core)
 
 ## Development
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -7,7 +7,7 @@ const skipAutoSitemap = {
 };
 
 export default defineConfig({
-  site: 'https://jvjithin.github.io/chaos-maker',
+  site: 'https://chaos-maker-dev.github.io/chaos-maker',
   base: '/chaos-maker',
   integrations: [
     // Starlight auto-adds @astrojs/sitemap when `site` is set. The docs release
@@ -18,10 +18,10 @@ export default defineConfig({
       description: 'Frontend chaos engineering toolkit for testing resilience across Playwright, Cypress, WebdriverIO, and Puppeteer.',
       favicon: '/favicon.svg',
       social: [
-        { icon: 'github', label: 'GitHub', href: 'https://github.com/jvjithin/chaos-maker' },
+        { icon: 'github', label: 'GitHub', href: 'https://github.com/chaos-maker-dev/chaos-maker' },
       ],
       editLink: {
-        baseUrl: 'https://github.com/jvjithin/chaos-maker/edit/main/docs/',
+        baseUrl: 'https://github.com/chaos-maker-dev/chaos-maker/edit/main/docs/',
       },
       lastUpdated: true,
       sidebar: [

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -10,7 +10,7 @@ hero:
       icon: right-arrow
       variant: primary
     - text: View on GitHub
-      link: https://github.com/jvjithin/chaos-maker
+      link: https://github.com/chaos-maker-dev/chaos-maker
       icon: external
       variant: minimal
 ---

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,12 +17,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jvjithin/chaos-maker.git",
+    "url": "https://github.com/chaos-maker-dev/chaos-maker.git",
     "directory": "packages/core"
   },
-  "homepage": "https://github.com/jvjithin/chaos-maker",
+  "homepage": "https://github.com/chaos-maker-dev/chaos-maker",
   "bugs": {
-    "url": "https://github.com/jvjithin/chaos-maker/issues"
+    "url": "https://github.com/chaos-maker-dev/chaos-maker/issues"
   },
   "engines": {
     "node": ">=18"

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -13,10 +13,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jvjithin/chaos-maker.git",
+    "url": "https://github.com/chaos-maker-dev/chaos-maker.git",
     "directory": "packages/cypress"
   },
-  "homepage": "https://github.com/jvjithin/chaos-maker",
+  "homepage": "https://github.com/chaos-maker-dev/chaos-maker",
   "engines": {
     "node": ">=18"
   },

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -13,10 +13,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jvjithin/chaos-maker.git",
+    "url": "https://github.com/chaos-maker-dev/chaos-maker.git",
     "directory": "packages/playwright"
   },
-  "homepage": "https://github.com/jvjithin/chaos-maker",
+  "homepage": "https://github.com/chaos-maker-dev/chaos-maker",
   "engines": {
     "node": ">=18"
   },

--- a/packages/puppeteer/README.md
+++ b/packages/puppeteer/README.md
@@ -1,6 +1,6 @@
 # @chaos-maker/puppeteer
 
-Puppeteer adapter for [`@chaos-maker/core`](https://github.com/jvjithin/chaos-maker) — inject network failures, UI assaults, and WebSocket chaos into Puppeteer tests with a single function call.
+Puppeteer adapter for [`@chaos-maker/core`](https://github.com/chaos-maker-dev/chaos-maker) — inject network failures, UI assaults, and WebSocket chaos into Puppeteer tests with a single function call.
 
 ## Install
 

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -14,10 +14,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jvjithin/chaos-maker.git",
+    "url": "https://github.com/chaos-maker-dev/chaos-maker.git",
     "directory": "packages/puppeteer"
   },
-  "homepage": "https://github.com/jvjithin/chaos-maker",
+  "homepage": "https://github.com/chaos-maker-dev/chaos-maker",
   "engines": {
     "node": ">=18"
   },

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -15,10 +15,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jvjithin/chaos-maker.git",
+    "url": "https://github.com/chaos-maker-dev/chaos-maker.git",
     "directory": "packages/webdriverio"
   },
-  "homepage": "https://github.com/jvjithin/chaos-maker",
+  "homepage": "https://github.com/chaos-maker-dev/chaos-maker",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary
- Repo transferred from `jvjithin/chaos-maker` to `chaos-maker-dev/chaos-maker`
- Updated all hardcoded URLs across package.json files, READMEs, CHANGELOG, and docs site config
- Docs site URL migrated from `jvjithin.github.io/chaos-maker` to `chaos-maker-dev.github.io/chaos-maker`
- Local git remote already repointed

## Test plan
- [x] CI badge resolves on new org
- [ ] `npm view @chaos-maker/core repository.url` reflects new URL after next publish
- [x] GitHub Pages re-enabled on new repo, docs site loads at new URL
- [ ] npm OIDC trusted publisher repointed for each `@chaos-maker/*` package