### PR TITLE
chore(release): prep v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.4.0] - 2026-04-26
 
 ### Added
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chaos-maker-docs",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "engines": {
     "node": ">=22.12.0"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @chaos-maker/core Changelog
 
-## Unreleased
+## 0.4.0 - 2026-04-26
 
 ### Added
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "A lightweight, framework-agnostic toolkit for injecting chaos into web applications to test frontend resilience",
   "keywords": [

--- a/packages/cypress/CHANGELOG.md
+++ b/packages/cypress/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @chaos-maker/cypress Changelog
 
-## Unreleased
+## 0.4.0 - 2026-04-26
 
 ### Added
 

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/cypress",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "Cypress adapter for @chaos-maker/core — custom commands for one-line chaos injection",
   "keywords": [

--- a/packages/playwright/CHANGELOG.md
+++ b/packages/playwright/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @chaos-maker/playwright Changelog
 
-## Unreleased
+## 0.4.0 - 2026-04-26
 
 ### Added
 

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/playwright",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "Playwright adapter for @chaos-maker/core — one-line chaos injection in E2E tests",
   "keywords": [

--- a/packages/puppeteer/CHANGELOG.md
+++ b/packages/puppeteer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @chaos-maker/puppeteer Changelog
 
-## Unreleased
+## 0.4.0 - 2026-04-26
 
 ### Added
 

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/puppeteer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "Puppeteer adapter for @chaos-maker/core — one-line chaos injection in Puppeteer tests",
   "keywords": [

--- a/packages/webdriverio/CHANGELOG.md
+++ b/packages/webdriverio/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @chaos-maker/webdriverio Changelog
 
-## Unreleased
+## 0.4.0 - 2026-04-26
 
 ### Added
 

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/webdriverio",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "WebdriverIO adapter for @chaos-maker/core — one-line chaos injection in WDIO tests",
   "keywords": [


### PR DESCRIPTION
## Summary

Final release prep for v0.4.0. Phase 4 (adapter parity + docs) merged via #41; this PR dates the changelogs and bumps published packages from 0.3.0 to 0.4.0 ahead of the npm release.

## Changes

- Bump version 0.3.0 to 0.4.0 in `@chaos-maker/core`, `@chaos-maker/playwright`, `@chaos-maker/cypress`, `@chaos-maker/puppeteer`, `@chaos-maker/webdriverio`, and `chaos-maker-docs`.
- Convert root + per-package `Unreleased` heading to `0.4.0 - 2026-04-26`.
- Workspace adapter deps already pin core via `workspace:*`; pnpm rewrites to `0.4.0` at publish time.

## Validation

- `pnpm lint` clean
- `pnpm test` 292 tests pass across 15 files
- `pnpm build` green for all 5 packages

## Release runway

After merge:
1. Tag `v0.4.0` on main
2. Push tag - release workflow OIDC-publishes all 5 packages (NPM_TOKEN fallback removed in #35)
3. Verify on npm

## Test plan

- [x] Lint clean
- [x] Unit tests pass
- [x] Build green
- [ ] Tag pushed and release workflow succeeds (post-merge)
- [ ] All 5 packages visible on npm at 0.4.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 0.4.0 is now officially released. All packages have been updated to the new release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->