### PR TITLE
ci: extract pnpm/node/install setup into composite action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,28 @@
+name: Setup pnpm + Node + install
+description: Checkout assumed already done by caller
+inputs:
+  frozen-lockfile:
+    description: Pass --frozen-lockfile to pnpm install
+    required: false
+    default: 'false'
+  skip-puppeteer-download:
+    description: Set PUPPETEER_SKIP_DOWNLOAD=true
+    required: false
+    default: 'false'
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+    - uses: actions/setup-node@v5
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'pnpm'
+    - shell: bash
+      env:
+        PUPPETEER_SKIP_DOWNLOAD: ${{ inputs.skip-puppeteer-download == 'true' && 'true' || '' }}
+      run: |
+        if [ "${{ inputs.frozen-lockfile }}" = "true" ]; then
+          pnpm install --frozen-lockfile
+        else
+          pnpm install
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,17 +21,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - name: Install Dependencies
-        run: pnpm install
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Run ESLint
         run: pnpm lint
@@ -45,17 +36,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - name: Install Dependencies
-        run: pnpm install
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Run Unit Tests
         run: pnpm test
@@ -69,17 +51,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - name: Install Dependencies
-        run: pnpm install
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Build All Packages
         run: pnpm build
@@ -117,17 +90,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
+      - name: Setup
+        uses: ./.github/actions/setup
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+          frozen-lockfile: 'true'
 
       - name: Build Docs
         run: pnpm --filter chaos-maker-docs build
@@ -162,17 +128,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - name: Install Dependencies
-        run: pnpm install
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Download Build Artifact
         uses: actions/download-artifact@v4
@@ -226,15 +183,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
+      # Restore Cypress binary cache before install so the cypress postinstall
+      # hook reuses the cached binary instead of re-downloading.
       - name: Cache Cypress Binary
         id: cypress-cache
         uses: actions/cache@v4
@@ -242,8 +192,8 @@ jobs:
           path: ~/.cache/Cypress
           key: cypress-${{ hashFiles('pnpm-lock.yaml') }}
 
-      - name: Install Dependencies
-        run: pnpm install
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Install Cypress Binary
         if: steps.cypress-cache.outputs.cache-hit != 'true'
@@ -281,17 +231,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - name: Install Dependencies
-        run: pnpm install
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Download Build Artifact
         uses: actions/download-artifact@v4
@@ -315,15 +256,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
       - name: Cache Puppeteer Chrome
         id: puppeteer-cache
         uses: actions/cache@v4
@@ -331,10 +263,10 @@ jobs:
           path: ~/.cache/puppeteer
           key: puppeteer-${{ hashFiles('e2e-tests/puppeteer/package.json', 'pnpm-lock.yaml') }}
 
-      - name: Install Dependencies
-        env:
-          PUPPETEER_SKIP_DOWNLOAD: 'true'
-        run: pnpm install
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          skip-puppeteer-download: 'true'
 
       - name: Download Build Artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- Add `.github/actions/setup` composite: pnpm + Node + `pnpm install` with `frozen-lockfile` and `skip-puppeteer-download` inputs.
- Replace 7 duplicated setup blocks across `lint`, `test`, `build`, `docs-build`, `e2e-playwright`, `e2e-cypress`, `e2e-webdriverio`, `e2e-puppeteer` with `uses: ./.github/actions/setup`.
- Cypress + Puppeteer jobs restore their browser caches *before* the composite runs so postinstall hooks reuse the cache.

Net: -89/+49 lines in ci.yml. Behavior unchanged.

## Test plan
- [ ] CI green on this PR (lint, test, build, docs-build)
- [ ] All e2e matrices pass (playwright x4, cypress x2, wdio x2, puppeteer)
- [ ] Cypress + Puppeteer cache-hit paths still skip browser re-download

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored CI/CD setup workflow by introducing a reusable configuration action. This consolidates repeated setup and installation steps across build and test jobs, improving consistency and maintainability of the continuous integration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->