### PR TITLE
feat(core): implement rule groups core data model (#44)

### DIFF
--- a/packages/core/src/ChaosMaker.ts
+++ b/packages/core/src/ChaosMaker.ts
@@ -152,12 +152,14 @@ export class ChaosMaker {
   }
 
   public hasGroup(name: string): boolean {
-    return this.groups.has(name);
+    const nameNorm = normalizeGroupName(name);
+    return this.groups.has(nameNorm);
   }
 
   /** True iff the named group is currently enabled (auto-creates unknown names). */
   public getGroupState(name: string): boolean {
-    return this.groups.isActive(name);
+    const nameNorm = normalizeGroupName(name);
+    return this.groups.isActive(nameNorm);
   }
 
   /** Snapshot of every known group as `{ name: enabled }`. */

--- a/packages/core/src/ChaosMaker.ts
+++ b/packages/core/src/ChaosMaker.ts
@@ -27,6 +27,14 @@ export interface ChaosMakerOptions {
   target?: ChaosTarget;
 }
 
+function normalizeGroupName(name: string): string {
+  const nameNorm = name.trim();
+  if (!nameNorm) {
+    throw new Error('[chaos-maker] Group name cannot be empty');
+  }
+  return nameNorm;
+}
+
 export class ChaosMaker {
   private config: ChaosConfig;
   private emitter: ChaosEventEmitter;
@@ -107,36 +115,40 @@ export class ChaosMaker {
   /** Enable a rule group at runtime (RFC-001). Auto-creates the group if unknown.
    *  Engine state and per-rule counters are preserved — no restart. */
   public enableGroup(name: string): void {
-    this.groups.setEnabled(name, true);
+    const nameNorm = normalizeGroupName(name);
+    this.groups.setEnabled(nameNorm, true);
     this.emitter.emit({
       type: 'rule-group:enabled',
       timestamp: Date.now(),
       applied: true,
-      detail: { groupName: name },
+      detail: { groupName: nameNorm },
     });
   }
 
   /** Disable a rule group at runtime (RFC-001). Subsequent matches are skipped
    *  and a single `rule-group:gated` event is emitted per cycle. */
   public disableGroup(name: string): void {
-    this.groups.setEnabled(name, false);
+    const nameNorm = normalizeGroupName(name);
+    this.groups.setEnabled(nameNorm, false);
     this.emitter.emit({
       type: 'rule-group:disabled',
       timestamp: Date.now(),
       applied: true,
-      detail: { groupName: name },
+      detail: { groupName: nameNorm },
     });
   }
 
   /** Pre-register a group (typically used to ship one as initially disabled). */
   public createGroup(name: string, opts?: { enabled?: boolean }): void {
-    this.groups.ensure(name, { ...opts, explicit: true });
+    const nameNorm = normalizeGroupName(name);
+    this.groups.ensure(nameNorm, { ...opts, explicit: true });
   }
 
   /** Remove a group from the registry. Throws when still referenced unless
    *  `{ force: true }`. `'default'` cannot be removed. */
   public removeGroup(name: string, opts?: { force?: boolean }): boolean {
-    return this.groups.remove(name, this.collectReferencedGroups(), opts);
+    const nameNorm = normalizeGroupName(name);
+    return this.groups.remove(nameNorm, this.collectReferencedGroups(), opts);
   }
 
   public hasGroup(name: string): boolean {

--- a/packages/core/src/ChaosMaker.ts
+++ b/packages/core/src/ChaosMaker.ts
@@ -7,6 +7,8 @@ import { patchXHR, patchXHROpen } from './interceptors/networkXHR';
 import { attachDomAssailant } from './interceptors/domAssailant';
 import { patchWebSocket, WebSocketPatchHandle } from './interceptors/websocket';
 import { patchEventSource, EventSourceLikeStatic, EventSourcePatchHandle } from './interceptors/eventSource';
+import { DEFAULT_GROUP_NAME, RuleGroup, RuleGroupRegistry } from './groups';
+import { forEachRule } from './utils';
 
 /**
  * Global context ChaosMaker patches against. Must expose at minimum `fetch`
@@ -42,6 +44,8 @@ export class ChaosMaker {
   private eventSourceHandle?: EventSourcePatchHandle;
   /** Shared counters keyed by config rule object reference. Shared across fetch + XHR + WS. */
   private requestCounters: Map<object, number> = new Map();
+  /** Rule-group registry (RFC-001). Default-on; default group always exists. */
+  private groups: RuleGroupRegistry;
 
   constructor(config: ChaosConfig, options: ChaosMakerOptions = {}) {
     this.config = validateConfig(config);
@@ -50,7 +54,33 @@ export class ChaosMaker {
     this.random = prng.random;
     this.seed = prng.seed;
     this.target = options.target ?? globalThis;
+    this.groups = new RuleGroupRegistry();
+    // Pre-register groups declared in config first (explicit, may flip enabled).
+    for (const g of this.config.groups ?? []) {
+      this.groups.ensure(g.name, { enabled: g.enabled ?? true, explicit: true });
+    }
+    // Walk every rule so referenced groups are observable from `listGroups()`
+    // before any request fires. Runtime auto-create still surfaces typos that
+    // appear only at probe time.
+    this.seedGroupsFromRules();
+    // Default group is always present; ensures `getGroupsSnapshot()` includes it.
+    this.groups.ensure(DEFAULT_GROUP_NAME, { enabled: true });
     console.log(`Chaos Maker initialized (seed: ${this.seed})`);
+  }
+
+  private seedGroupsFromRules(): void {
+    forEachRule(this.config, (rule) => {
+      if (rule.group) this.groups.ensure(rule.group);
+    });
+  }
+
+  /** Compute the set of group names currently referenced by any rule. Used by `removeGroup`. */
+  private collectReferencedGroups(): Set<string> {
+    const referenced = new Set<string>();
+    forEachRule(this.config, (rule) => {
+      if (rule.group) referenced.add(rule.group);
+    });
+    return referenced;
   }
 
   /** Get the seed used by this instance. Log this on failure to reproduce exact chaos decisions. */
@@ -74,6 +104,59 @@ export class ChaosMaker {
     this.emitter.clearLog();
   }
 
+  /** Enable a rule group at runtime (RFC-001). Auto-creates the group if unknown.
+   *  Engine state and per-rule counters are preserved — no restart. */
+  public enableGroup(name: string): void {
+    this.groups.setEnabled(name, true);
+    this.emitter.emit({
+      type: 'rule-group:enabled',
+      timestamp: Date.now(),
+      applied: true,
+      detail: { groupName: name },
+    });
+  }
+
+  /** Disable a rule group at runtime (RFC-001). Subsequent matches are skipped
+   *  and a single `rule-group:gated` event is emitted per cycle. */
+  public disableGroup(name: string): void {
+    this.groups.setEnabled(name, false);
+    this.emitter.emit({
+      type: 'rule-group:disabled',
+      timestamp: Date.now(),
+      applied: true,
+      detail: { groupName: name },
+    });
+  }
+
+  /** Pre-register a group (typically used to ship one as initially disabled). */
+  public createGroup(name: string, opts?: { enabled?: boolean }): void {
+    this.groups.ensure(name, { ...opts, explicit: true });
+  }
+
+  /** Remove a group from the registry. Throws when still referenced unless
+   *  `{ force: true }`. `'default'` cannot be removed. */
+  public removeGroup(name: string, opts?: { force?: boolean }): boolean {
+    return this.groups.remove(name, this.collectReferencedGroups(), opts);
+  }
+
+  public hasGroup(name: string): boolean {
+    return this.groups.has(name);
+  }
+
+  /** True iff the named group is currently enabled (auto-creates unknown names). */
+  public getGroupState(name: string): boolean {
+    return this.groups.isActive(name);
+  }
+
+  /** Snapshot of every known group as `{ name: enabled }`. */
+  public getGroupsSnapshot(): Record<string, boolean> {
+    return this.groups.getSnapshot();
+  }
+
+  public listGroups(): RuleGroup[] {
+    return this.groups.list();
+  }
+
   public start(): void {
     if (this.running) {
       console.warn('Chaos Maker is already running. Call stop() first.');
@@ -90,7 +173,7 @@ export class ChaosMaker {
     if (this.config.network) {
       if (typeof target.fetch === 'function') {
         this.originalFetch = target.fetch;
-        target.fetch = patchFetch(this.originalFetch.bind(target), this.config.network, this.random, this.emitter, this.requestCounters);
+        target.fetch = patchFetch(this.originalFetch.bind(target), this.config.network, this.random, this.emitter, this.requestCounters, this.groups);
       }
 
       if (typeof target.XMLHttpRequest === 'function') {
@@ -98,7 +181,7 @@ export class ChaosMaker {
         target.XMLHttpRequest.prototype.open = patchXHROpen(this.originalXhrOpen);
 
         this.originalXhrSend = target.XMLHttpRequest.prototype.send;
-        target.XMLHttpRequest.prototype.send = patchXHR(this.originalXhrSend, this.config.network, this.random, this.emitter, this.requestCounters);
+        target.XMLHttpRequest.prototype.send = patchXHR(this.originalXhrSend, this.config.network, this.random, this.emitter, this.requestCounters, this.groups);
       }
     }
 
@@ -106,7 +189,7 @@ export class ChaosMaker {
       if (typeof document === 'undefined' || typeof MutationObserver === 'undefined') {
         console.warn('Chaos Maker: UI config ignored — no DOM available in current context.');
       } else {
-        this.domObserver = attachDomAssailant(this.config.ui, this.random, this.emitter);
+        this.domObserver = attachDomAssailant(this.config.ui, this.random, this.emitter, this.groups);
         this.domObserver.observe(document.body, {
           childList: true,
           subtree: true,
@@ -123,6 +206,7 @@ export class ChaosMaker {
         this.emitter,
         this.random,
         this.requestCounters,
+        this.groups,
       );
       target.WebSocket = this.webSocketHandle.Wrapped;
     }
@@ -135,6 +219,7 @@ export class ChaosMaker {
         this.emitter,
         this.random,
         this.requestCounters,
+        this.groups,
       );
       target.EventSource = this.eventSourceHandle.Wrapped;
     }

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -22,6 +22,14 @@ function cloneConfig(config: ChaosConfig): ChaosConfig {
   return cloneValue(config);
 }
 
+function normalizeGroupName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw new Error('[chaos-maker] Group name cannot be empty');
+  }
+  return trimmed;
+}
+
 export class ChaosConfigBuilder {
   private config: ChaosConfig;
   /** Single-shot group name applied to the next rule pushed and then cleared.
@@ -40,7 +48,7 @@ export class ChaosConfigBuilder {
   /** Tag the next rule pushed with this group name (RFC-001).
    *  Single-shot: cleared after the next builder method that pushes a rule. */
   inGroup(name: string): this {
-    this.pendingGroup = name;
+    this.pendingGroup = normalizeGroupName(name);
     return this;
   }
 
@@ -48,7 +56,7 @@ export class ChaosConfigBuilder {
    *  initially disabled). Equivalent to setting `ChaosConfig.groups` directly. */
   defineGroup(name: string, opts?: { enabled?: boolean }): this {
     if (!this.config.groups) this.config.groups = [];
-    const entry: RuleGroupConfig = { name };
+    const entry: RuleGroupConfig = { name: normalizeGroupName(name) };
     if (opts?.enabled !== undefined) entry.enabled = opts.enabled;
     this.config.groups.push(entry);
     return this;

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -1,4 +1,5 @@
 import { ChaosConfig, CorruptionStrategy, GraphQLOperationMatcher, RequestCountingOptions, SSECorruptionStrategy, WebSocketDirection, WebSocketCorruptionStrategy } from './config';
+import type { RuleGroupConfig } from './groups';
 
 function cloneValue<T>(value: T): T {
   if (value === null || typeof value !== 'object') return value;
@@ -23,6 +24,10 @@ function cloneConfig(config: ChaosConfig): ChaosConfig {
 
 export class ChaosConfigBuilder {
   private config: ChaosConfig;
+  /** Single-shot group name applied to the next rule pushed and then cleared.
+   *  Sticky semantics intentionally rejected — silent capture of stale groups
+   *  is harder to debug than the explicit re-chain. */
+  private pendingGroup?: string;
 
   constructor(initialConfig?: ChaosConfig) {
     this.config = initialConfig ? cloneConfig(initialConfig) : { network: {}, ui: {}, websocket: {}, sse: {} };
@@ -32,33 +37,58 @@ export class ChaosConfigBuilder {
     if (!this.config.sse) this.config.sse = {};
   }
 
+  /** Tag the next rule pushed with this group name (RFC-001).
+   *  Single-shot: cleared after the next builder method that pushes a rule. */
+  inGroup(name: string): this {
+    this.pendingGroup = name;
+    return this;
+  }
+
+  /** Pre-register a group on the config (typically used to ship one as
+   *  initially disabled). Equivalent to setting `ChaosConfig.groups` directly. */
+  defineGroup(name: string, opts?: { enabled?: boolean }): this {
+    if (!this.config.groups) this.config.groups = [];
+    const entry: RuleGroupConfig = { name };
+    if (opts?.enabled !== undefined) entry.enabled = opts.enabled;
+    this.config.groups.push(entry);
+    return this;
+  }
+
+  /** Apply `pendingGroup` (single-shot) to a rule literal before it is pushed.
+   *  MUST be called at every rule-push site so `.inGroup(...)` is honored. */
+  private withGroup<T extends object>(rule: T): T & { group?: string } {
+    const g = this.pendingGroup;
+    this.pendingGroup = undefined;
+    return g ? { ...rule, group: g } : rule;
+  }
+
   failRequests(urlPattern: string, statusCode: number, probability: number, methods?: string[], body?: string, headers?: Record<string, string>, counting?: RequestCountingOptions) {
     if (!this.config.network!.failures) this.config.network!.failures = [];
-    this.config.network!.failures.push({ urlPattern, statusCode, probability, methods, body, headers, ...counting });
+    this.config.network!.failures.push(this.withGroup({ urlPattern, statusCode, probability, methods, body, headers, ...counting }));
     return this;
   }
 
   addLatency(urlPattern: string, delayMs: number, probability: number, methods?: string[], counting?: RequestCountingOptions) {
     if (!this.config.network!.latencies) this.config.network!.latencies = [];
-    this.config.network!.latencies.push({ urlPattern, delayMs, probability, methods, ...counting });
+    this.config.network!.latencies.push(this.withGroup({ urlPattern, delayMs, probability, methods, ...counting }));
     return this;
   }
 
   abortRequests(urlPattern: string, probability: number, timeout?: number, methods?: string[], counting?: RequestCountingOptions) {
     if (!this.config.network!.aborts) this.config.network!.aborts = [];
-    this.config.network!.aborts.push({ urlPattern, probability, timeout, methods, ...counting });
+    this.config.network!.aborts.push(this.withGroup({ urlPattern, probability, timeout, methods, ...counting }));
     return this;
   }
 
   corruptResponses(urlPattern: string, strategy: CorruptionStrategy, probability: number, methods?: string[], counting?: RequestCountingOptions) {
     if (!this.config.network!.corruptions) this.config.network!.corruptions = [];
-    this.config.network!.corruptions.push({ urlPattern, strategy, probability, methods, ...counting });
+    this.config.network!.corruptions.push(this.withGroup({ urlPattern, strategy, probability, methods, ...counting }));
     return this;
   }
 
   simulateCors(urlPattern: string, probability: number, methods?: string[], counting?: RequestCountingOptions) {
     if (!this.config.network!.cors) this.config.network!.cors = [];
-    this.config.network!.cors.push({ urlPattern, probability, methods, ...counting });
+    this.config.network!.cors.push(this.withGroup({ urlPattern, probability, methods, ...counting }));
     return this;
   }
 
@@ -130,7 +160,7 @@ export class ChaosConfigBuilder {
 
   assaultUi(selector: string, action: 'disable' | 'hide' | 'remove', probability: number) {
     if (!this.config.ui!.assaults) this.config.ui!.assaults = [];
-    this.config.ui!.assaults.push({ selector, action, probability });
+    this.config.ui!.assaults.push(this.withGroup({ selector, action, probability }));
     return this;
   }
 
@@ -138,25 +168,25 @@ export class ChaosConfigBuilder {
 
   dropMessages(urlPattern: string, direction: WebSocketDirection, probability: number, counting?: RequestCountingOptions) {
     if (!this.config.websocket!.drops) this.config.websocket!.drops = [];
-    this.config.websocket!.drops.push({ urlPattern, direction, probability, ...counting });
+    this.config.websocket!.drops.push(this.withGroup({ urlPattern, direction, probability, ...counting }));
     return this;
   }
 
   delayMessages(urlPattern: string, direction: WebSocketDirection, delayMs: number, probability: number, counting?: RequestCountingOptions) {
     if (!this.config.websocket!.delays) this.config.websocket!.delays = [];
-    this.config.websocket!.delays.push({ urlPattern, direction, delayMs, probability, ...counting });
+    this.config.websocket!.delays.push(this.withGroup({ urlPattern, direction, delayMs, probability, ...counting }));
     return this;
   }
 
   corruptMessages(urlPattern: string, direction: WebSocketDirection, strategy: WebSocketCorruptionStrategy, probability: number, counting?: RequestCountingOptions) {
     if (!this.config.websocket!.corruptions) this.config.websocket!.corruptions = [];
-    this.config.websocket!.corruptions.push({ urlPattern, direction, strategy, probability, ...counting });
+    this.config.websocket!.corruptions.push(this.withGroup({ urlPattern, direction, strategy, probability, ...counting }));
     return this;
   }
 
   closeConnection(urlPattern: string, probability: number, opts?: { code?: number; reason?: string; afterMs?: number }, counting?: RequestCountingOptions) {
     if (!this.config.websocket!.closes) this.config.websocket!.closes = [];
-    this.config.websocket!.closes.push({ urlPattern, probability, ...opts, ...counting });
+    this.config.websocket!.closes.push(this.withGroup({ urlPattern, probability, ...opts, ...counting }));
     return this;
   }
 
@@ -177,14 +207,14 @@ export class ChaosConfigBuilder {
    *  argument to scope to a specific endpoint. */
   failGraphQLOperation(operationName: GraphQLOperationMatcher, statusCode: number, probability: number, urlPattern: string = '*') {
     if (!this.config.network!.failures) this.config.network!.failures = [];
-    this.config.network!.failures.push({ urlPattern, statusCode, probability, graphqlOperation: operationName });
+    this.config.network!.failures.push(this.withGroup({ urlPattern, statusCode, probability, graphqlOperation: operationName }));
     return this;
   }
 
   /** Add `delayMs` of latency to every GraphQL request matching `operationName`. */
   delayGraphQLOperation(operationName: GraphQLOperationMatcher, delayMs: number, probability: number, urlPattern: string = '*') {
     if (!this.config.network!.latencies) this.config.network!.latencies = [];
-    this.config.network!.latencies.push({ urlPattern, delayMs, probability, graphqlOperation: operationName });
+    this.config.network!.latencies.push(this.withGroup({ urlPattern, delayMs, probability, graphqlOperation: operationName }));
     return this;
   }
 
@@ -192,25 +222,25 @@ export class ChaosConfigBuilder {
 
   dropSSE(urlPattern: string, probability: number, eventType?: string, counting?: RequestCountingOptions) {
     if (!this.config.sse!.drops) this.config.sse!.drops = [];
-    this.config.sse!.drops.push({ urlPattern, probability, ...(eventType ? { eventType } : {}), ...counting });
+    this.config.sse!.drops.push(this.withGroup({ urlPattern, probability, ...(eventType ? { eventType } : {}), ...counting }));
     return this;
   }
 
   delaySSE(urlPattern: string, delayMs: number, probability: number, eventType?: string, counting?: RequestCountingOptions) {
     if (!this.config.sse!.delays) this.config.sse!.delays = [];
-    this.config.sse!.delays.push({ urlPattern, delayMs, probability, ...(eventType ? { eventType } : {}), ...counting });
+    this.config.sse!.delays.push(this.withGroup({ urlPattern, delayMs, probability, ...(eventType ? { eventType } : {}), ...counting }));
     return this;
   }
 
   corruptSSE(urlPattern: string, strategy: SSECorruptionStrategy, probability: number, eventType?: string, counting?: RequestCountingOptions) {
     if (!this.config.sse!.corruptions) this.config.sse!.corruptions = [];
-    this.config.sse!.corruptions.push({ urlPattern, strategy, probability, ...(eventType ? { eventType } : {}), ...counting });
+    this.config.sse!.corruptions.push(this.withGroup({ urlPattern, strategy, probability, ...(eventType ? { eventType } : {}), ...counting }));
     return this;
   }
 
   closeSSE(urlPattern: string, probability: number, opts?: { afterMs?: number }, counting?: RequestCountingOptions) {
     if (!this.config.sse!.closes) this.config.sse!.closes = [];
-    this.config.sse!.closes.push({ urlPattern, probability, ...opts, ...counting });
+    this.config.sse!.closes.push(this.withGroup({ urlPattern, probability, ...opts, ...counting }));
     return this;
   }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,3 +1,5 @@
+import type { RuleGroupConfig } from './groups';
+
 /** Counting options shared by all network chaos config types.
  *  At most one of `onNth`, `everyNth`, or `afterN` may be set on a single rule.
  *  Counting is per-rule and shared across fetch + XHR (only increments when a
@@ -10,6 +12,15 @@ export interface RequestCountingOptions {
   onNth?: number;
   everyNth?: number;
   afterN?: number;
+}
+
+/** Optional group membership shared by every rule type (RFC-001).
+ *  Rules without a `group` belong to the implicit `'default'` group, which is
+ *  always enabled. Toggling a group at runtime via `enableGroup` /
+ *  `disableGroup` skips its rules without restarting the engine — counters
+ *  stay intact across toggles. */
+export interface RuleGroupAssignment {
+  group?: string;
 }
 
 /** Match a GraphQL operation by name. Applied AFTER `urlPattern` + `methods`
@@ -36,7 +47,7 @@ export interface NetworkRuleMatchers {
   graphqlOperation?: GraphQLOperationMatcher;
 }
 
-export interface NetworkFailureConfig extends RequestCountingOptions, NetworkRuleMatchers {
+export interface NetworkFailureConfig extends RequestCountingOptions, NetworkRuleMatchers, RuleGroupAssignment {
   statusCode: number;
   probability: number;
   body?: string;
@@ -44,24 +55,24 @@ export interface NetworkFailureConfig extends RequestCountingOptions, NetworkRul
   headers?: Record<string, string>;
 }
 
-export interface NetworkLatencyConfig extends RequestCountingOptions, NetworkRuleMatchers {
+export interface NetworkLatencyConfig extends RequestCountingOptions, NetworkRuleMatchers, RuleGroupAssignment {
   delayMs: number;
   probability: number;
 }
 
-export interface NetworkAbortConfig extends RequestCountingOptions, NetworkRuleMatchers {
+export interface NetworkAbortConfig extends RequestCountingOptions, NetworkRuleMatchers, RuleGroupAssignment {
   probability: number;
   timeout?: number; // ms before abort; 0 or omitted = immediate
 }
 
 export type CorruptionStrategy = 'truncate' | 'malformed-json' | 'empty' | 'wrong-type';
 
-export interface NetworkCorruptionConfig extends RequestCountingOptions, NetworkRuleMatchers {
+export interface NetworkCorruptionConfig extends RequestCountingOptions, NetworkRuleMatchers, RuleGroupAssignment {
   probability: number;
   strategy: CorruptionStrategy;
 }
 
-export interface NetworkCorsConfig extends RequestCountingOptions, NetworkRuleMatchers {
+export interface NetworkCorsConfig extends RequestCountingOptions, NetworkRuleMatchers, RuleGroupAssignment {
   probability: number;
 }
 
@@ -73,7 +84,7 @@ export interface NetworkConfig {
   cors?: NetworkCorsConfig[];
 }
 
-export interface UiAssaultConfig {
+export interface UiAssaultConfig extends RuleGroupAssignment {
   selector: string;
   action: 'disable' | 'hide' | 'remove';
   probability: number;
@@ -90,13 +101,13 @@ export interface UiConfig {
  */
 export type WebSocketDirection = 'inbound' | 'outbound' | 'both';
 
-export interface WebSocketDropConfig extends RequestCountingOptions {
+export interface WebSocketDropConfig extends RequestCountingOptions, RuleGroupAssignment {
   urlPattern: string;
   direction: WebSocketDirection;
   probability: number;
 }
 
-export interface WebSocketDelayConfig extends RequestCountingOptions {
+export interface WebSocketDelayConfig extends RequestCountingOptions, RuleGroupAssignment {
   urlPattern: string;
   direction: WebSocketDirection;
   delayMs: number;
@@ -111,14 +122,14 @@ export interface WebSocketDelayConfig extends RequestCountingOptions {
  */
 export type WebSocketCorruptionStrategy = 'truncate' | 'malformed-json' | 'empty' | 'wrong-type';
 
-export interface WebSocketCorruptConfig extends RequestCountingOptions {
+export interface WebSocketCorruptConfig extends RequestCountingOptions, RuleGroupAssignment {
   urlPattern: string;
   direction: WebSocketDirection;
   strategy: WebSocketCorruptionStrategy;
   probability: number;
 }
 
-export interface WebSocketCloseConfig extends RequestCountingOptions {
+export interface WebSocketCloseConfig extends RequestCountingOptions, RuleGroupAssignment {
   urlPattern: string;
   /**
    * WebSocket close code. Must be either `1000` (Normal Closure) or in the
@@ -159,27 +170,27 @@ export type SSECorruptionStrategy = 'truncate' | 'malformed-json' | 'empty' | 'w
  */
 export type SSEEventTypeMatcher = string | '*';
 
-export interface SSEDropConfig extends RequestCountingOptions {
+export interface SSEDropConfig extends RequestCountingOptions, RuleGroupAssignment {
   urlPattern: string;
   eventType?: SSEEventTypeMatcher;
   probability: number;
 }
 
-export interface SSEDelayConfig extends RequestCountingOptions {
+export interface SSEDelayConfig extends RequestCountingOptions, RuleGroupAssignment {
   urlPattern: string;
   eventType?: SSEEventTypeMatcher;
   delayMs: number;
   probability: number;
 }
 
-export interface SSECorruptConfig extends RequestCountingOptions {
+export interface SSECorruptConfig extends RequestCountingOptions, RuleGroupAssignment {
   urlPattern: string;
   eventType?: SSEEventTypeMatcher;
   strategy: SSECorruptionStrategy;
   probability: number;
 }
 
-export interface SSECloseConfig extends RequestCountingOptions {
+export interface SSECloseConfig extends RequestCountingOptions, RuleGroupAssignment {
   urlPattern: string;
   /** Delay after `open` before dispatching `error` + closing, in ms. Default 0. */
   afterMs?: number;
@@ -198,6 +209,15 @@ export interface ChaosConfig {
   ui?: UiConfig;
   websocket?: WebSocketConfig;
   sse?: SSEConfig;
+  /**
+   * Pre-register rule groups (RFC-001) with an explicit initial enabled state.
+   *
+   * Rules opt into a group by setting `group: 'name'`; groups referenced from
+   * rules but not listed here are auto-registered as enabled. Use this field
+   * only to ship a group as initially disabled (e.g. `{ name: 'payments',
+   * enabled: false }`) or to reserve a group name with no rules attached yet.
+   */
+  groups?: RuleGroupConfig[];
   /**
    * Seed for Chaos Maker's PRNG.
    *

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -12,7 +12,15 @@ export type ChaosEventType =
   | 'sse:drop'
   | 'sse:delay'
   | 'sse:corrupt'
-  | 'sse:close';
+  | 'sse:close'
+  /** Emitted once per `enableGroup()` call. `applied: true`. (RFC-001) */
+  | 'rule-group:enabled'
+  /** Emitted once per `disableGroup()` call. `applied: true`. (RFC-001) */
+  | 'rule-group:disabled'
+  /** Emitted once per group per toggle cycle when a rule is skipped because
+   *  its group is disabled. Deduped — at most one event per group between
+   *  toggles to avoid log floods. `applied: false`. (RFC-001) */
+  | 'rule-group:gated';
 
 export interface ChaosEvent {
   type: ChaosEventType;
@@ -43,6 +51,8 @@ export interface ChaosEvent {
     operationName?: string;
     /** Reason string for diagnostic `applied: false` events. */
     reason?: string;
+    /** Group name (for `rule-group:*` events, and on gated rule diagnostics). */
+    groupName?: string;
   };
 }
 

--- a/packages/core/src/groups.ts
+++ b/packages/core/src/groups.ts
@@ -24,7 +24,7 @@ export interface RuleGroup {
   readonly name: string;
   enabled: boolean;
   /** True when registered via `ChaosConfig.groups` or `createGroup()`. False when auto-registered from `isActive()`. */
-  readonly explicit: boolean;
+  explicit: boolean;
 }
 
 export class RuleGroupRegistry {
@@ -48,7 +48,10 @@ export class RuleGroupRegistry {
   ensure(name: string, opts?: { enabled?: boolean; explicit?: boolean }): RuleGroup {
     const existing = this.groups.get(name);
     if (existing) {
-      if (opts?.explicit && opts.enabled !== undefined) {
+      if (opts?.explicit) {
+        existing.explicit = true;
+      }
+      if (opts?.enabled !== undefined) {
         existing.enabled = opts.enabled;
       }
       return existing;

--- a/packages/core/src/groups.ts
+++ b/packages/core/src/groups.ts
@@ -106,11 +106,17 @@ export class RuleGroupRegistry {
         `[chaos-maker] Cannot remove group '${name}': still referenced by one or more rules. Pass { force: true } to override.`,
       );
     }
-    return this.groups.delete(name);
+    const removed = this.groups.delete(name);
+    if (removed) {
+      this.gatedEmitted.delete(name);
+    }
+    return removed;
   }
 
   list(): RuleGroup[] {
-    return [...this.groups.values()];
+    return [...this.groups.values()].map(
+      g => ({ ...g })
+    );
   }
 
   getSnapshot(): Record<string, boolean> {

--- a/packages/core/src/groups.ts
+++ b/packages/core/src/groups.ts
@@ -1,0 +1,118 @@
+/**
+ * Rule Groups (RFC-001) — bulk runtime enable/disable for chaos rules.
+ *
+ * A `RuleGroupRegistry` tracks named groups (default-on) and answers
+ * `isActive(name)` from interceptors before they apply chaos. Groups not
+ * declared up-front are auto-registered the first time they are referenced
+ * (typo surfacing — appears in `list()` / `getSnapshot()`).
+ *
+ * Toggle is runtime-only: there is no engine restart, so `requestCounters`
+ * survive across `setEnabled()` calls.
+ */
+
+/** Name of the implicit group all rules without an explicit `group` belong to. */
+export const DEFAULT_GROUP_NAME = 'default';
+
+/** Public, declarative form accepted on `ChaosConfig.groups`. */
+export interface RuleGroupConfig {
+  name: string;
+  enabled?: boolean;
+}
+
+/** Snapshot record describing a group inside the registry. */
+export interface RuleGroup {
+  readonly name: string;
+  enabled: boolean;
+  /** True when registered via `ChaosConfig.groups` or `createGroup()`. False when auto-registered from `isActive()`. */
+  readonly explicit: boolean;
+}
+
+export class RuleGroupRegistry {
+  private groups = new Map<string, RuleGroup>();
+  /**
+   * Tracks groups that have already emitted a `rule-group:gated` event since
+   * the last toggle. Cleared on every `setEnabled()` so the next toggle cycle
+   * gets a fresh diagnostic event without flooding.
+   */
+  private gatedEmitted = new Set<string>();
+
+  /**
+   * Look up an existing group or create a new one.
+   *
+   * - Implicit (auto-create from `isActive`): `explicit: false`, defaults
+   *   `enabled: true`.
+   * - Explicit (`ChaosConfig.groups` / `createGroup()`): `explicit: true`.
+   *   When called with both `explicit: true` and `enabled` set, the existing
+   *   group's `enabled` is overwritten; the explicit form is the source of truth.
+   */
+  ensure(name: string, opts?: { enabled?: boolean; explicit?: boolean }): RuleGroup {
+    const existing = this.groups.get(name);
+    if (existing) {
+      if (opts?.explicit && opts.enabled !== undefined) {
+        existing.enabled = opts.enabled;
+      }
+      return existing;
+    }
+    const g: RuleGroup = {
+      name,
+      enabled: opts?.enabled ?? true,
+      explicit: opts?.explicit ?? false,
+    };
+    this.groups.set(name, g);
+    return g;
+  }
+
+  setEnabled(name: string, enabled: boolean): void {
+    this.ensure(name).enabled = enabled;
+    this.gatedEmitted.clear();
+  }
+
+  /**
+   * Auto-creates unknown groups on first check (implicit). Rationale:
+   * silently returning `true` for unknown names lets typos like
+   * `group: 'paymets'` mask chaos as if no group existed; auto-registering
+   * surfaces the typo via `list()` / `getSnapshot()` and keeps default-on
+   * backward compat.
+   */
+  isActive(name: string | undefined): boolean {
+    return this.ensure(name ?? DEFAULT_GROUP_NAME).enabled;
+  }
+
+  /** True when this group should emit a `rule-group:gated` event right now (first block since last toggle). */
+  shouldEmitGated(name: string): boolean {
+    if (this.gatedEmitted.has(name)) return false;
+    this.gatedEmitted.add(name);
+    return true;
+  }
+
+  has(name: string): boolean {
+    return this.groups.has(name);
+  }
+
+  /**
+   * Remove a group from the registry.
+   * - `'default'` cannot be removed (returns `false`).
+   * - By default, throws when any rule in `referencedBy` still uses the group.
+   * - Pass `{ force: true }` to remove anyway. Subsequent `isActive(name)`
+   *   calls auto-recreate the group (default-on).
+   */
+  remove(name: string, referencedBy: ReadonlySet<string>, opts?: { force?: boolean }): boolean {
+    if (name === DEFAULT_GROUP_NAME) return false;
+    if (!opts?.force && referencedBy.has(name)) {
+      throw new Error(
+        `[chaos-maker] Cannot remove group '${name}': still referenced by one or more rules. Pass { force: true } to override.`,
+      );
+    }
+    return this.groups.delete(name);
+  }
+
+  list(): RuleGroup[] {
+    return [...this.groups.values()];
+  }
+
+  getSnapshot(): Record<string, boolean> {
+    const out: Record<string, boolean> = {};
+    for (const g of this.groups.values()) out[g.name] = g.enabled;
+    return out;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 import { ChaosMaker } from './ChaosMaker';
-import { ChaosConfig, CorruptionStrategy, GraphQLOperationMatcher, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, NetworkRuleMatchers, UiAssaultConfig, UiConfig, WebSocketConfig, WebSocketDropConfig, WebSocketDelayConfig, WebSocketCorruptConfig, WebSocketCloseConfig, WebSocketDirection, WebSocketCorruptionStrategy, SSEConfig, SSEDropConfig, SSEDelayConfig, SSECorruptConfig, SSECloseConfig, SSECorruptionStrategy, SSEEventTypeMatcher } from './config';
+import { ChaosConfig, CorruptionStrategy, GraphQLOperationMatcher, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, NetworkRuleMatchers, RuleGroupAssignment, UiAssaultConfig, UiConfig, WebSocketConfig, WebSocketDropConfig, WebSocketDelayConfig, WebSocketCorruptConfig, WebSocketCloseConfig, WebSocketDirection, WebSocketCorruptionStrategy, SSEConfig, SSEDropConfig, SSEDelayConfig, SSECorruptConfig, SSECloseConfig, SSECorruptionStrategy, SSEEventTypeMatcher } from './config';
 import { ChaosConfigError } from './errors';
 import { validateConfig } from './validation';
 import { ChaosEvent, ChaosEventType, ChaosEventListener, ChaosEventEmitter } from './events';
@@ -12,8 +12,10 @@ export { ChaosMaker, ChaosConfigError, validateConfig, ChaosEventEmitter, ChaosC
 export { SW_BRIDGE_SOURCE } from './sw-bridge-source';
 export { extractGraphQLOperation, parseOperationFromQueryString, operationNameMatches } from './graphql';
 export { serializeForTransport, deserializeForTransport } from './transport';
+export { DEFAULT_GROUP_NAME, RuleGroupRegistry } from './groups';
+export type { RuleGroup, RuleGroupConfig } from './groups';
 export type { GraphQLExtractResult, GraphQLRuleOutcome } from './graphql';
-export type { ChaosConfig, CorruptionStrategy, GraphQLOperationMatcher, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, NetworkRuleMatchers, UiAssaultConfig, UiConfig, WebSocketConfig, WebSocketDropConfig, WebSocketDelayConfig, WebSocketCorruptConfig, WebSocketCloseConfig, WebSocketDirection, WebSocketCorruptionStrategy, SSEConfig, SSEDropConfig, SSEDelayConfig, SSECorruptConfig, SSECloseConfig, SSECorruptionStrategy, SSEEventTypeMatcher, ChaosEvent, ChaosEventType, ChaosEventListener };
+export type { ChaosConfig, CorruptionStrategy, GraphQLOperationMatcher, NetworkFailureConfig, NetworkLatencyConfig, NetworkAbortConfig, NetworkCorruptionConfig, NetworkCorsConfig, NetworkConfig, NetworkRuleMatchers, RuleGroupAssignment, UiAssaultConfig, UiConfig, WebSocketConfig, WebSocketDropConfig, WebSocketDelayConfig, WebSocketCorruptConfig, WebSocketCloseConfig, WebSocketDirection, WebSocketCorruptionStrategy, SSEConfig, SSEDropConfig, SSEDelayConfig, SSECorruptConfig, SSECloseConfig, SSECorruptionStrategy, SSEEventTypeMatcher, ChaosEvent, ChaosEventType, ChaosEventListener };
 
 // --- NEW INTERFACE ---
 interface ChaosUtilsApi {

--- a/packages/core/src/interceptors/domAssailant.ts
+++ b/packages/core/src/interceptors/domAssailant.ts
@@ -1,8 +1,10 @@
 import { UiConfig, UiAssaultConfig } from '../config';
-import { shouldApplyChaos } from '../utils';
+import { shouldApplyChaos, gateGroup } from '../utils';
 import { ChaosEventEmitter } from '../events';
+import type { RuleGroupRegistry } from '../groups';
 
-function applyAssault(element: HTMLElement, assault: UiAssaultConfig, random: () => number, emitter?: ChaosEventEmitter) {
+function applyAssault(element: HTMLElement, assault: UiAssaultConfig, random: () => number, emitter?: ChaosEventEmitter, groups?: RuleGroupRegistry) {
+  if (!gateGroup(assault, groups, emitter, { selector: assault.selector, action: assault.action })) return;
   const applied = shouldApplyChaos(assault.probability, random);
   emitter?.emit({
     type: 'ui:assault',
@@ -36,7 +38,7 @@ function applyAssault(element: HTMLElement, assault: UiAssaultConfig, random: ()
   }
 }
 
-function checkNode(node: Node, config: UiConfig, random: () => number, emitter?: ChaosEventEmitter) {
+function checkNode(node: Node, config: UiConfig, random: () => number, emitter?: ChaosEventEmitter, groups?: RuleGroupRegistry) {
   if (node.nodeType !== Node.ELEMENT_NODE || !config.assaults) {
     return;
   }
@@ -46,10 +48,10 @@ function checkNode(node: Node, config: UiConfig, random: () => number, emitter?:
   for (const assault of config.assaults) {
     try {
       if (element.matches(assault.selector)) {
-        applyAssault(element, assault, random, emitter);
+        applyAssault(element, assault, random, emitter, groups);
       }
       element.querySelectorAll(assault.selector).forEach(childEl => {
-        applyAssault(childEl as HTMLElement, assault, random, emitter);
+        applyAssault(childEl as HTMLElement, assault, random, emitter, groups);
       });
     } catch (e) {
       console.error(`Chaos Maker: Invalid selector '${assault.selector}'`, e);
@@ -57,13 +59,13 @@ function checkNode(node: Node, config: UiConfig, random: () => number, emitter?:
   }
 }
 
-export function attachDomAssailant(config: UiConfig, random: () => number, emitter?: ChaosEventEmitter): MutationObserver {
+export function attachDomAssailant(config: UiConfig, random: () => number, emitter?: ChaosEventEmitter, groups?: RuleGroupRegistry): MutationObserver {
   if (config.assaults) {
     console.log('CHAOS: Running initial DOM scan for existing elements...');
     for (const assault of config.assaults) {
       try {
         document.querySelectorAll(assault.selector).forEach(element => {
-          applyAssault(element as HTMLElement, assault, random, emitter);
+          applyAssault(element as HTMLElement, assault, random, emitter, groups);
         });
       } catch (e) {
         console.error(`Chaos Maker: Invalid selector in initial scan '${assault.selector}'`, e);
@@ -74,7 +76,7 @@ export function attachDomAssailant(config: UiConfig, random: () => number, emitt
   const observer = new MutationObserver((mutationsList) => {
     for (const mutation of mutationsList) {
       if (mutation.type === 'childList') {
-        mutation.addedNodes.forEach(node => checkNode(node, config, random, emitter));
+        mutation.addedNodes.forEach(node => checkNode(node, config, random, emitter, groups));
       }
     }
   });

--- a/packages/core/src/interceptors/eventSource.ts
+++ b/packages/core/src/interceptors/eventSource.ts
@@ -34,7 +34,8 @@ import {
   RequestCountingOptions,
 } from '../config';
 import { ChaosEventEmitter } from '../events';
-import { shouldApplyChaos, matchUrl, incrementCounter, checkCountingCondition, corruptText } from '../utils';
+import { shouldApplyChaos, matchUrl, incrementCounter, checkCountingCondition, corruptText, gateGroup } from '../utils';
+import type { RuleGroupRegistry } from '../groups';
 
 const INTERCEPT_MARKER = Symbol.for('chaos-maker.eventsource.intercepted');
 
@@ -74,12 +75,14 @@ function eventTypeMatches(rule: WildcardOrString, actual: string): boolean {
   return rule === actual;
 }
 
-function findFiringRule<T extends RequestCountingOptions & { urlPattern: string; eventType?: WildcardOrString; probability: number }>(
+function findFiringRule<T extends RequestCountingOptions & { urlPattern: string; eventType?: WildcardOrString; probability: number; group?: string }>(
   rules: T[] | undefined,
   url: string,
   eventType: string,
   random: () => number,
   counters: Map<object, number>,
+  groups: RuleGroupRegistry | undefined,
+  emitter: ChaosEventEmitter | undefined,
 ): T | null {
   if (!rules) return null;
   for (const rule of rules) {
@@ -87,6 +90,7 @@ function findFiringRule<T extends RequestCountingOptions & { urlPattern: string;
     if (!eventTypeMatches(rule.eventType, eventType)) continue;
     const count = incrementCounter(rule, counters);
     if (!checkCountingCondition(rule, count)) continue;
+    if (!gateGroup(rule, groups, emitter, { url, eventType })) continue;
     if (!shouldApplyChaos(rule.probability, random)) continue;
     return rule;
   }
@@ -135,6 +139,7 @@ export function patchEventSource(
   emitter: ChaosEventEmitter,
   random: () => number,
   counters: Map<object, number>,
+  groups?: RuleGroupRegistry,
 ): EventSourcePatchHandle {
   const pendingTimersBySource = new Map<EventSource, Set<PendingTimer>>();
   let running = true;
@@ -182,7 +187,7 @@ export function patchEventSource(
     // for unnamed events.
     const eventType = msgEvt.type || 'message';
 
-    if (findFiringRule<SSEDropConfig>(config.drops, url, eventType, random, counters)) {
+    if (findFiringRule<SSEDropConfig>(config.drops, url, eventType, random, counters, groups, emitter)) {
       msgEvt.stopImmediatePropagation();
       emitDrop(emitter, url, eventType);
       return;
@@ -191,14 +196,14 @@ export function patchEventSource(
     let payload = typeof msgEvt.data === 'string' ? msgEvt.data : String(msgEvt.data);
     let mutated = false;
 
-    const corruptRule = findFiringRule<SSECorruptConfig>(config.corruptions, url, eventType, random, counters);
+    const corruptRule = findFiringRule<SSECorruptConfig>(config.corruptions, url, eventType, random, counters, groups, emitter);
     if (corruptRule) {
       payload = corruptText(payload, corruptRule.strategy);
       mutated = true;
       emitCorrupt(emitter, url, eventType, corruptRule.strategy);
     }
 
-    const delayRule = findFiringRule<SSEDelayConfig>(config.delays, url, eventType, random, counters);
+    const delayRule = findFiringRule<SSEDelayConfig>(config.delays, url, eventType, random, counters, groups, emitter);
     if (delayRule) {
       msgEvt.stopImmediatePropagation();
       emitDelay(emitter, url, eventType, delayRule.delayMs);
@@ -234,6 +239,7 @@ export function patchEventSource(
       if (!matchUrl(url, rule.urlPattern)) continue;
       const count = incrementCounter(rule, counters);
       if (!checkCountingCondition(rule, count)) continue;
+      if (!gateGroup(rule, groups, emitter, { url })) continue;
       if (!shouldApplyChaos(rule.probability, random)) continue;
       return rule;
     }

--- a/packages/core/src/interceptors/networkFetch.ts
+++ b/packages/core/src/interceptors/networkFetch.ts
@@ -1,5 +1,6 @@
 import { NetworkAbortConfig, NetworkConfig, NetworkCorruptionConfig, NetworkRuleMatchers } from '../config';
-import { shouldApplyChaos, corruptText, matchUrl, incrementCounter, checkCountingCondition } from '../utils';
+import { shouldApplyChaos, corruptText, matchUrl, incrementCounter, checkCountingCondition, gateGroup } from '../utils';
+import type { RuleGroupRegistry } from '../groups';
 import {
   evaluateGraphQLRule,
   extractGraphQLOperation,
@@ -214,7 +215,7 @@ function ruleHasGraphQLConstraint(rule: NetworkRuleMatchers): boolean {
   return rule.graphqlOperation !== undefined;
 }
 
-export function patchFetch(originalFetch: typeof globalThis.fetch, config: NetworkConfig, random: () => number, emitter?: ChaosEventEmitter, counters: Map<object, number> = new Map()) {
+export function patchFetch(originalFetch: typeof globalThis.fetch, config: NetworkConfig, random: () => number, emitter?: ChaosEventEmitter, counters: Map<object, number> = new Map(), groups?: RuleGroupRegistry) {
   return async (
     input: RequestInfo | URL,
     init?: RequestInit
@@ -252,6 +253,7 @@ export function patchFetch(originalFetch: typeof globalThis.fetch, config: Netwo
         }
         const count = incrementCounter(cors, counters);
         if (!checkCountingCondition(cors, count)) continue;
+        if (!gateGroup(cors, groups, emitter, { url, method })) continue;
         const applied = shouldApplyChaos(cors.probability, random);
         emitter?.emit({
           type: 'network:cors',
@@ -297,6 +299,7 @@ export function patchFetch(originalFetch: typeof globalThis.fetch, config: Netwo
           }
           continue;
         }
+        if (!gateGroup(abort, groups, emitter, { url, method, timeoutMs: abort.timeout })) continue;
         const applied = shouldApplyChaos(abort.probability, random);
         if (!applied) {
           emitAbortEvent(emitter, abort, url, method, false, gate.outcome);
@@ -348,6 +351,7 @@ export function patchFetch(originalFetch: typeof globalThis.fetch, config: Netwo
           }
           continue;
         }
+        if (!gateGroup(failure, groups, emitter, { url, method, statusCode: failure.statusCode })) continue;
         const applied = shouldApplyChaos(failure.probability, random);
         emitter?.emit({
           type: 'network:failure',
@@ -378,6 +382,7 @@ export function patchFetch(originalFetch: typeof globalThis.fetch, config: Netwo
           }
           continue;
         }
+        if (!gateGroup(latency, groups, emitter, { url, method, delayMs: latency.delayMs })) continue;
         const applied = shouldApplyChaos(latency.probability, random);
         emitter?.emit({
           type: 'network:latency',
@@ -404,6 +409,7 @@ export function patchFetch(originalFetch: typeof globalThis.fetch, config: Netwo
           }
           continue;
         }
+        if (!gateGroup(corruption, groups, emitter, { url, method, strategy: corruption.strategy })) continue;
         const applied = shouldApplyChaos(corruption.probability, random);
         if (!applied) {
           emitCorruptionEvent(emitter, corruption, url, method, false, gate.outcome);

--- a/packages/core/src/interceptors/networkFetch.ts
+++ b/packages/core/src/interceptors/networkFetch.ts
@@ -147,27 +147,24 @@ function emitGraphQLDiagnostic(
 }
 
 /**
- * Run the shared per-rule gate: urlPattern + methods + GraphQL operation +
- * counting. Returns `proceed: true` only when the rule should evaluate
- * probability for this request.
+ * Run the shared per-rule gate: urlPattern + methods + GraphQL operation.
+ * Counting remains in the branch so group gating stays after the counter
+ * update and before probability.
  */
 function gateRule(
-  rule: NetworkRuleMatchers & { onNth?: number; everyNth?: number; afterN?: number },
+  rule: NetworkRuleMatchers,
   url: string,
   method: string,
   gqlExtract: GraphQLExtractResult,
-  counters: Map<object, number>,
 ): { proceed: boolean; outcome: GraphQLRuleOutcome | null } {
   if (!matchUrl(url, rule.urlPattern)) return { proceed: false, outcome: null };
   if (rule.methods && !rule.methods.includes(method)) return { proceed: false, outcome: null };
 
   const outcome = evaluateGraphQLRule(rule.graphqlOperation, gqlExtract);
-  if (outcome.kind === 'no-match' || outcome.kind === 'unparseable') {
+  if (outcome.kind === 'no-match') {
     return { proceed: false, outcome };
   }
 
-  const count = incrementCounter(rule, counters);
-  if (!checkCountingCondition(rule, count)) return { proceed: false, outcome };
   return { proceed: true, outcome };
 }
 
@@ -243,23 +240,23 @@ export function patchFetch(originalFetch: typeof globalThis.fetch, config: Netwo
     // 1. Check for CORS
     if (config.cors) {
       for (const cors of config.cors) {
-        if (!matchUrl(url, cors.urlPattern)) continue;
-        if (cors.methods && !cors.methods.includes(method)) continue;
-        const outcome = evaluateGraphQLRule(cors.graphqlOperation, gqlExtract);
-        if (outcome.kind === 'no-match') continue;
-        if (outcome.kind === 'unparseable') {
-          emitGraphQLDiagnostic(emitter, 'network:cors', url, method, {});
-          continue;
-        }
+        const gate = gateRule(cors, url, method, gqlExtract);
+        if (!gate.proceed) continue;
         const count = incrementCounter(cors, counters);
         if (!checkCountingCondition(cors, count)) continue;
         if (!gateGroup(cors, groups, emitter, { url, method })) continue;
         const applied = shouldApplyChaos(cors.probability, random);
+        if (gate.outcome?.kind === 'unparseable') {
+          if (applied) {
+            emitGraphQLDiagnostic(emitter, 'network:cors', url, method, {});
+          }
+          continue;
+        }
         emitter?.emit({
           type: 'network:cors',
           timestamp: Date.now(),
           applied,
-          detail: { url, method, ...operationDetail(outcome) },
+          detail: { url, method, ...operationDetail(gate.outcome) },
         });
         if (applied) {
           console.debug(`[chaos-maker] CORS block: ${method} ${url}`);
@@ -292,15 +289,18 @@ export function patchFetch(originalFetch: typeof globalThis.fetch, config: Netwo
 
     if (config.aborts) {
       for (const abort of config.aborts) {
-        const gate = gateRule(abort, url, method, gqlExtract, counters);
-        if (!gate.proceed) {
-          if (gate.outcome?.kind === 'unparseable') {
+        const gate = gateRule(abort, url, method, gqlExtract);
+        if (!gate.proceed) continue;
+        const count = incrementCounter(abort, counters);
+        if (!checkCountingCondition(abort, count)) continue;
+        if (!gateGroup(abort, groups, emitter, { url, method, timeoutMs: abort.timeout })) continue;
+        const applied = shouldApplyChaos(abort.probability, random);
+        if (gate.outcome?.kind === 'unparseable') {
+          if (applied) {
             emitGraphQLDiagnostic(emitter, 'network:abort', url, method, { timeoutMs: abort.timeout });
           }
           continue;
         }
-        if (!gateGroup(abort, groups, emitter, { url, method, timeoutMs: abort.timeout })) continue;
-        const applied = shouldApplyChaos(abort.probability, random);
         if (!applied) {
           emitAbortEvent(emitter, abort, url, method, false, gate.outcome);
           continue;
@@ -344,15 +344,18 @@ export function patchFetch(originalFetch: typeof globalThis.fetch, config: Netwo
     // 3. Check for Failures
     if (config.failures) {
       for (const failure of config.failures) {
-        const gate = gateRule(failure, url, method, gqlExtract, counters);
-        if (!gate.proceed) {
-          if (gate.outcome?.kind === 'unparseable') {
+        const gate = gateRule(failure, url, method, gqlExtract);
+        if (!gate.proceed) continue;
+        const count = incrementCounter(failure, counters);
+        if (!checkCountingCondition(failure, count)) continue;
+        if (!gateGroup(failure, groups, emitter, { url, method, statusCode: failure.statusCode })) continue;
+        const applied = shouldApplyChaos(failure.probability, random);
+        if (gate.outcome?.kind === 'unparseable') {
+          if (applied) {
             emitGraphQLDiagnostic(emitter, 'network:failure', url, method, { statusCode: failure.statusCode });
           }
           continue;
         }
-        if (!gateGroup(failure, groups, emitter, { url, method, statusCode: failure.statusCode })) continue;
-        const applied = shouldApplyChaos(failure.probability, random);
         emitter?.emit({
           type: 'network:failure',
           timestamp: Date.now(),
@@ -375,15 +378,18 @@ export function patchFetch(originalFetch: typeof globalThis.fetch, config: Netwo
     // 4. Check for Latency
     if (config.latencies) {
       for (const latency of config.latencies) {
-        const gate = gateRule(latency, url, method, gqlExtract, counters);
-        if (!gate.proceed) {
-          if (gate.outcome?.kind === 'unparseable') {
+        const gate = gateRule(latency, url, method, gqlExtract);
+        if (!gate.proceed) continue;
+        const count = incrementCounter(latency, counters);
+        if (!checkCountingCondition(latency, count)) continue;
+        if (!gateGroup(latency, groups, emitter, { url, method, delayMs: latency.delayMs })) continue;
+        const applied = shouldApplyChaos(latency.probability, random);
+        if (gate.outcome?.kind === 'unparseable') {
+          if (applied) {
             emitGraphQLDiagnostic(emitter, 'network:latency', url, method, { delayMs: latency.delayMs });
           }
           continue;
         }
-        if (!gateGroup(latency, groups, emitter, { url, method, delayMs: latency.delayMs })) continue;
-        const applied = shouldApplyChaos(latency.probability, random);
         emitter?.emit({
           type: 'network:latency',
           timestamp: Date.now(),
@@ -402,15 +408,18 @@ export function patchFetch(originalFetch: typeof globalThis.fetch, config: Netwo
     let selectedCorruptionOutcome: GraphQLRuleOutcome | null = null;
     if (config.corruptions) {
       for (const corruption of config.corruptions) {
-        const gate = gateRule(corruption, url, method, gqlExtract, counters);
-        if (!gate.proceed) {
-          if (gate.outcome?.kind === 'unparseable') {
+        const gate = gateRule(corruption, url, method, gqlExtract);
+        if (!gate.proceed) continue;
+        const count = incrementCounter(corruption, counters);
+        if (!checkCountingCondition(corruption, count)) continue;
+        if (!gateGroup(corruption, groups, emitter, { url, method, strategy: corruption.strategy })) continue;
+        const applied = shouldApplyChaos(corruption.probability, random);
+        if (gate.outcome?.kind === 'unparseable') {
+          if (applied) {
             emitGraphQLDiagnostic(emitter, 'network:corruption', url, method, { strategy: corruption.strategy });
           }
           continue;
         }
-        if (!gateGroup(corruption, groups, emitter, { url, method, strategy: corruption.strategy })) continue;
-        const applied = shouldApplyChaos(corruption.probability, random);
         if (!applied) {
           emitCorruptionEvent(emitter, corruption, url, method, false, gate.outcome);
           continue;

--- a/packages/core/src/interceptors/networkXHR.ts
+++ b/packages/core/src/interceptors/networkXHR.ts
@@ -1,6 +1,6 @@
 import { NetworkAbortConfig, NetworkConfig, NetworkCorruptionConfig, NetworkRuleMatchers } from '../config';
 import { shouldApplyChaos, corruptText, matchUrl, incrementCounter, checkCountingCondition, gateGroup } from '../utils';
-import { DEFAULT_GROUP_NAME, type RuleGroupRegistry } from '../groups';
+import type { RuleGroupRegistry } from '../groups';
 import {
   evaluateGraphQLRule,
   extractGraphQLOperation,
@@ -388,18 +388,7 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
           }
           continue;
         }
-        if (groups && !groups.isActive(latency.group)) {
-          const groupName = latency.group ?? DEFAULT_GROUP_NAME;
-          if (groups.shouldEmitGated(groupName)) {
-            emitter?.emit({
-              type: 'rule-group:gated',
-              timestamp: Date.now(),
-              applied: false,
-              detail: { url, method, groupName },
-            });
-          }
-          continue;
-        }
+        if (!gateGroup(latency, groups, emitter, { url, method, delayMs: latency.delayMs })) continue;
         const applied = shouldApplyChaos(latency.probability, random);
         emitter?.emit({
           type: 'network:latency',

--- a/packages/core/src/interceptors/networkXHR.ts
+++ b/packages/core/src/interceptors/networkXHR.ts
@@ -1,6 +1,6 @@
 import { NetworkAbortConfig, NetworkConfig, NetworkCorruptionConfig, NetworkRuleMatchers } from '../config';
 import { shouldApplyChaos, corruptText, matchUrl, incrementCounter, checkCountingCondition, gateGroup } from '../utils';
-import type { RuleGroupRegistry } from '../groups';
+import { DEFAULT_GROUP_NAME, type RuleGroupRegistry } from '../groups';
 import {
   evaluateGraphQLRule,
   extractGraphQLOperation,
@@ -385,6 +385,18 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
         if (!gate.proceed) {
           if (gate.outcome?.kind === 'unparseable') {
             emitGraphQLDiagnostic(emitter, 'network:latency', url, method, { delayMs: latency.delayMs });
+          }
+          continue;
+        }
+        if (groups && !groups.isActive(latency.group)) {
+          const groupName = latency.group ?? DEFAULT_GROUP_NAME;
+          if (groups.shouldEmitGated(groupName)) {
+            emitter?.emit({
+              type: 'rule-group:gated',
+              timestamp: Date.now(),
+              applied: false,
+              detail: { url, method, groupName },
+            });
           }
           continue;
         }

--- a/packages/core/src/interceptors/networkXHR.ts
+++ b/packages/core/src/interceptors/networkXHR.ts
@@ -1,5 +1,6 @@
 import { NetworkAbortConfig, NetworkConfig, NetworkCorruptionConfig, NetworkRuleMatchers } from '../config';
-import { shouldApplyChaos, corruptText, matchUrl, incrementCounter, checkCountingCondition } from '../utils';
+import { shouldApplyChaos, corruptText, matchUrl, incrementCounter, checkCountingCondition, gateGroup } from '../utils';
+import type { RuleGroupRegistry } from '../groups';
 import {
   evaluateGraphQLRule,
   extractGraphQLOperation,
@@ -110,7 +111,7 @@ function emitCorruptionEvent(
   });
 }
 
-export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyInit) => void, config: NetworkConfig, random: () => number, emitter?: ChaosEventEmitter, counters: Map<object, number> = new Map()) {
+export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyInit) => void, config: NetworkConfig, random: () => number, emitter?: ChaosEventEmitter, counters: Map<object, number> = new Map(), groups?: RuleGroupRegistry) {
   const needsGqlExtract = configHasGraphQLRule(config);
 
   return function (this: XMLHttpRequest, body?: Document | XMLHttpRequestBodyInit) {
@@ -136,6 +137,7 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
         }
         const count = incrementCounter(cors, counters);
         if (!checkCountingCondition(cors, count)) continue;
+        if (!gateGroup(cors, groups, emitter, { url, method })) continue;
         const applied = shouldApplyChaos(cors.probability, random);
         emitter?.emit({
           type: 'network:cors',
@@ -164,6 +166,7 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
           }
           continue;
         }
+        if (!gateGroup(abort, groups, emitter, { url, method, timeoutMs: abort.timeout })) continue;
         const applied = shouldApplyChaos(abort.probability, random);
         if (!applied) {
           emitAbortEvent(emitter, abort, url, method, false, gate.outcome);
@@ -240,6 +243,7 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
           }
           continue;
         }
+        if (!gateGroup(failure, groups, emitter, { url, method, statusCode: failure.statusCode })) continue;
         const applied = shouldApplyChaos(failure.probability, random);
         emitter?.emit({
           type: 'network:failure',
@@ -292,6 +296,7 @@ export function patchXHR(originalXhrSend: (body?: Document | XMLHttpRequestBodyI
           }
           continue;
         }
+        if (!gateGroup(corruption, groups, emitter, { url, method, strategy: corruption.strategy })) continue;
         const applied = shouldApplyChaos(corruption.probability, random);
         if (!applied) {
           emitCorruptionEvent(emitter, corruption, url, method, false, gate.outcome);

--- a/packages/core/src/interceptors/websocket.ts
+++ b/packages/core/src/interceptors/websocket.ts
@@ -30,7 +30,8 @@ import {
   RequestCountingOptions,
 } from '../config';
 import { ChaosEventEmitter } from '../events';
-import { shouldApplyChaos, matchUrl, incrementCounter, checkCountingCondition } from '../utils';
+import { shouldApplyChaos, matchUrl, incrementCounter, checkCountingCondition, gateGroup } from '../utils';
+import type { RuleGroupRegistry } from '../groups';
 
 type Direction = 'inbound' | 'outbound';
 type PayloadType = 'text' | 'binary';
@@ -105,12 +106,14 @@ function corruptBinaryPayload(
   return new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + end));
 }
 
-function findFiringRule<T extends RequestCountingOptions & { urlPattern: string; direction: WebSocketDirection; probability: number }>(
+function findFiringRule<T extends RequestCountingOptions & { urlPattern: string; direction: WebSocketDirection; probability: number; group?: string }>(
   rules: T[] | undefined,
   url: string,
   direction: Direction,
   random: () => number,
   counters: Map<object, number>,
+  groups: RuleGroupRegistry | undefined,
+  emitter: ChaosEventEmitter | undefined,
 ): T | null {
   if (!rules) return null;
   for (const rule of rules) {
@@ -118,6 +121,7 @@ function findFiringRule<T extends RequestCountingOptions & { urlPattern: string;
     if (!directionApplies(rule.direction, direction)) continue;
     const count = incrementCounter(rule, counters);
     if (!checkCountingCondition(rule, count)) continue;
+    if (!gateGroup(rule, groups, emitter, { url, direction })) continue;
     if (!shouldApplyChaos(rule.probability, random)) continue;
     return rule;
   }
@@ -191,6 +195,7 @@ export function patchWebSocket(
   emitter: ChaosEventEmitter,
   random: () => number,
   counters: Map<object, number>,
+  groups?: RuleGroupRegistry,
 ): WebSocketPatchHandle {
   const pendingTimersBySocket = new Map<WebSocket, Set<PendingTimer>>();
   // Set to false in uninstall() so that already-wrapped sockets stop applying
@@ -249,13 +254,13 @@ export function patchWebSocket(
     const direction: Direction = 'outbound';
     const payloadType = getPayloadType(data);
 
-    if (findFiringRule<WebSocketDropConfig>(config.drops, url, direction, random, counters)) {
+    if (findFiringRule<WebSocketDropConfig>(config.drops, url, direction, random, counters, groups, emitter)) {
       emitDrop(emitter, url, direction, payloadType);
       return { handled: true, data };
     }
 
     let payload = data;
-    const corruptRule = findFiringRule<WebSocketCorruptConfig>(config.corruptions, url, direction, random, counters);
+    const corruptRule = findFiringRule<WebSocketCorruptConfig>(config.corruptions, url, direction, random, counters, groups, emitter);
     if (corruptRule) {
       if (payloadType === 'text') {
         payload = corruptTextPayload(payload as string, corruptRule.strategy);
@@ -271,7 +276,7 @@ export function patchWebSocket(
       }
     }
 
-    const delayRule = findFiringRule<WebSocketDelayConfig>(config.delays, url, direction, random, counters);
+    const delayRule = findFiringRule<WebSocketDelayConfig>(config.delays, url, direction, random, counters, groups, emitter);
     if (delayRule) {
       emitDelay(emitter, url, direction, payloadType, delayRule.delayMs);
       const timer: PendingDelayTimer = {
@@ -303,7 +308,7 @@ export function patchWebSocket(
       const direction: Direction = 'inbound';
       const payloadType = getPayloadType(msgEvt.data);
 
-      if (findFiringRule<WebSocketDropConfig>(config.drops, url, direction, random, counters)) {
+      if (findFiringRule<WebSocketDropConfig>(config.drops, url, direction, random, counters, groups, emitter)) {
         msgEvt.stopImmediatePropagation();
         emitDrop(emitter, url, direction, payloadType);
         return;
@@ -311,7 +316,7 @@ export function patchWebSocket(
 
       let payload: unknown = msgEvt.data;
       let wasCorrupted = false;
-      const corruptRule = findFiringRule<WebSocketCorruptConfig>(config.corruptions, url, direction, random, counters);
+      const corruptRule = findFiringRule<WebSocketCorruptConfig>(config.corruptions, url, direction, random, counters, groups, emitter);
       if (corruptRule) {
         if (payloadType === 'text') {
           payload = corruptTextPayload(payload as string, corruptRule.strategy);
@@ -329,7 +334,7 @@ export function patchWebSocket(
         }
       }
 
-      const delayRule = findFiringRule<WebSocketDelayConfig>(config.delays, url, direction, random, counters);
+      const delayRule = findFiringRule<WebSocketDelayConfig>(config.delays, url, direction, random, counters, groups, emitter);
       if (delayRule) {
         msgEvt.stopImmediatePropagation();
         emitDelay(emitter, url, direction, payloadType, delayRule.delayMs);
@@ -358,6 +363,7 @@ export function patchWebSocket(
       if (!matchUrl(url, rule.urlPattern)) continue;
       const count = incrementCounter(rule, counters);
       if (!checkCountingCondition(rule, count)) continue;
+      if (!gateGroup(rule, groups, emitter, { url })) continue;
       if (!shouldApplyChaos(rule.probability, random)) continue;
       // Default to 1000 (Normal Closure) — the only 1xxx code browsers accept
       // as input to `socket.close(code)`. Reserved codes like 1006 throw

--- a/packages/core/src/sw.ts
+++ b/packages/core/src/sw.ts
@@ -330,7 +330,15 @@ export function installChaosSW(opts: InstallChaosSWOptions = {}): SWChaosHandle 
     }
 
     if (asCfg.__chaosMakerToggleGroup) {
-      const { name, enabled } = asCfg.__chaosMakerToggleGroup;
+      const { name: rawName, enabled } = asCfg.__chaosMakerToggleGroup;
+      const name = rawName.trim();
+      if (!name) {
+        replyViaPortOrBroadcast(target, evt, {
+          __chaosMakerAck: true,
+          running: state.running,
+        } satisfies ChaosSWAck);
+        return;
+      }
       state.groups.setEnabled(name, enabled);
       state.emitter.emit({
         type: enabled ? 'rule-group:enabled' : 'rule-group:disabled',

--- a/packages/core/src/sw.ts
+++ b/packages/core/src/sw.ts
@@ -71,6 +71,14 @@ export interface ChaosSWClearLogMessage {
   __chaosMakerClearLog: true;
 }
 
+/** Message sent by page -> SW to toggle a rule group without restarting chaos. */
+export interface ChaosSWToggleGroupMessage {
+  __chaosMakerToggleGroup: {
+    name: string;
+    enabled: boolean;
+  };
+}
+
 /** Ack sent SW → port (or broadcast) after a config / stop message lands. */
 export interface ChaosSWAck {
   __chaosMakerAck: true;
@@ -300,7 +308,7 @@ export function installChaosSW(opts: InstallChaosSWOptions = {}): SWChaosHandle 
     const evt = raw as { data?: unknown; ports?: readonly unknown[] };
     const data = evt.data;
     if (!data || typeof data !== 'object') return;
-    const asCfg = data as Partial<ChaosSWConfigMessage & ChaosSWStopMessage & ChaosSWGetLogMessage & ChaosSWClearLogMessage>;
+    const asCfg = data as Partial<ChaosSWConfigMessage & ChaosSWStopMessage & ChaosSWGetLogMessage & ChaosSWClearLogMessage & ChaosSWToggleGroupMessage>;
 
     if (asCfg.__chaosMakerConfig) {
       const seed = startEngine(state, asCfg.__chaosMakerConfig);
@@ -317,6 +325,22 @@ export function installChaosSW(opts: InstallChaosSWOptions = {}): SWChaosHandle 
       replyViaPortOrBroadcast(target, evt, {
         __chaosMakerAck: true,
         running: false,
+      } satisfies ChaosSWAck);
+      return;
+    }
+
+    if (asCfg.__chaosMakerToggleGroup) {
+      const { name, enabled } = asCfg.__chaosMakerToggleGroup;
+      state.groups.setEnabled(name, enabled);
+      state.emitter.emit({
+        type: enabled ? 'rule-group:enabled' : 'rule-group:disabled',
+        timestamp: Date.now(),
+        applied: true,
+        detail: { groupName: name },
+      });
+      replyViaPortOrBroadcast(target, evt, {
+        __chaosMakerAck: true,
+        running: state.running,
       } satisfies ChaosSWAck);
       return;
     }

--- a/packages/core/src/sw.ts
+++ b/packages/core/src/sw.ts
@@ -21,6 +21,8 @@ import { ChaosEventEmitter } from './events';
 import { createPrng } from './prng';
 import { patchFetch } from './interceptors/networkFetch';
 import { patchWebSocket, WebSocketPatchHandle } from './interceptors/websocket';
+import { DEFAULT_GROUP_NAME, RuleGroupRegistry } from './groups';
+import { forEachRule } from './utils';
 
 /**
  * Service-Worker global scope. Typed manually so this file compiles under the
@@ -151,6 +153,8 @@ interface SWEngineState {
   originalWebSocket?: typeof WebSocket;
   webSocketHandle?: WebSocketPatchHandle;
   requestCounters: Map<object, number>;
+  /** Rule-group registry (RFC-001). Survives `startEngine()` swaps. */
+  groups: RuleGroupRegistry;
 }
 
 function startEngine(state: SWEngineState, config: ChaosConfig): number {
@@ -160,6 +164,18 @@ function startEngine(state: SWEngineState, config: ChaosConfig): number {
   state.seed = prng.seed;
   state.random = prng.random;
   state.requestCounters = new Map();
+
+  // Rebuild the group registry from this config. Phase B will preserve toggles
+  // across reconfigure by carrying overrides forward; Phase A wipes & rebuilds
+  // because there is no toggle entry point yet.
+  state.groups = new RuleGroupRegistry();
+  for (const g of config.groups ?? []) {
+    state.groups.ensure(g.name, { enabled: g.enabled ?? true, explicit: true });
+  }
+  forEachRule(config, (rule) => {
+    if (rule.group) state.groups.ensure(rule.group);
+  });
+  state.groups.ensure(DEFAULT_GROUP_NAME, { enabled: true });
 
   if (config.network) {
     const target = state.target;
@@ -171,6 +187,7 @@ function startEngine(state: SWEngineState, config: ChaosConfig): number {
         state.random,
         state.emitter,
         state.requestCounters,
+        state.groups,
       ) as typeof globalThis.fetch;
     }
   }
@@ -183,6 +200,7 @@ function startEngine(state: SWEngineState, config: ChaosConfig): number {
       state.emitter,
       state.random,
       state.requestCounters,
+      state.groups,
     );
     state.target.WebSocket = state.webSocketHandle.Wrapped;
   }
@@ -271,6 +289,7 @@ export function installChaosSW(opts: InstallChaosSWOptions = {}): SWChaosHandle 
     seed: null,
     random: placeholder.random,
     requestCounters: new Map(),
+    groups: new RuleGroupRegistry(),
   };
 
   emitter.on('*', (event) => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,4 +1,6 @@
-import type { CorruptionStrategy, RequestCountingOptions } from './config';
+import type { ChaosConfig, CorruptionStrategy, RequestCountingOptions } from './config';
+import { DEFAULT_GROUP_NAME, RuleGroupRegistry } from './groups';
+import type { ChaosEvent, ChaosEventEmitter } from './events';
 
 export function shouldApplyChaos(probability: number, random: () => number): boolean {
   return random() < probability;
@@ -43,4 +45,77 @@ export function corruptText(text: string, strategy: CorruptionStrategy): string 
     case 'wrong-type':
       return '<html><body>Unexpected HTML</body></html>';
   }
+}
+
+/**
+ * Group-active gate (RFC-001). Sits between `gateRule` and `shouldApplyChaos`
+ * inside every interceptor.
+ *
+ * - `registry === undefined` (legacy / direct interceptor caller): returns
+ *   `true` so the interceptor proceeds without group checks.
+ * - When the rule's group is enabled: returns `true`.
+ * - When disabled: emits at most one `rule-group:gated` event per group per
+ *   toggle cycle (deduped via `RuleGroupRegistry.shouldEmitGated`) and
+ *   returns `false`. The emitted detail merges `baseDetail` (e.g. url +
+ *   method) with `groupName`.
+ *
+ * Counting (`onNth` / `everyNth` / `afterN`) runs *before* this gate inside
+ * `gateRule`, so toggling a group does not desync per-rule counters.
+ */
+export function gateGroup(
+  rule: { group?: string },
+  registry: RuleGroupRegistry | undefined,
+  emitter: ChaosEventEmitter | undefined,
+  baseDetail: ChaosEvent['detail'],
+): boolean {
+  if (!registry) return true;
+  if (registry.isActive(rule.group)) return true;
+  const groupName = rule.group ?? DEFAULT_GROUP_NAME;
+  if (registry.shouldEmitGated(groupName) && emitter) {
+    emitter.emit({
+      type: 'rule-group:gated',
+      timestamp: Date.now(),
+      applied: false,
+      detail: { ...baseDetail, groupName },
+    });
+  }
+  return false;
+}
+
+/** Minimal rule shape walked by `forEachRule`. Carries the optional `group`
+ *  field every rule type now supports (RFC-001) plus an open index for the
+ *  remaining per-rule fields the walker doesn't care about. */
+export type AnyRule = { group?: string;[k: string]: unknown };
+
+/**
+ * Iterate every rule across every chaos category in the config exactly once.
+ *
+ * IMPORTANT: any new rule array added to `ChaosConfig` (e.g. `websocket.timeouts`,
+ * `sse.reconnects`) MUST be registered here. The matching test in
+ * `forEachRule.test.ts` asserts the visited count against a sample config; that
+ * test will fail loudly if a new array is added without updating this walker.
+ *
+ * Single source of truth for rule iteration. Used by `seedGroupsFromRules`
+ * and `collectReferencedGroups` in `ChaosMaker`, plus any future feature
+ * that needs to walk all rules.
+ */
+export function forEachRule(config: ChaosConfig, fn: (rule: AnyRule) => void): void {
+  const visit = (rules: AnyRule[] | undefined): void => {
+    if (!rules) return;
+    for (const r of rules) fn(r);
+  };
+  visit(config.network?.failures as AnyRule[] | undefined);
+  visit(config.network?.latencies as AnyRule[] | undefined);
+  visit(config.network?.aborts as AnyRule[] | undefined);
+  visit(config.network?.corruptions as AnyRule[] | undefined);
+  visit(config.network?.cors as AnyRule[] | undefined);
+  visit(config.ui?.assaults as AnyRule[] | undefined);
+  visit(config.websocket?.drops as AnyRule[] | undefined);
+  visit(config.websocket?.delays as AnyRule[] | undefined);
+  visit(config.websocket?.corruptions as AnyRule[] | undefined);
+  visit(config.websocket?.closes as AnyRule[] | undefined);
+  visit(config.sse?.drops as AnyRule[] | undefined);
+  visit(config.sse?.delays as AnyRule[] | undefined);
+  visit(config.sse?.corruptions as AnyRule[] | undefined);
+  visit(config.sse?.closes as AnyRule[] | undefined);
 }

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -223,12 +223,28 @@ const groupConfigSchema = z.object({
   enabled: z.boolean().optional(),
 }).strict();
 
+const groupConfigListSchema = z.array(groupConfigSchema).superRefine((groups, ctx) => {
+  const seen = new Set<string>();
+  for (const [index, group] of groups.entries()) {
+    const norm = group.name.trim();
+    if (seen.has(norm)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'duplicate group name after normalization',
+        path: [index, 'name'],
+      });
+      continue;
+    }
+    seen.add(norm);
+  }
+});
+
 const chaosConfigSchema = z.object({
   network: networkConfigSchema.optional(),
   ui: uiConfigSchema.optional(),
   websocket: webSocketConfigSchema.optional(),
   sse: sseConfigSchema.optional(),
-  groups: z.array(groupConfigSchema).optional(),
+  groups: groupConfigListSchema.optional(),
   seed: z.number().int('Seed must be an integer').optional(),
 }).strict();
 

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -13,6 +13,13 @@ const countingFields = {
   afterN: z.number().int().min(0).optional(),
 };
 
+/** Optional `group` field shared by every rule type (RFC-001).
+ *  `.trim()` runs before `.min(1)` so `'payments '` and `'payments'` collapse
+ *  to one group and whitespace-only names are rejected. */
+const groupField = {
+  group: z.string().trim().min(1, 'group must not be empty').optional(),
+};
+
 const mutuallyExclusiveCounting = (data: { onNth?: number; everyNth?: number; afterN?: number }) =>
   [data.onNth, data.everyNth, data.afterN].filter(v => v !== undefined).length <= 1;
 
@@ -49,6 +56,7 @@ const networkFailureSchema = z.object({
   statusText: z.string().optional(),
   headers: z.record(z.string()).optional(),
   ...countingFields,
+  ...groupField,
 }).strict().refine(...countingRefinement);
 
 const networkLatencySchema = z.object({
@@ -56,6 +64,7 @@ const networkLatencySchema = z.object({
   delayMs: z.number().min(0, 'delayMs must be >= 0'),
   probability,
   ...countingFields,
+  ...groupField,
 }).strict().refine(...countingRefinement);
 
 const networkAbortSchema = z.object({
@@ -63,6 +72,7 @@ const networkAbortSchema = z.object({
   probability,
   timeout: z.number().min(0, 'timeout must be >= 0').optional(),
   ...countingFields,
+  ...groupField,
 }).strict().refine(...countingRefinement);
 
 const networkCorruptionSchema = z.object({
@@ -70,12 +80,14 @@ const networkCorruptionSchema = z.object({
   probability,
   strategy: z.enum(['truncate', 'malformed-json', 'empty', 'wrong-type']),
   ...countingFields,
+  ...groupField,
 }).strict().refine(...countingRefinement);
 
 const networkCorsSchema = z.object({
   ...networkMatcherFields,
   probability,
   ...countingFields,
+  ...groupField,
 }).strict().refine(...countingRefinement);
 
 const networkConfigSchema = z.object({
@@ -90,6 +102,7 @@ const uiAssaultSchema = z.object({
   selector: z.string().min(1, 'selector must not be empty'),
   action: z.enum(['disable', 'hide', 'remove']),
   probability,
+  ...groupField,
 }).strict();
 
 const uiConfigSchema = z.object({
@@ -103,6 +116,7 @@ const webSocketDropSchema = z.object({
   direction: webSocketDirection,
   probability,
   ...countingFields,
+  ...groupField,
 }).strict().refine(...countingRefinement);
 
 const webSocketDelaySchema = z.object({
@@ -111,6 +125,7 @@ const webSocketDelaySchema = z.object({
   delayMs: z.number().min(0, 'delayMs must be >= 0'),
   probability,
   ...countingFields,
+  ...groupField,
 }).strict().refine(...countingRefinement);
 
 const webSocketCorruptSchema = z.object({
@@ -119,6 +134,7 @@ const webSocketCorruptSchema = z.object({
   strategy: z.enum(['truncate', 'malformed-json', 'empty', 'wrong-type']),
   probability,
   ...countingFields,
+  ...groupField,
 }).strict().refine(...countingRefinement);
 
 // WebSocket close code spec: only 1000 or the 3000–4999 range are valid as input
@@ -143,6 +159,7 @@ const webSocketCloseSchema = z.object({
   afterMs: z.number().min(0, 'afterMs must be >= 0').optional(),
   probability,
   ...countingFields,
+  ...groupField,
 }).strict().refine(...countingRefinement);
 
 const webSocketConfigSchema = z.object({
@@ -162,6 +179,7 @@ const sseDropSchema = z.object({
   eventType: sseEventType.optional(),
   probability,
   ...countingFields,
+  ...groupField,
 }).strict().refine(...countingRefinement);
 
 const sseDelaySchema = z.object({
@@ -170,6 +188,7 @@ const sseDelaySchema = z.object({
   delayMs: z.number().min(0, 'delayMs must be >= 0'),
   probability,
   ...countingFields,
+  ...groupField,
 }).strict().refine(...countingRefinement);
 
 const sseCorruptSchema = z.object({
@@ -178,6 +197,7 @@ const sseCorruptSchema = z.object({
   strategy: z.enum(['truncate', 'malformed-json', 'empty', 'wrong-type']),
   probability,
   ...countingFields,
+  ...groupField,
 }).strict().refine(...countingRefinement);
 
 const sseCloseSchema = z.object({
@@ -185,6 +205,7 @@ const sseCloseSchema = z.object({
   afterMs: z.number().min(0, 'afterMs must be >= 0').optional(),
   probability,
   ...countingFields,
+  ...groupField,
 }).strict().refine(...countingRefinement);
 
 const sseConfigSchema = z.object({
@@ -194,11 +215,20 @@ const sseConfigSchema = z.object({
   closes: z.array(sseCloseSchema).optional(),
 }).strict();
 
+/** Declarative group config (RFC-001) accepted on `ChaosConfig.groups`.
+ *  Same `.trim().min(1)` discipline as the per-rule `group` field so
+ *  `'payments '` and `'payments'` collapse to one group. */
+const groupConfigSchema = z.object({
+  name: z.string().trim().min(1, 'group name must not be empty'),
+  enabled: z.boolean().optional(),
+}).strict();
+
 const chaosConfigSchema = z.object({
   network: networkConfigSchema.optional(),
   ui: uiConfigSchema.optional(),
   websocket: webSocketConfigSchema.optional(),
   sse: sseConfigSchema.optional(),
+  groups: z.array(groupConfigSchema).optional(),
   seed: z.number().int('Seed must be an integer').optional(),
 }).strict();
 

--- a/packages/core/test/builder-groups.test.ts
+++ b/packages/core/test/builder-groups.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { ChaosConfigBuilder } from '../src/builder';
+
+describe('ChaosConfigBuilder rule groups', () => {
+  it('.inGroup tags exactly the next rule pushed (single-shot)', () => {
+    const cfg = new ChaosConfigBuilder()
+      .inGroup('A')
+      .failRequests('/x', 500, 1)
+      .addLatency('/y', 100, 1)
+      .build();
+
+    const failures = cfg.network!.failures!;
+    const latencies = cfg.network!.latencies!;
+    expect(failures[0].group).toBe('A');
+    expect(latencies[0].group).toBeUndefined();
+  });
+
+  it('.inGroup applies regardless of which builder method consumes it next', () => {
+    const cfg = new ChaosConfigBuilder()
+      .failRequests('/preceding', 500, 1)
+      .inGroup('payments')
+      .assaultUi('.checkout', 'disable', 1)
+      .build();
+
+    expect(cfg.network!.failures![0].group).toBeUndefined();
+    expect(cfg.ui!.assaults![0].group).toBe('payments');
+  });
+
+  it('chained .inGroup calls re-tag the next rule each time', () => {
+    const cfg = new ChaosConfigBuilder()
+      .inGroup('A').failRequests('/a', 500, 1)
+      .inGroup('B').failRequests('/b', 500, 1)
+      .failRequests('/c', 500, 1)
+      .build();
+    const f = cfg.network!.failures!;
+    expect([f[0].group, f[1].group, f[2].group]).toEqual(['A', 'B', undefined]);
+  });
+
+  it('.defineGroup writes a groups entry on the config', () => {
+    const cfg = new ChaosConfigBuilder()
+      .defineGroup('analytics', { enabled: false })
+      .defineGroup('payments')
+      .build();
+    expect(cfg.groups).toEqual([
+      { name: 'analytics', enabled: false },
+      { name: 'payments' },
+    ]);
+  });
+
+  it('build() round-trip preserves group on rules', () => {
+    const cfg = new ChaosConfigBuilder()
+      .inGroup('payments')
+      .delayMessages('ws://x', 'inbound', 100, 1)
+      .build();
+    expect(cfg.websocket!.delays![0].group).toBe('payments');
+  });
+
+  it('.inGroup applies to UI assault rules', () => {
+    const cfg = new ChaosConfigBuilder()
+      .inGroup('checkout')
+      .assaultUi('button.pay', 'disable', 1)
+      .build();
+    expect(cfg.ui!.assaults![0].group).toBe('checkout');
+  });
+
+  it('.inGroup applies to SSE rules', () => {
+    const cfg = new ChaosConfigBuilder()
+      .inGroup('analytics')
+      .dropSSE('/events', 1, 'metric')
+      .build();
+    expect(cfg.sse!.drops![0].group).toBe('analytics');
+  });
+});

--- a/packages/core/test/builder-groups.test.ts
+++ b/packages/core/test/builder-groups.test.ts
@@ -15,6 +15,11 @@ describe('ChaosConfigBuilder rule groups', () => {
     expect(latencies[0].group).toBeUndefined();
   });
 
+  it('.inGroup rejects empty or whitespace-only names', () => {
+    expect(() => new ChaosConfigBuilder().inGroup('')).toThrow('[chaos-maker] Group name cannot be empty');
+    expect(() => new ChaosConfigBuilder().inGroup('   ')).toThrow('[chaos-maker] Group name cannot be empty');
+  });
+
   it('.inGroup applies regardless of which builder method consumes it next', () => {
     const cfg = new ChaosConfigBuilder()
       .failRequests('/preceding', 500, 1)
@@ -38,13 +43,18 @@ describe('ChaosConfigBuilder rule groups', () => {
 
   it('.defineGroup writes a groups entry on the config', () => {
     const cfg = new ChaosConfigBuilder()
-      .defineGroup('analytics', { enabled: false })
+      .defineGroup(' analytics ', { enabled: false })
       .defineGroup('payments')
       .build();
     expect(cfg.groups).toEqual([
       { name: 'analytics', enabled: false },
       { name: 'payments' },
     ]);
+  });
+
+  it('.defineGroup rejects empty or whitespace-only names', () => {
+    expect(() => new ChaosConfigBuilder().defineGroup('')).toThrow('[chaos-maker] Group name cannot be empty');
+    expect(() => new ChaosConfigBuilder().defineGroup('   ')).toThrow('[chaos-maker] Group name cannot be empty');
   });
 
   it('build() round-trip preserves group on rules', () => {

--- a/packages/core/test/forEachRule.test.ts
+++ b/packages/core/test/forEachRule.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { forEachRule } from '../src/utils';
+import type { ChaosConfig } from '../src/config';
+
+describe('forEachRule', () => {
+  it('does not crash on empty/missing arrays', () => {
+    const seen: unknown[] = [];
+    forEachRule({}, (r) => seen.push(r));
+    expect(seen).toEqual([]);
+  });
+
+  it('visits every rule across all 14 arrays exactly once', () => {
+    // Single rule per array — count assertion guards future rule-array
+    // additions to ChaosConfig that forget to register in forEachRule.
+    const cfg: ChaosConfig = {
+      network: {
+        failures: [{ urlPattern: '*', statusCode: 500, probability: 1 }],
+        latencies: [{ urlPattern: '*', delayMs: 1, probability: 1 }],
+        aborts: [{ urlPattern: '*', probability: 1 }],
+        corruptions: [{ urlPattern: '*', strategy: 'truncate', probability: 1 }],
+        cors: [{ urlPattern: '*', probability: 1 }],
+      },
+      ui: {
+        assaults: [{ selector: '.x', action: 'hide', probability: 1 }],
+      },
+      websocket: {
+        drops: [{ urlPattern: '*', direction: 'both', probability: 1 }],
+        delays: [{ urlPattern: '*', direction: 'both', delayMs: 1, probability: 1 }],
+        corruptions: [{ urlPattern: '*', direction: 'both', strategy: 'truncate', probability: 1 }],
+        closes: [{ urlPattern: '*', probability: 1 }],
+      },
+      sse: {
+        drops: [{ urlPattern: '*', probability: 1 }],
+        delays: [{ urlPattern: '*', delayMs: 1, probability: 1 }],
+        corruptions: [{ urlPattern: '*', strategy: 'truncate', probability: 1 }],
+        closes: [{ urlPattern: '*', probability: 1 }],
+      },
+    };
+    const seen: unknown[] = [];
+    forEachRule(cfg, (r) => seen.push(r));
+    // 5 network + 1 ui + 4 websocket + 4 sse = 14. If a future rule array is
+    // added to ChaosConfig but not forEachRule, this count breaks.
+    expect(seen.length).toBe(14);
+  });
+
+  it('visits each rule object exactly once (no duplicates from shared shapes)', () => {
+    const ruleA = { urlPattern: '/a', statusCode: 500, probability: 1 } as const;
+    const ruleB = { urlPattern: '/b', statusCode: 503, probability: 1 } as const;
+    const cfg: ChaosConfig = {
+      network: { failures: [ruleA, ruleB] },
+    };
+    const seen = new Map<unknown, number>();
+    forEachRule(cfg, (r) => seen.set(r, (seen.get(r) ?? 0) + 1));
+    expect(seen.get(ruleA)).toBe(1);
+    expect(seen.get(ruleB)).toBe(1);
+  });
+
+  it('threads the group field through to the callback', () => {
+    const cfg: ChaosConfig = {
+      network: {
+        failures: [{ urlPattern: '*', statusCode: 500, probability: 1, group: 'payments' }],
+      },
+    };
+    const groups: (string | undefined)[] = [];
+    forEachRule(cfg, (r) => groups.push(r.group));
+    expect(groups).toEqual(['payments']);
+  });
+});

--- a/packages/core/test/groups.test.ts
+++ b/packages/core/test/groups.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_GROUP_NAME, RuleGroupRegistry } from '../src/groups';
+
+describe('RuleGroupRegistry', () => {
+  describe('ensure / defaults', () => {
+    it('creates an implicit group default-on the first time it is referenced', () => {
+      const r = new RuleGroupRegistry();
+      const g = r.ensure('payments');
+      expect(g.name).toBe('payments');
+      expect(g.enabled).toBe(true);
+      expect(g.explicit).toBe(false);
+    });
+
+    it('returns the same group object on subsequent ensure() calls', () => {
+      const r = new RuleGroupRegistry();
+      const a = r.ensure('payments');
+      const b = r.ensure('payments');
+      expect(a).toBe(b);
+    });
+
+    it('explicit ensure() overwrites enabled when supplied', () => {
+      const r = new RuleGroupRegistry();
+      r.ensure('payments'); // implicit default-on
+      r.ensure('payments', { enabled: false, explicit: true });
+      expect(r.isActive('payments')).toBe(false);
+    });
+
+    it('non-explicit re-ensure does NOT change enabled even if enabled is supplied', () => {
+      const r = new RuleGroupRegistry();
+      r.ensure('payments', { enabled: false, explicit: true });
+      r.ensure('payments', { enabled: true }); // implicit; should not flip
+      expect(r.isActive('payments')).toBe(false);
+    });
+  });
+
+  describe('isActive auto-create', () => {
+    it('auto-registers an unknown name and returns true (default-on)', () => {
+      const r = new RuleGroupRegistry();
+      expect(r.isActive('unknown')).toBe(true);
+      expect(r.has('unknown')).toBe(true);
+    });
+
+    it('isActive(undefined) maps to the default group and is true', () => {
+      const r = new RuleGroupRegistry();
+      expect(r.isActive(undefined)).toBe(true);
+      expect(r.has(DEFAULT_GROUP_NAME)).toBe(true);
+    });
+
+    it('typo surfaces in list() because isActive() auto-registers', () => {
+      const r = new RuleGroupRegistry();
+      r.isActive('paymets'); // typo
+      const names = r.list().map((g) => g.name).sort();
+      expect(names).toEqual(['paymets']);
+    });
+  });
+
+  describe('setEnabled + gated dedup', () => {
+    it('flips enabled state and clears the gated dedup set', () => {
+      const r = new RuleGroupRegistry();
+      r.setEnabled('payments', false);
+      expect(r.isActive('payments')).toBe(false);
+      expect(r.shouldEmitGated('payments')).toBe(true);
+      expect(r.shouldEmitGated('payments')).toBe(false);
+      // toggle clears dedup
+      r.setEnabled('payments', true);
+      r.setEnabled('payments', false);
+      expect(r.shouldEmitGated('payments')).toBe(true);
+    });
+
+    it('shouldEmitGated returns true exactly once between toggles', () => {
+      const r = new RuleGroupRegistry();
+      r.setEnabled('a', false);
+      const flips = [
+        r.shouldEmitGated('a'),
+        r.shouldEmitGated('a'),
+        r.shouldEmitGated('a'),
+      ];
+      expect(flips).toEqual([true, false, false]);
+    });
+  });
+
+  describe('remove', () => {
+    it("refuses to remove the 'default' group", () => {
+      const r = new RuleGroupRegistry();
+      r.ensure(DEFAULT_GROUP_NAME);
+      expect(r.remove(DEFAULT_GROUP_NAME, new Set())).toBe(false);
+      expect(r.has(DEFAULT_GROUP_NAME)).toBe(true);
+    });
+
+    it('throws when the group is still referenced by a rule', () => {
+      const r = new RuleGroupRegistry();
+      r.ensure('payments', { explicit: true });
+      expect(() => r.remove('payments', new Set(['payments']))).toThrow(/still referenced/);
+    });
+
+    it('removes when not referenced', () => {
+      const r = new RuleGroupRegistry();
+      r.ensure('payments', { explicit: true });
+      expect(r.remove('payments', new Set())).toBe(true);
+      expect(r.has('payments')).toBe(false);
+    });
+
+    it('force-removes even when referenced and re-creates default-on on next isActive', () => {
+      const r = new RuleGroupRegistry();
+      r.ensure('payments', { enabled: false, explicit: true });
+      r.remove('payments', new Set(['payments']), { force: true });
+      expect(r.has('payments')).toBe(false);
+      expect(r.isActive('payments')).toBe(true); // auto-create default-on
+    });
+  });
+
+  describe('getSnapshot / list', () => {
+    it('snapshot reports every known group with its current enabled state', () => {
+      const r = new RuleGroupRegistry();
+      r.ensure('a', { enabled: true, explicit: true });
+      r.ensure('b', { enabled: false, explicit: true });
+      expect(r.getSnapshot()).toEqual({ a: true, b: false });
+    });
+
+    it('list returns RuleGroup objects with explicit flag preserved', () => {
+      const r = new RuleGroupRegistry();
+      r.ensure('a', { explicit: true });
+      r.isActive('b'); // implicit
+      const byName = Object.fromEntries(r.list().map((g) => [g.name, g.explicit]));
+      expect(byName).toEqual({ a: true, b: false });
+    });
+  });
+});

--- a/packages/core/test/groups.test.ts
+++ b/packages/core/test/groups.test.ts
@@ -114,6 +114,15 @@ describe('RuleGroupRegistry', () => {
       expect(r.has('payments')).toBe(false);
       expect(r.isActive('payments')).toBe(true); // auto-create default-on
     });
+
+    it('clears gated dedup state after a successful removal', () => {
+      const r = new RuleGroupRegistry();
+      r.ensure('payments', { enabled: false, explicit: true });
+      expect(r.shouldEmitGated('payments')).toBe(true);
+      expect(r.remove('payments', new Set())).toBe(true);
+      r.ensure('payments', { enabled: false, explicit: true });
+      expect(r.shouldEmitGated('payments')).toBe(true);
+    });
   });
 
   describe('getSnapshot / list', () => {
@@ -130,6 +139,14 @@ describe('RuleGroupRegistry', () => {
       r.isActive('b'); // implicit
       const byName = Object.fromEntries(r.list().map((g) => [g.name, g.explicit]));
       expect(byName).toEqual({ a: true, b: false });
+    });
+
+    it('list returns defensive copies', () => {
+      const r = new RuleGroupRegistry();
+      r.ensure('a', { enabled: true, explicit: true });
+      const [listed] = r.list();
+      listed.enabled = false;
+      expect(r.isActive('a')).toBe(true);
     });
   });
 });

--- a/packages/core/test/groups.test.ts
+++ b/packages/core/test/groups.test.ts
@@ -25,11 +25,18 @@ describe('RuleGroupRegistry', () => {
       expect(r.isActive('payments')).toBe(false);
     });
 
-    it('non-explicit re-ensure does NOT change enabled even if enabled is supplied', () => {
+    it('re-ensure updates enabled when supplied', () => {
       const r = new RuleGroupRegistry();
       r.ensure('payments', { enabled: false, explicit: true });
-      r.ensure('payments', { enabled: true }); // implicit; should not flip
-      expect(r.isActive('payments')).toBe(false);
+      r.ensure('payments', { enabled: true });
+      expect(r.isActive('payments')).toBe(true);
+    });
+
+    it('explicit ensure() upgrades an implicit group to explicit', () => {
+      const r = new RuleGroupRegistry();
+      r.ensure('payments');
+      r.ensure('payments', { explicit: true });
+      expect(r.list().find((g) => g.name === 'payments')!.explicit).toBe(true);
     });
   });
 

--- a/packages/core/test/networkFetch.test.ts
+++ b/packages/core/test/networkFetch.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { patchFetch } from '../src/interceptors/networkFetch';
 import { NetworkConfig } from '../src/config';
 import { ChaosEventEmitter } from '../src/events';
+import { RuleGroupRegistry } from '../src/groups';
 // Import the mock from setup.ts
 import { mockFetch } from './setup';
 
@@ -371,6 +372,85 @@ describe('patchFetch', () => {
       expect(diag).toBeDefined();
       expect(diag?.applied).toBe(false);
       expect(diag?.type).toBe('network:failure');
+    });
+
+    it('suppresses graphql-body-unparseable diagnostics while the matching group is disabled', async () => {
+      const emitter = new ChaosEventEmitter();
+      const groups = new RuleGroupRegistry();
+      groups.ensure('payments', { enabled: false, explicit: true });
+      const config: NetworkConfig = {
+        failures: [{
+          urlPattern: '/graphql',
+          statusCode: 500,
+          probability: 1,
+          graphqlOperation: 'GetUser',
+          group: 'payments',
+        }],
+      };
+      const patchedFetch = patchFetch(originalFetch, config, deterministicRandom, emitter, new Map(), groups);
+
+      const form = new FormData();
+      form.append('operations', JSON.stringify({ operationName: 'GetUser', query: 'query GetUser { user { id } }' }));
+
+      await patchedFetch('/graphql', { method: 'POST', body: form });
+
+      expect(originalFetch).toHaveBeenCalledTimes(1);
+      expect(emitter.getLog().some(e => e.detail.reason === 'graphql-body-unparseable')).toBe(false);
+      expect(emitter.getLog()).toEqual([
+        expect.objectContaining({
+          type: 'rule-group:gated',
+          applied: false,
+          detail: expect.objectContaining({ groupName: 'payments' }),
+        }),
+      ]);
+    });
+
+    it('emits graphql-body-unparseable diagnostics only after group and probability pass', async () => {
+      const emitter = new ChaosEventEmitter();
+      const groups = new RuleGroupRegistry();
+      groups.ensure('payments', { enabled: true, explicit: true });
+      const config: NetworkConfig = {
+        failures: [{
+          urlPattern: '/graphql',
+          statusCode: 500,
+          probability: 1,
+          graphqlOperation: 'GetUser',
+          group: 'payments',
+        }],
+      };
+      const patchedFetch = patchFetch(originalFetch, config, deterministicRandom, emitter, new Map(), groups);
+
+      const form = new FormData();
+      form.append('operations', JSON.stringify({ operationName: 'GetUser', query: 'query GetUser { user { id } }' }));
+
+      await patchedFetch('/graphql', { method: 'POST', body: form });
+
+      expect(originalFetch).toHaveBeenCalledTimes(1);
+      const diag = emitter.getLog().find(e => e.detail.reason === 'graphql-body-unparseable');
+      expect(diag).toBeDefined();
+      expect(diag?.type).toBe('network:failure');
+      expect(diag?.applied).toBe(false);
+    });
+
+    it('suppresses graphql-body-unparseable diagnostics when probability misses', async () => {
+      const emitter = new ChaosEventEmitter();
+      const config: NetworkConfig = {
+        failures: [{
+          urlPattern: '/graphql',
+          statusCode: 500,
+          probability: 0,
+          graphqlOperation: 'GetUser',
+        }],
+      };
+      const patchedFetch = patchFetch(originalFetch, config, deterministicRandom, emitter);
+
+      const form = new FormData();
+      form.append('operations', JSON.stringify({ operationName: 'GetUser', query: 'query GetUser { user { id } }' }));
+
+      await patchedFetch('/graphql', { method: 'POST', body: form });
+
+      expect(originalFetch).toHaveBeenCalledTimes(1);
+      expect(emitter.getLog().some(e => e.detail.reason === 'graphql-body-unparseable')).toBe(false);
     });
 
     it('skips body extraction entirely when no rule has graphqlOperation (fast path)', async () => {

--- a/packages/core/test/networkXHR.test.ts
+++ b/packages/core/test/networkXHR.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { patchXHR, patchXHROpen } from '../src/interceptors/networkXHR';
 import { NetworkConfig } from '../src/config';
 import { ChaosEventEmitter } from '../src/events';
+import { RuleGroupRegistry } from '../src/groups';
 // Import the mocks from setup.ts
 import { mockXhrAbort, mockXhrOpen, mockXhrSend } from './setup';
 
@@ -125,6 +126,41 @@ describe('patchXHR (send)', () => {
     expect(mockXhrSend).toHaveBeenCalled();
 
     vi.useRealTimers(); // Restore real timers
+  });
+
+  it('should not add latency when the matching rule group is disabled', () => {
+    vi.useFakeTimers();
+
+    const latencyConfig: NetworkConfig = {
+      latencies: [{ urlPattern: '/api/slow', delayMs: 100, probability: 1.0, group: 'payments' }]
+    };
+    const groups = new RuleGroupRegistry();
+    groups.ensure('payments', { enabled: false, explicit: true });
+    const emitter = new ChaosEventEmitter();
+    const patchedSend = patchXHR(originalXhrSend, latencyConfig, deterministicRandom, emitter, new Map(), groups);
+    global.XMLHttpRequest.prototype.send = patchedSend;
+
+    const xhr = new global.XMLHttpRequest();
+    (xhr as any)._chaos_url = '/api/slow';
+    (xhr as any)._chaos_method = 'GET';
+
+    xhr.send();
+
+    expect(mockXhrSend).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(100);
+    expect(mockXhrSend).toHaveBeenCalledTimes(1);
+    expect(emitter.getLog()).toEqual([
+      expect.objectContaining({
+        type: 'rule-group:gated',
+        applied: false,
+        detail: expect.objectContaining({
+          url: '/api/slow',
+          method: 'GET',
+          groupName: 'payments',
+        }),
+      }),
+    ]);
+    vi.useRealTimers();
   });
 
   it('should force a CORS error for a matching URL', () => {

--- a/packages/core/test/networkXHR.test.ts
+++ b/packages/core/test/networkXHR.test.ts
@@ -24,6 +24,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   // Ensure originals are restored after each test
   global.XMLHttpRequest.prototype.open = originalXhrOpen;
   global.XMLHttpRequest.prototype.send = originalXhrSend;
@@ -125,7 +126,6 @@ describe('patchXHR (send)', () => {
     // Now it should have been called
     expect(mockXhrSend).toHaveBeenCalled();
 
-    vi.useRealTimers(); // Restore real timers
   });
 
   it('should not add latency when the matching rule group is disabled', () => {
@@ -160,7 +160,6 @@ describe('patchXHR (send)', () => {
         }),
       }),
     ]);
-    vi.useRealTimers();
   });
 
   it('should force a CORS error for a matching URL', () => {
@@ -226,7 +225,6 @@ describe('patchXHR (send)', () => {
     expect(mockXhrAbort).toHaveBeenCalledTimes(1);
     expect(xhr.status).toBe(0);
     expect(abortSpy).toHaveBeenCalledWith(new Event('abort'));
-    vi.useRealTimers();
   });
 
   it('should corrupt response text according to truncate strategy', () => {
@@ -368,6 +366,5 @@ describe('patchXHR (send)', () => {
         }),
       }),
     ]);
-    vi.useRealTimers();
   });
 });

--- a/packages/core/test/runtime-groups.test.ts
+++ b/packages/core/test/runtime-groups.test.ts
@@ -179,6 +179,21 @@ describe('ChaosMaker public group API', () => {
     expect(cm.getGroupState('payments')).toBe(true);
   });
 
+  it('public group APIs trim names and reject empty names', () => {
+    const cm = new ChaosMaker({});
+    cm.createGroup(' payments ', { enabled: false });
+    expect(cm.getGroupState('payments')).toBe(false);
+    cm.enableGroup(' payments ');
+    expect(cm.getGroupState('payments')).toBe(true);
+    cm.disableGroup(' payments ');
+    expect(cm.getGroupState('payments')).toBe(false);
+    expect(cm.removeGroup(' payments ')).toBe(true);
+    expect(() => cm.createGroup('   ')).toThrow('[chaos-maker] Group name cannot be empty');
+    expect(() => cm.enableGroup('')).toThrow('[chaos-maker] Group name cannot be empty');
+    expect(() => cm.disableGroup('')).toThrow('[chaos-maker] Group name cannot be empty');
+    expect(() => cm.removeGroup('')).toThrow('[chaos-maker] Group name cannot be empty');
+  });
+
   it('config.groups pre-registers groups as initially disabled', () => {
     const cm = new ChaosMaker({
       groups: [{ name: 'payments', enabled: false }],

--- a/packages/core/test/runtime-groups.test.ts
+++ b/packages/core/test/runtime-groups.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { patchFetch } from '../src/interceptors/networkFetch';
+import { NetworkConfig } from '../src/config';
+import { ChaosEventEmitter, ChaosEvent } from '../src/events';
+import { RuleGroupRegistry } from '../src/groups';
+import { ChaosMaker } from '../src/ChaosMaker';
+import { mockFetch } from './setup';
+
+const deterministicRandom = () => 0;
+
+beforeEach(() => {
+  mockFetch.mockClear();
+  mockFetch.mockResolvedValue(new global.Response('{}', { status: 200 }));
+});
+
+describe('runtime group gating — network fetch', () => {
+  it('skips a rule when its group is disabled (no chaos applied)', async () => {
+    const groups = new RuleGroupRegistry();
+    groups.ensure('payments', { enabled: false, explicit: true });
+
+    const config: NetworkConfig = {
+      failures: [{ urlPattern: '/api/pay', statusCode: 503, probability: 1, group: 'payments' }],
+    };
+    const emitter = new ChaosEventEmitter();
+    const patched = patchFetch(mockFetch, config, deterministicRandom, emitter, new Map(), groups);
+
+    const res = await patched('/api/pay');
+    expect((res as { status?: number }).status).toBe(200);
+    const fired = emitter.getLog().filter((e) => e.type === 'network:failure' && e.applied);
+    expect(fired.length).toBe(0);
+  });
+
+  it('emits exactly ONE rule-group:gated event regardless of blocked-request count', async () => {
+    const groups = new RuleGroupRegistry();
+    groups.ensure('payments', { enabled: false, explicit: true });
+
+    const config: NetworkConfig = {
+      failures: [{ urlPattern: '/api/pay', statusCode: 503, probability: 1, group: 'payments' }],
+    };
+    const emitter = new ChaosEventEmitter();
+    const patched = patchFetch(mockFetch, config, deterministicRandom, emitter, new Map(), groups);
+
+    for (let i = 0; i < 50; i++) {
+      await patched('/api/pay');
+    }
+    const gated = emitter.getLog().filter((e) => e.type === 'rule-group:gated');
+    expect(gated.length).toBe(1);
+    expect(gated[0].detail.groupName).toBe('payments');
+    expect(gated[0].applied).toBe(false);
+  });
+
+  it('re-enabling and re-disabling emits a fresh gated event next cycle', async () => {
+    const groups = new RuleGroupRegistry();
+    groups.ensure('payments', { enabled: false, explicit: true });
+
+    const config: NetworkConfig = {
+      failures: [{ urlPattern: '/api/pay', statusCode: 503, probability: 1, group: 'payments' }],
+    };
+    const emitter = new ChaosEventEmitter();
+    const patched = patchFetch(mockFetch, config, deterministicRandom, emitter, new Map(), groups);
+
+    await patched('/api/pay'); // emits gated #1
+    groups.setEnabled('payments', true);
+    await patched('/api/pay'); // chaos fires; status 503
+    groups.setEnabled('payments', false);
+    await patched('/api/pay'); // emits gated #2 (fresh cycle)
+    await patched('/api/pay'); // already-emitted, dedup blocks
+
+    const gated = emitter.getLog().filter((e) => e.type === 'rule-group:gated');
+    expect(gated.length).toBe(2);
+  });
+
+  it('toggle storm (disable → enable → disable → enable) emits exactly one gated per disabled cycle', async () => {
+    const groups = new RuleGroupRegistry();
+    groups.ensure('payments', { enabled: false, explicit: true });
+
+    const config: NetworkConfig = {
+      failures: [{ urlPattern: '/api/pay', statusCode: 503, probability: 1, group: 'payments' }],
+    };
+    const emitter = new ChaosEventEmitter();
+    const patched = patchFetch(mockFetch, config, deterministicRandom, emitter, new Map(), groups);
+
+    await patched('/api/pay'); // gated #1
+    await patched('/api/pay'); // dedup
+    groups.setEnabled('payments', true);
+    await patched('/api/pay'); // applied
+    groups.setEnabled('payments', false);
+    await patched('/api/pay'); // gated #2
+    await patched('/api/pay'); // dedup
+    groups.setEnabled('payments', true);
+    await patched('/api/pay'); // applied
+    groups.setEnabled('payments', false);
+    await patched('/api/pay'); // gated #3
+
+    const gated = emitter.getLog().filter((e) => e.type === 'rule-group:gated');
+    expect(gated.length).toBe(3);
+  });
+
+  it('ungrouped rules continue firing when another group is disabled', async () => {
+    const groups = new RuleGroupRegistry();
+    groups.ensure('payments', { enabled: false, explicit: true });
+
+    const config: NetworkConfig = {
+      failures: [
+        { urlPattern: '/api/pay', statusCode: 503, probability: 1, group: 'payments' },
+        { urlPattern: '/api/data', statusCode: 500, probability: 1 }, // ungrouped (default)
+      ],
+    };
+    const emitter = new ChaosEventEmitter();
+    const patched = patchFetch(mockFetch, config, deterministicRandom, emitter, new Map(), groups);
+
+    const ungrouped = await patched('/api/data') as { status?: number };
+    const gatedRes = await patched('/api/pay') as { status?: number };
+    expect(ungrouped.status).toBe(500);
+    expect(gatedRes.status).toBe(200);
+  });
+
+  it('counters survive a disable→enable→disable cycle (onNth still hits at the right index)', async () => {
+    const groups = new RuleGroupRegistry();
+    const config: NetworkConfig = {
+      failures: [{ urlPattern: '/api/pay', statusCode: 503, probability: 1, onNth: 3, group: 'payments' }],
+    };
+    const emitter = new ChaosEventEmitter();
+    const counters = new Map<object, number>();
+    const patched = patchFetch(mockFetch, config, deterministicRandom, emitter, counters, groups);
+
+    // Counter increments even while gated — that's intentional so the rule
+    // hits its 3rd MATCHING request irrespective of toggle state.
+    groups.setEnabled('payments', false);
+    await patched('/api/pay'); // count=1, gated
+    await patched('/api/pay'); // count=2, gated
+    groups.setEnabled('payments', true);
+    const r3 = await patched('/api/pay') as { status?: number }; // count=3, fires
+    expect(r3.status).toBe(503);
+  });
+});
+
+describe('ChaosMaker public group API', () => {
+  it('exposes enableGroup / disableGroup that emit lifecycle events', () => {
+    const cm = new ChaosMaker({});
+    const events: ChaosEvent[] = [];
+    cm.on('*', (e) => events.push(e));
+    cm.disableGroup('payments');
+    cm.enableGroup('payments');
+    const types = events.map((e) => e.type);
+    expect(types).toContain('rule-group:disabled');
+    expect(types).toContain('rule-group:enabled');
+  });
+
+  it('seedGroupsFromRules populates listGroups before any request fires', () => {
+    const cm = new ChaosMaker({
+      network: {
+        failures: [{ urlPattern: '/x', statusCode: 500, probability: 1, group: 'payments' }],
+      },
+      websocket: {
+        drops: [{ urlPattern: 'ws://x', direction: 'both', probability: 1, group: 'analytics' }],
+      },
+    });
+    const names = cm.listGroups().map((g) => g.name).sort();
+    // expect both rule-referenced groups + the default group
+    expect(names).toEqual(['analytics', 'default', 'payments']);
+  });
+
+  it('removeGroup respects {force} and rejects default', () => {
+    const cm = new ChaosMaker({
+      network: { failures: [{ urlPattern: '/x', statusCode: 500, probability: 1, group: 'payments' }] },
+    });
+    expect(cm.removeGroup('default')).toBe(false);
+    expect(() => cm.removeGroup('payments')).toThrow(/still referenced/);
+    expect(cm.removeGroup('payments', { force: true })).toBe(true);
+    expect(cm.hasGroup('payments')).toBe(false);
+  });
+
+  it('createGroup with enabled:false ships a group disabled at construction time', () => {
+    const cm = new ChaosMaker({});
+    cm.createGroup('payments', { enabled: false });
+    expect(cm.getGroupState('payments')).toBe(false);
+    cm.enableGroup('payments');
+    expect(cm.getGroupState('payments')).toBe(true);
+  });
+
+  it('config.groups pre-registers groups as initially disabled', () => {
+    const cm = new ChaosMaker({
+      groups: [{ name: 'payments', enabled: false }],
+      network: { failures: [{ urlPattern: '/x', statusCode: 500, probability: 1, group: 'payments' }] },
+    });
+    expect(cm.getGroupState('payments')).toBe(false);
+  });
+
+  it('backward compat: a v0.4.x config without groups behaves identically (no group on rules)', () => {
+    const cm = new ChaosMaker({
+      network: { failures: [{ urlPattern: '/x', statusCode: 500, probability: 1 }] },
+    });
+    // Only the default group exists; the failure rule retains group: undefined.
+    const snapshot = cm.getGroupsSnapshot();
+    expect(Object.keys(snapshot)).toEqual(['default']);
+  });
+});

--- a/packages/core/test/runtime-groups.test.ts
+++ b/packages/core/test/runtime-groups.test.ts
@@ -182,9 +182,10 @@ describe('ChaosMaker public group API', () => {
   it('public group APIs trim names and reject empty names', () => {
     const cm = new ChaosMaker({});
     cm.createGroup(' payments ', { enabled: false });
+    expect(cm.hasGroup(' payments ')).toBe(true);
     expect(cm.getGroupState('payments')).toBe(false);
     cm.enableGroup(' payments ');
-    expect(cm.getGroupState('payments')).toBe(true);
+    expect(cm.getGroupState(' payments ')).toBe(true);
     cm.disableGroup(' payments ');
     expect(cm.getGroupState('payments')).toBe(false);
     expect(cm.removeGroup(' payments ')).toBe(true);
@@ -192,6 +193,8 @@ describe('ChaosMaker public group API', () => {
     expect(() => cm.enableGroup('')).toThrow('[chaos-maker] Group name cannot be empty');
     expect(() => cm.disableGroup('')).toThrow('[chaos-maker] Group name cannot be empty');
     expect(() => cm.removeGroup('')).toThrow('[chaos-maker] Group name cannot be empty');
+    expect(() => cm.hasGroup('   ')).toThrow('[chaos-maker] Group name cannot be empty');
+    expect(() => cm.getGroupState('')).toThrow('[chaos-maker] Group name cannot be empty');
   });
 
   it('config.groups pre-registers groups as initially disabled', () => {

--- a/packages/core/test/sw-groups.test.ts
+++ b/packages/core/test/sw-groups.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { ChaosConfig, ChaosEvent } from '../src';
+
+/**
+ * Phase A SW group tests.
+ *
+ * Phase A only adds the registry data layer: SW configs may carry `group: …`
+ * on rules, the SW state owns a `RuleGroupRegistry`, and a disabled group on
+ * an incoming config blocks chaos. Phase B will introduce a dedicated
+ * `__chaosMakerToggleGroup` message and an ack pattern; the toggle-message
+ * tests live in `sw-groups.test.ts` then.
+ */
+
+type MessageListener = (event: { data: unknown; ports?: unknown[] }) => void;
+
+interface FakeClient {
+  id: string;
+  messages: unknown[];
+  postMessage(m: unknown): void;
+}
+
+function makeFakeClient(id: string): FakeClient {
+  return {
+    id,
+    messages: [],
+    postMessage(m) { this.messages.push(m); },
+  };
+}
+
+interface SWLikeTarget {
+  fetch: typeof globalThis.fetch;
+  WebSocket?: typeof WebSocket;
+  clients: { matchAll: () => Promise<readonly FakeClient[]> };
+  __messageListeners: Set<MessageListener>;
+  addEventListener: (type: string, fn: MessageListener) => void;
+  removeEventListener: (type: string, fn: MessageListener) => void;
+  dispatchMessage: (data: unknown, ports?: unknown[]) => void;
+}
+
+function makeSWTarget(clients: FakeClient[]): SWLikeTarget {
+  const listeners = new Set<MessageListener>();
+  return {
+    fetch: vi.fn().mockResolvedValue(new Response('real', { status: 200 })),
+    clients: {
+      matchAll: vi.fn().mockResolvedValue(clients),
+    },
+    __messageListeners: listeners,
+    addEventListener(type, fn) {
+      if (type === 'message') listeners.add(fn);
+    },
+    removeEventListener(type, fn) {
+      if (type === 'message') listeners.delete(fn);
+    },
+    dispatchMessage(data, ports) {
+      for (const fn of listeners) fn({ data, ports });
+    },
+  };
+}
+
+async function importSwWithTarget(target: SWLikeTarget): Promise<typeof import('../src/sw')> {
+  const INSTALL_MARK = Symbol.for('chaos-maker.sw.installed');
+  delete (target as unknown as Record<symbol, unknown>)[INSTALL_MARK];
+  vi.stubGlobal('self', target);
+  return import('../src/sw');
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('SW chaos — rule groups (Phase A)', () => {
+  let origSelf: unknown;
+  beforeEach(() => {
+    vi.resetModules();
+    origSelf = (globalThis as Record<string, unknown>).self;
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    (globalThis as Record<string, unknown>).self = origSelf;
+  });
+
+  it('a config with `groups: [{name, enabled:false}]` blocks the matching rule and emits a single rule-group:gated event', async () => {
+    const client = makeFakeClient('a');
+    const target = makeSWTarget([client]);
+    const { installChaosSW } = await importSwWithTarget(target);
+    const handle = installChaosSW();
+
+    const cfg: ChaosConfig = {
+      groups: [{ name: 'payments', enabled: false }],
+      network: {
+        failures: [
+          { urlPattern: '/api/pay', statusCode: 503, probability: 1, group: 'payments' },
+        ],
+      },
+      seed: 42,
+    };
+    target.dispatchMessage({ __chaosMakerConfig: cfg });
+    await flushMicrotasks();
+
+    const r1 = await target.fetch('/api/pay');
+    const r2 = await target.fetch('/api/pay');
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+
+    const log = handle.getLog();
+    const gated = log.filter((e) => e.type === 'rule-group:gated');
+    expect(gated.length).toBe(1);
+    expect(gated[0].detail.groupName).toBe('payments');
+    expect(gated[0].applied).toBe(false);
+
+    handle.uninstall();
+  });
+
+  it('rules with no group continue firing while another group is disabled', async () => {
+    const target = makeSWTarget([]);
+    const { installChaosSW } = await importSwWithTarget(target);
+    const handle = installChaosSW();
+
+    const cfg: ChaosConfig = {
+      groups: [{ name: 'analytics', enabled: false }],
+      network: {
+        failures: [
+          { urlPattern: '/api/data', statusCode: 500, probability: 1 }, // ungrouped
+          { urlPattern: '/api/track', statusCode: 503, probability: 1, group: 'analytics' },
+        ],
+      },
+      seed: 1,
+    };
+    target.dispatchMessage({ __chaosMakerConfig: cfg });
+    await flushMicrotasks();
+
+    const ungrouped = await target.fetch('/api/data');
+    const gatedRes = await target.fetch('/api/track');
+    expect(ungrouped.status).toBe(500);
+    expect(gatedRes.status).toBe(200);
+
+    handle.uninstall();
+  });
+
+  it('startEngine seeds groups from rule references — referenced groups become observable post-config', async () => {
+    const client = makeFakeClient('a');
+    const target = makeSWTarget([client]);
+    const { installChaosSW } = await importSwWithTarget(target);
+    const handle = installChaosSW();
+
+    const cfg: ChaosConfig = {
+      network: {
+        failures: [
+          { urlPattern: '/api/pay', statusCode: 500, probability: 1, group: 'payments' },
+        ],
+      },
+      seed: 9,
+    };
+    target.dispatchMessage({ __chaosMakerConfig: cfg });
+    await flushMicrotasks();
+
+    // The first request to /api/pay still applies chaos because `payments`
+    // was auto-registered as default-on.
+    const r = await target.fetch('/api/pay');
+    expect(r.status).toBe(500);
+
+    handle.uninstall();
+  });
+
+  it('broadcasts rule-group:gated events to controlled clients', async () => {
+    const client = makeFakeClient('a');
+    const target = makeSWTarget([client]);
+    const { installChaosSW } = await importSwWithTarget(target);
+    const handle = installChaosSW();
+
+    const cfg: ChaosConfig = {
+      groups: [{ name: 'payments', enabled: false }],
+      network: {
+        failures: [{ urlPattern: '/api/pay', statusCode: 500, probability: 1, group: 'payments' }],
+      },
+      seed: 11,
+    };
+    target.dispatchMessage({ __chaosMakerConfig: cfg });
+    await flushMicrotasks();
+    await target.fetch('/api/pay');
+    await flushMicrotasks();
+
+    const events = client.messages.filter(
+      (m): m is { __chaosMakerSWEvent: true; event: ChaosEvent } =>
+        typeof m === 'object' && m !== null && '__chaosMakerSWEvent' in m,
+    );
+    const gatedEvents = events.filter((m) => m.event.type === 'rule-group:gated');
+    expect(gatedEvents.length).toBe(1);
+
+    handle.uninstall();
+  });
+});

--- a/packages/core/test/sw-groups.test.ts
+++ b/packages/core/test/sw-groups.test.ts
@@ -209,6 +209,42 @@ describe('SW chaos - rule groups', () => {
     handle.uninstall();
   });
 
+  it('__chaosMakerToggleGroup trims names and rejects empty normalized names', async () => {
+    const target = makeSWTarget([]);
+    const { installChaosSW } = await importSwWithTarget(target);
+    const handle = installChaosSW();
+
+    const cfg: ChaosConfig = {
+      network: {
+        failures: [
+          { urlPattern: '/api/pay', statusCode: 500, probability: 1, group: 'payments' },
+        ],
+      },
+      seed: 13,
+    };
+    target.dispatchMessage({ __chaosMakerConfig: cfg });
+    await flushMicrotasks();
+
+    const emptyPort = makePort();
+    target.dispatchMessage({ __chaosMakerToggleGroup: { name: '   ', enabled: false } }, [emptyPort]);
+    expect(emptyPort.messages).toEqual([
+      { __chaosMakerAck: true, running: true },
+    ]);
+    expect(handle.getLog().some((e) => e.type === 'rule-group:disabled')).toBe(false);
+
+    const disablePort = makePort();
+    target.dispatchMessage({ __chaosMakerToggleGroup: { name: ' payments ', enabled: false } }, [disablePort]);
+    expect(disablePort.messages).toEqual([
+      { __chaosMakerAck: true, running: true },
+    ]);
+
+    const gated = await target.fetch('/api/pay');
+    expect(gated.status).toBe(200);
+    expect(handle.getLog().some((e) => e.type === 'rule-group:gated' && e.detail.groupName === 'payments')).toBe(true);
+
+    handle.uninstall();
+  });
+
   it('broadcasts rule-group:gated events to controlled clients', async () => {
     const client = makeFakeClient('a');
     const target = makeSWTarget([client]);

--- a/packages/core/test/sw-groups.test.ts
+++ b/packages/core/test/sw-groups.test.ts
@@ -2,13 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { ChaosConfig, ChaosEvent } from '../src';
 
 /**
- * Phase A SW group tests.
+ * SW group tests.
  *
- * Phase A only adds the registry data layer: SW configs may carry `group: …`
- * on rules, the SW state owns a `RuleGroupRegistry`, and a disabled group on
- * an incoming config blocks chaos. Phase B will introduce a dedicated
- * `__chaosMakerToggleGroup` message and an ack pattern; the toggle-message
- * tests live in `sw-groups.test.ts` then.
+ * SW configs may carry `group: ...` on rules, the SW state owns a
+ * `RuleGroupRegistry`, disabled groups block chaos, and
+ * `__chaosMakerToggleGroup` toggles runtime state without restarting.
  */
 
 type MessageListener = (event: { data: unknown; ports?: unknown[] }) => void;
@@ -35,6 +33,13 @@ interface SWLikeTarget {
   addEventListener: (type: string, fn: MessageListener) => void;
   removeEventListener: (type: string, fn: MessageListener) => void;
   dispatchMessage: (data: unknown, ports?: unknown[]) => void;
+}
+
+function makePort(): { messages: unknown[]; postMessage(m: unknown): void } {
+  return {
+    messages: [],
+    postMessage(m) { this.messages.push(m); },
+  };
 }
 
 function makeSWTarget(clients: FakeClient[]): SWLikeTarget {
@@ -70,7 +75,7 @@ async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
 }
 
-describe('SW chaos — rule groups (Phase A)', () => {
+describe('SW chaos - rule groups', () => {
   let origSelf: unknown;
   beforeEach(() => {
     vi.resetModules();
@@ -160,6 +165,46 @@ describe('SW chaos — rule groups (Phase A)', () => {
     // was auto-registered as default-on.
     const r = await target.fetch('/api/pay');
     expect(r.status).toBe(500);
+
+    handle.uninstall();
+  });
+
+  it('__chaosMakerToggleGroup toggles groups without resetting counters', async () => {
+    const target = makeSWTarget([]);
+    const { installChaosSW } = await importSwWithTarget(target);
+    const handle = installChaosSW();
+
+    const cfg: ChaosConfig = {
+      network: {
+        failures: [
+          { urlPattern: '/api/pay', statusCode: 500, probability: 1, afterN: 1, group: 'payments' },
+        ],
+      },
+      seed: 12,
+    };
+    target.dispatchMessage({ __chaosMakerConfig: cfg });
+    await flushMicrotasks();
+
+    const disablePort = makePort();
+    target.dispatchMessage({ __chaosMakerToggleGroup: { name: 'payments', enabled: false } }, [disablePort]);
+    expect(disablePort.messages).toEqual([
+      { __chaosMakerAck: true, running: true },
+    ]);
+
+    const warmup = await target.fetch('/api/pay');
+    const gated = await target.fetch('/api/pay');
+    expect(warmup.status).toBe(200);
+    expect(gated.status).toBe(200);
+    expect(handle.getLog().some((e) => e.type === 'rule-group:gated' && e.detail.groupName === 'payments')).toBe(true);
+
+    const enablePort = makePort();
+    target.dispatchMessage({ __chaosMakerToggleGroup: { name: 'payments', enabled: true } }, [enablePort]);
+    expect(enablePort.messages).toEqual([
+      { __chaosMakerAck: true, running: true },
+    ]);
+
+    const applied = await target.fetch('/api/pay');
+    expect(applied.status).toBe(500);
 
     handle.uninstall();
   });

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -605,5 +605,15 @@ describe('validateConfig', () => {
       const parsed = validateConfig({ groups: [{ name: 'payments ' }] });
       expect(parsed.groups![0].name).toBe('payments');
     });
+
+    it('rejects duplicate group names after normalization', () => {
+      const config = {
+        groups: [
+          { name: 'payments' },
+          { name: ' payments ' },
+        ],
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
   });
 });

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -534,4 +534,76 @@ describe('validateConfig', () => {
       expect(() => validateConfig(config)).toThrow(ChaosConfigError);
     });
   });
+
+  describe('rule groups (RFC-001)', () => {
+    it('accepts group: "x" on every rule type', () => {
+      const config = {
+        network: {
+          failures: [{ urlPattern: '/x', statusCode: 500, probability: 1, group: 'a' }],
+          latencies: [{ urlPattern: '/x', delayMs: 1, probability: 1, group: 'a' }],
+          aborts: [{ urlPattern: '/x', probability: 1, group: 'a' }],
+          corruptions: [{ urlPattern: '/x', strategy: 'truncate' as const, probability: 1, group: 'a' }],
+          cors: [{ urlPattern: '/x', probability: 1, group: 'a' }],
+        },
+        ui: {
+          assaults: [{ selector: '.x', action: 'hide' as const, probability: 1, group: 'a' }],
+        },
+        websocket: {
+          drops: [{ urlPattern: 'ws://x', direction: 'both' as const, probability: 1, group: 'a' }],
+          delays: [{ urlPattern: 'ws://x', direction: 'both' as const, delayMs: 1, probability: 1, group: 'a' }],
+          corruptions: [{ urlPattern: 'ws://x', direction: 'both' as const, strategy: 'truncate' as const, probability: 1, group: 'a' }],
+          closes: [{ urlPattern: 'ws://x', probability: 1, group: 'a' }],
+        },
+        sse: {
+          drops: [{ urlPattern: '/sse', probability: 1, group: 'a' }],
+          delays: [{ urlPattern: '/sse', delayMs: 1, probability: 1, group: 'a' }],
+          corruptions: [{ urlPattern: '/sse', strategy: 'truncate' as const, probability: 1, group: 'a' }],
+          closes: [{ urlPattern: '/sse', probability: 1, group: 'a' }],
+        },
+      };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('rejects an empty group field on a rule', () => {
+      const config = {
+        network: { failures: [{ urlPattern: '/x', statusCode: 500, probability: 1, group: '' }] },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it('rejects a whitespace-only group field on a rule', () => {
+      const config = {
+        network: { failures: [{ urlPattern: '/x', statusCode: 500, probability: 1, group: '   ' }] },
+      };
+      expect(() => validateConfig(config)).toThrow(ChaosConfigError);
+    });
+
+    it("trims surrounding whitespace on rule's group ('payments ' → 'payments')", () => {
+      const config = {
+        network: { failures: [{ urlPattern: '/x', statusCode: 500, probability: 1, group: 'payments ' }] },
+      };
+      const parsed = validateConfig(config);
+      expect(parsed.network!.failures![0].group).toBe('payments');
+    });
+
+    it('accepts groups: [{ name, enabled }] on the top-level config', () => {
+      const config = {
+        groups: [
+          { name: 'payments', enabled: false },
+          { name: 'analytics' },
+        ],
+      };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('rejects empty / whitespace-only group name in groups array', () => {
+      expect(() => validateConfig({ groups: [{ name: '' }] })).toThrow(ChaosConfigError);
+      expect(() => validateConfig({ groups: [{ name: '   ' }] })).toThrow(ChaosConfigError);
+    });
+
+    it('trims surrounding whitespace on groups[].name', () => {
+      const parsed = validateConfig({ groups: [{ name: 'payments ' }] });
+      expect(parsed.groups![0].name).toBe('payments');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implements RFC-001 — Rule Groups core functionality.

This PR introduces group-based rule gating across all supported interceptors, registry lifecycle management, builder integration, validation, and Service Worker support.

Corresponds to:
Issue #44 — Rule Group Core Data Model

---

## Key Features

- RuleGroupRegistry implementation
- Builder `.inGroup()` support (single-shot)
- Runtime group gating across all interceptors
- Service Worker group toggle support
- Lifecycle event emission
- Validation with trimmed group names
- Safe group removal behavior
- Default group fallback support

---

## Bug Fixes Included

- Fixed missing XHR latency gating
- Added SW toggle message support
- Prevented empty group names
- Fixed implicit → explicit upgrade behavior
- Normalized public API group inputs

---

## Tests Added

- Disabled XHR latency regression
- Empty builder group rejection
- Explicit registry upgrade
- SW toggle ACK validation
- Toggle storm behavior tests

Total tests passing: 347

---

## Scope Notes

This PR intentionally focuses only on:

RFC-001 core model

Follow-up work tracked in:

- Issue #45 — Adapter Integration
- Issue #46 — Tests
- Issue #47 — Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rule-group management: nameable groups that can be pre-configured and toggled at runtime, with events emitted on state changes and SW support.
  * Builder and config now support tagging rules with groups; runtime API to create/enable/disable/remove/list groups and inspect snapshots.
  * Chaos interceptors (network, XHR, fetch, websockets, SSE, DOM) now honor group gating.

* **Tests**
  * Extensive tests added covering group lifecycle, gating behavior, validation, and SW messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->