### PR TITLE
feat(adapters): rule groups page + SW toggle helpers (RFC-001 phase B, #45)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,7 +110,11 @@ if (typeof window !== 'undefined') {
 
     getGroupState: (name: string) => {
       if (!chaosUtilsApi.instance) return null;
-      return chaosUtilsApi.instance.getGroupState(name);
+      try {
+        return chaosUtilsApi.instance.getGroupState(name);
+      } catch {
+        return null;
+      }
     },
   };
   

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,10 @@ interface ChaosUtilsApi {
   stop: () => { success: boolean; message: string };
   getLog: () => ChaosEvent[];
   getSeed: () => number | null;
+  enableGroup: (name: string) => { success: boolean; message: string };
+  disableGroup: (name: string) => { success: boolean; message: string };
+  createGroup: (name: string, opts?: { enabled?: boolean }) => { success: boolean; message: string };
+  getGroupState: (name: string) => boolean | null;
 }
 
 // --- Global API & Auto-Start Logic ---
@@ -72,7 +76,42 @@ if (typeof window !== 'undefined') {
         return chaosUtilsApi.instance.getSeed();
       }
       return null;
-    }
+    },
+
+    enableGroup: (name: string) => {
+      if (!chaosUtilsApi.instance) return { success: false, message: 'No chaos instance' };
+      try {
+        chaosUtilsApi.instance.enableGroup(name);
+        return { success: true, message: `Group '${name}' enabled` };
+      } catch (e: any) {
+        return { success: false, message: e?.message ?? String(e) };
+      }
+    },
+
+    disableGroup: (name: string) => {
+      if (!chaosUtilsApi.instance) return { success: false, message: 'No chaos instance' };
+      try {
+        chaosUtilsApi.instance.disableGroup(name);
+        return { success: true, message: `Group '${name}' disabled` };
+      } catch (e: any) {
+        return { success: false, message: e?.message ?? String(e) };
+      }
+    },
+
+    createGroup: (name: string, opts?: { enabled?: boolean }) => {
+      if (!chaosUtilsApi.instance) return { success: false, message: 'No chaos instance' };
+      try {
+        chaosUtilsApi.instance.createGroup(name, opts);
+        return { success: true, message: `Group '${name}' created` };
+      } catch (e: any) {
+        return { success: false, message: e?.message ?? String(e) };
+      }
+    },
+
+    getGroupState: (name: string) => {
+      if (!chaosUtilsApi.instance) return null;
+      return chaosUtilsApi.instance.getGroupState(name);
+    },
   };
   
   (window as any).chaosUtils = chaosUtilsApi;

--- a/packages/core/src/sw-bridge-source.ts
+++ b/packages/core/src/sw-bridge-source.ts
@@ -9,6 +9,8 @@
  * Exposes `window.__chaosMakerSWBridge`:
  *  - `apply(cfg, timeoutMs)` — post config over MessageChannel, wait for ack.
  *  - `stop(timeoutMs)` — stop chaos in the SW.
+ *  - `toggleGroup(name, enabled, timeoutMs)` — flip a rule group inside the SW
+ *    via `__chaosMakerToggleGroup`; resolves on ack with no engine restart.
  *  - `getLocalLog()` / `clearLocalLog()` — page-side buffered event log.
  *  - `getRemoteLog(timeoutMs)` — fetch SW's in-memory log.
  *
@@ -105,6 +107,17 @@ export const SW_BRIDGE_SOURCE = /* js */ `
         return Promise.resolve({ running: false });
       }
       return postViaPort(navigator.serviceWorker.controller, { __chaosMakerStop: true }, timeoutMs);
+    },
+    toggleGroup: function (name, enabled, timeoutMs) {
+      if (!('serviceWorker' in navigator) || !navigator.serviceWorker.controller) {
+        return Promise.reject(new Error('[chaos-maker] no SW controller — call injectSWChaos before toggleGroup'));
+      }
+      var t = (typeof timeoutMs === 'number' && timeoutMs > 0) ? timeoutMs : 2000;
+      return postViaPort(
+        navigator.serviceWorker.controller,
+        { __chaosMakerToggleGroup: { name: String(name), enabled: !!enabled } },
+        t,
+      );
     },
     getLocalLog: function () { return log.slice(); },
     clearLocalLog: function () { log.length = 0; },

--- a/packages/cypress/src/commands.ts
+++ b/packages/cypress/src/commands.ts
@@ -13,6 +13,8 @@ interface ChaosUtilsApi {
   stop: () => { success: boolean; message: string };
   getLog: () => ChaosEvent[];
   getSeed: () => number | null;
+  enableGroup?: (name: string) => { success: boolean; message: string };
+  disableGroup?: (name: string) => { success: boolean; message: string };
 }
 
 // Module-level state. Cypress loads the support file once per spec; these
@@ -118,6 +120,32 @@ export function registerChaosCommands(): void {
         return utils.getLog();
       }
       return [];
+    });
+  });
+
+  Cypress.Commands.add('enableGroup', (name: string) => {
+    cy.window({ log: false }).then((win) => {
+      const utils = (win as unknown as { chaosUtils?: ChaosUtilsApi }).chaosUtils;
+      if (!utils || !utils.instance) {
+        throw new Error('[chaos-maker] no chaos instance — call cy.injectChaos() first');
+      }
+      const result = utils.enableGroup?.(name);
+      if (result && result.success === false) {
+        throw new Error(`[chaos-maker] enableGroup('${name}') failed: ${result.message}`);
+      }
+    });
+  });
+
+  Cypress.Commands.add('disableGroup', (name: string) => {
+    cy.window({ log: false }).then((win) => {
+      const utils = (win as unknown as { chaosUtils?: ChaosUtilsApi }).chaosUtils;
+      if (!utils || !utils.instance) {
+        throw new Error('[chaos-maker] no chaos instance — call cy.injectChaos() first');
+      }
+      const result = utils.disableGroup?.(name);
+      if (result && result.success === false) {
+        throw new Error(`[chaos-maker] disableGroup('${name}') failed: ${result.message}`);
+      }
     });
   });
 

--- a/packages/cypress/src/commands.ts
+++ b/packages/cypress/src/commands.ts
@@ -124,7 +124,10 @@ export function registerChaosCommands(): void {
   });
 
   Cypress.Commands.add('enableGroup', (name: string) => {
-    const nameNorm = String(name).trim();
+    if (typeof name !== 'string') {
+      throw new Error('[chaos-maker] group name must be a string');
+    }
+    const nameNorm = name.trim();
     if (!nameNorm) {
       throw new Error('[chaos-maker] group name cannot be empty');
     }
@@ -144,7 +147,10 @@ export function registerChaosCommands(): void {
   });
 
   Cypress.Commands.add('disableGroup', (name: string) => {
-    const nameNorm = String(name).trim();
+    if (typeof name !== 'string') {
+      throw new Error('[chaos-maker] group name must be a string');
+    }
+    const nameNorm = name.trim();
     if (!nameNorm) {
       throw new Error('[chaos-maker] group name cannot be empty');
     }

--- a/packages/cypress/src/commands.ts
+++ b/packages/cypress/src/commands.ts
@@ -124,27 +124,41 @@ export function registerChaosCommands(): void {
   });
 
   Cypress.Commands.add('enableGroup', (name: string) => {
+    const nameNorm = String(name).trim();
+    if (!nameNorm) {
+      throw new Error('[chaos-maker] group name cannot be empty');
+    }
     cy.window({ log: false }).then((win) => {
       const utils = (win as unknown as { chaosUtils?: ChaosUtilsApi }).chaosUtils;
       if (!utils || !utils.instance) {
         throw new Error('[chaos-maker] no chaos instance — call cy.injectChaos() first');
       }
-      const result = utils.enableGroup?.(name);
+      if (typeof utils.enableGroup !== 'function') {
+        throw new Error('[chaos-maker] enableGroup API unavailable');
+      }
+      const result = utils.enableGroup(nameNorm);
       if (result && result.success === false) {
-        throw new Error(`[chaos-maker] enableGroup('${name}') failed: ${result.message}`);
+        throw new Error(`[chaos-maker] enableGroup('${nameNorm}') failed: ${result.message}`);
       }
     });
   });
 
   Cypress.Commands.add('disableGroup', (name: string) => {
+    const nameNorm = String(name).trim();
+    if (!nameNorm) {
+      throw new Error('[chaos-maker] group name cannot be empty');
+    }
     cy.window({ log: false }).then((win) => {
       const utils = (win as unknown as { chaosUtils?: ChaosUtilsApi }).chaosUtils;
       if (!utils || !utils.instance) {
         throw new Error('[chaos-maker] no chaos instance — call cy.injectChaos() first');
       }
-      const result = utils.disableGroup?.(name);
+      if (typeof utils.disableGroup !== 'function') {
+        throw new Error('[chaos-maker] disableGroup API unavailable');
+      }
+      const result = utils.disableGroup(nameNorm);
       if (result && result.success === false) {
-        throw new Error(`[chaos-maker] disableGroup('${name}') failed: ${result.message}`);
+        throw new Error(`[chaos-maker] disableGroup('${nameNorm}') failed: ${result.message}`);
       }
     });
   });

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -100,6 +100,24 @@ declare global {
        * debugging a race where the page-side listener may have missed events.
        */
       getSWChaosLogFromSW(options?: SWChaosOptions): Chainable<ChaosEvent[]>;
+
+      /**
+       * Enable a rule group at runtime in the page-side chaos engine.
+       * Auto-creates the group if unknown and emits `rule-group:enabled`.
+       */
+      enableGroup(name: string): Chainable<void>;
+
+      /** Disable a rule group at runtime in the page-side chaos engine. */
+      disableGroup(name: string): Chainable<void>;
+
+      /**
+       * Enable a rule group inside the active SW chaos engine. Resolves only
+       * after the SW acks via MessageChannel.
+       */
+      enableSWGroup(name: string, options?: SWChaosOptions): Chainable<void>;
+
+      /** Disable a rule group inside the active SW chaos engine. */
+      disableSWGroup(name: string, options?: SWChaosOptions): Chainable<void>;
     }
   }
 }

--- a/packages/cypress/src/sw.ts
+++ b/packages/cypress/src/sw.ts
@@ -16,6 +16,7 @@ export interface SWChaosOptions {
 interface SWBridge {
   apply: (cfg: ChaosConfig, timeoutMs: number) => Promise<{ seed: number | null }>;
   stop: (timeoutMs: number) => Promise<unknown>;
+  toggleGroup: (name: string, enabled: boolean, timeoutMs: number) => Promise<unknown>;
   getLocalLog: () => ChaosEvent[];
   clearLocalLog: () => void;
   getRemoteLog: (timeoutMs: number) => Promise<ChaosEvent[]>;
@@ -72,6 +73,26 @@ export function registerSWChaosCommands(): void {
       const bridge = getBridge(win);
       return bridge ? bridge.getLocalLog() : [];
     });
+  });
+
+  Cypress.Commands.add('enableSWGroup', (name: string, options?: SWChaosOptions) => {
+    const timeoutMs = options?.timeoutMs ?? 2_000;
+    return cy.window({ log: false }).then((win) => {
+      const bridge = ensureBridge(win);
+      return Cypress.Promise.resolve(bridge.toggleGroup(name, true, timeoutMs)).then(
+        () => undefined,
+      ) as unknown as Cypress.Chainable<void>;
+    }) as unknown as Cypress.Chainable<void>;
+  });
+
+  Cypress.Commands.add('disableSWGroup', (name: string, options?: SWChaosOptions) => {
+    const timeoutMs = options?.timeoutMs ?? 2_000;
+    return cy.window({ log: false }).then((win) => {
+      const bridge = ensureBridge(win);
+      return Cypress.Promise.resolve(bridge.toggleGroup(name, false, timeoutMs)).then(
+        () => undefined,
+      ) as unknown as Cypress.Chainable<void>;
+    }) as unknown as Cypress.Chainable<void>;
   });
 
   Cypress.Commands.add('getSWChaosLogFromSW', (options?: SWChaosOptions) => {

--- a/packages/cypress/src/sw.ts
+++ b/packages/cypress/src/sw.ts
@@ -78,7 +78,10 @@ export function registerSWChaosCommands(): void {
   });
 
   Cypress.Commands.add('enableSWGroup', (name: string, options?: SWChaosOptions) => {
-    const nameNorm = String(name).trim();
+    if (typeof name !== 'string') {
+      throw new Error('[chaos-maker] group name must be a string');
+    }
+    const nameNorm = name.trim();
     if (!nameNorm) {
       throw new Error('[chaos-maker] group name cannot be empty');
     }
@@ -92,7 +95,10 @@ export function registerSWChaosCommands(): void {
   });
 
   Cypress.Commands.add('disableSWGroup', (name: string, options?: SWChaosOptions) => {
-    const nameNorm = String(name).trim();
+    if (typeof name !== 'string') {
+      throw new Error('[chaos-maker] group name must be a string');
+    }
+    const nameNorm = name.trim();
     if (!nameNorm) {
       throw new Error('[chaos-maker] group name cannot be empty');
     }

--- a/packages/cypress/src/sw.ts
+++ b/packages/cypress/src/sw.ts
@@ -22,6 +22,8 @@ interface SWBridge {
   getRemoteLog: (timeoutMs: number) => Promise<ChaosEvent[]>;
 }
 
+const DEFAULT_SW_TOGGLE_TIMEOUT = 2_000;
+
 function getBridge(win: Cypress.AUTWindow): SWBridge | undefined {
   return (win as unknown as { __chaosMakerSWBridge?: SWBridge }).__chaosMakerSWBridge;
 }
@@ -76,20 +78,28 @@ export function registerSWChaosCommands(): void {
   });
 
   Cypress.Commands.add('enableSWGroup', (name: string, options?: SWChaosOptions) => {
-    const timeoutMs = options?.timeoutMs ?? 2_000;
+    const nameNorm = String(name).trim();
+    if (!nameNorm) {
+      throw new Error('[chaos-maker] group name cannot be empty');
+    }
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_SW_TOGGLE_TIMEOUT;
     return cy.window({ log: false }).then((win) => {
       const bridge = ensureBridge(win);
-      return Cypress.Promise.resolve(bridge.toggleGroup(name, true, timeoutMs)).then(
+      return Cypress.Promise.resolve(bridge.toggleGroup(nameNorm, true, timeoutMs)).then(
         () => undefined,
       ) as unknown as Cypress.Chainable<void>;
     }) as unknown as Cypress.Chainable<void>;
   });
 
   Cypress.Commands.add('disableSWGroup', (name: string, options?: SWChaosOptions) => {
-    const timeoutMs = options?.timeoutMs ?? 2_000;
+    const nameNorm = String(name).trim();
+    if (!nameNorm) {
+      throw new Error('[chaos-maker] group name cannot be empty');
+    }
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_SW_TOGGLE_TIMEOUT;
     return cy.window({ log: false }).then((win) => {
       const bridge = ensureBridge(win);
-      return Cypress.Promise.resolve(bridge.toggleGroup(name, false, timeoutMs)).then(
+      return Cypress.Promise.resolve(bridge.toggleGroup(nameNorm, false, timeoutMs)).then(
         () => undefined,
       ) as unknown as Cypress.Chainable<void>;
     }) as unknown as Cypress.Chainable<void>;

--- a/packages/playwright/src/fixture.ts
+++ b/packages/playwright/src/fixture.ts
@@ -6,14 +6,23 @@ import {
   removeChaos,
   getChaosLog,
   getChaosSeed,
+  enableGroup,
+  disableGroup,
+  enableSWGroup,
+  disableSWGroup,
   InjectChaosOptions,
 } from './index';
+import type { SWChaosOptions } from './sw';
 
 export interface ChaosFixture {
   inject: (config: ChaosConfig, opts?: InjectChaosOptions) => Promise<void>;
   remove: () => Promise<void>;
   getLog: () => Promise<ChaosEvent[]>;
   getSeed: () => Promise<number | null>;
+  enableGroup: (name: string) => Promise<void>;
+  disableGroup: (name: string) => Promise<void>;
+  enableSWGroup: (name: string, opts?: SWChaosOptions) => Promise<void>;
+  disableSWGroup: (name: string, opts?: SWChaosOptions) => Promise<void>;
 }
 
 /**
@@ -82,6 +91,10 @@ export const test = base.extend<{ chaos: ChaosFixture }>({
       remove: () => removeChaos(page),
       getLog: () => getChaosLog(page),
       getSeed: () => getChaosSeed(page),
+      enableGroup: (name: string) => enableGroup(page, name),
+      disableGroup: (name: string) => disableGroup(page, name),
+      enableSWGroup: (name: string, opts?: SWChaosOptions) => enableSWGroup(page, name, opts),
+      disableSWGroup: (name: string, opts?: SWChaosOptions) => disableSWGroup(page, name, opts),
     };
     await use(fixture);
     await removeChaos(page);

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -173,7 +173,10 @@ export async function getChaosLog(page: Page): Promise<ChaosEvent[]> {
  * the assertion that depends on the group being live.
  */
 export async function enableGroup(page: Page, name: string): Promise<void> {
-  const nameNorm = String(name).trim();
+  if (typeof name !== 'string') {
+    throw new Error('[chaos-maker] group name must be a string');
+  }
+  const nameNorm = name.trim();
   if (!nameNorm) {
     throw new Error('[chaos-maker] group name cannot be empty');
   }
@@ -199,7 +202,10 @@ export async function enableGroup(page: Page, name: string): Promise<void> {
 
 /** Disable a rule group at runtime in the page-side chaos engine. */
 export async function disableGroup(page: Page, name: string): Promise<void> {
-  const nameNorm = String(name).trim();
+  if (typeof name !== 'string') {
+    throw new Error('[chaos-maker] group name must be a string');
+  }
+  const nameNorm = name.trim();
   if (!nameNorm) {
     throw new Error('[chaos-maker] group name cannot be empty');
   }

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -173,24 +173,54 @@ export async function getChaosLog(page: Page): Promise<ChaosEvent[]> {
  * the assertion that depends on the group being live.
  */
 export async function enableGroup(page: Page, name: string): Promise<void> {
+  const nameNorm = String(name).trim();
+  if (!nameNorm) {
+    throw new Error('[chaos-maker] group name cannot be empty');
+  }
   await page.evaluate(({ n }: { n: string }) => {
-    const utils = (globalThis as unknown as { chaosUtils?: { instance: unknown; enableGroup?: (n: string) => unknown } }).chaosUtils;
+    const utils = (globalThis as unknown as {
+      chaosUtils?: {
+        instance: unknown;
+        enableGroup?: (n: string) => { success: boolean; message: string };
+      };
+    }).chaosUtils;
     if (!utils || !utils.instance) {
       throw new Error('[chaos-maker] no chaos instance on page — call injectChaos first');
     }
-    utils.enableGroup?.(n);
-  }, { n: name });
+    if (typeof utils.enableGroup !== 'function') {
+      throw new Error('[chaos-maker] enableGroup API unavailable');
+    }
+    const result = utils.enableGroup(n);
+    if (result && result.success === false) {
+      throw new Error(`[chaos-maker] enableGroup('${n}') failed: ${result.message}`);
+    }
+  }, { n: nameNorm });
 }
 
 /** Disable a rule group at runtime in the page-side chaos engine. */
 export async function disableGroup(page: Page, name: string): Promise<void> {
+  const nameNorm = String(name).trim();
+  if (!nameNorm) {
+    throw new Error('[chaos-maker] group name cannot be empty');
+  }
   await page.evaluate(({ n }: { n: string }) => {
-    const utils = (globalThis as unknown as { chaosUtils?: { instance: unknown; disableGroup?: (n: string) => unknown } }).chaosUtils;
+    const utils = (globalThis as unknown as {
+      chaosUtils?: {
+        instance: unknown;
+        disableGroup?: (n: string) => { success: boolean; message: string };
+      };
+    }).chaosUtils;
     if (!utils || !utils.instance) {
       throw new Error('[chaos-maker] no chaos instance on page — call injectChaos first');
     }
-    utils.disableGroup?.(n);
-  }, { n: name });
+    if (typeof utils.disableGroup !== 'function') {
+      throw new Error('[chaos-maker] disableGroup API unavailable');
+    }
+    const result = utils.disableGroup(n);
+    if (result && result.success === false) {
+      throw new Error(`[chaos-maker] disableGroup('${n}') failed: ${result.message}`);
+    }
+  }, { n: nameNorm });
 }
 
 /**

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -168,6 +168,32 @@ export async function getChaosLog(page: Page): Promise<ChaosEvent[]> {
 }
 
 /**
+ * Enable a rule group at runtime in the page-side chaos engine. Resolves once
+ * `page.evaluate` round-trips so the call is safe to await before triggering
+ * the assertion that depends on the group being live.
+ */
+export async function enableGroup(page: Page, name: string): Promise<void> {
+  await page.evaluate(({ n }: { n: string }) => {
+    const utils = (globalThis as unknown as { chaosUtils?: { instance: unknown; enableGroup?: (n: string) => unknown } }).chaosUtils;
+    if (!utils || !utils.instance) {
+      throw new Error('[chaos-maker] no chaos instance on page — call injectChaos first');
+    }
+    utils.enableGroup?.(n);
+  }, { n: name });
+}
+
+/** Disable a rule group at runtime in the page-side chaos engine. */
+export async function disableGroup(page: Page, name: string): Promise<void> {
+  await page.evaluate(({ n }: { n: string }) => {
+    const utils = (globalThis as unknown as { chaosUtils?: { instance: unknown; disableGroup?: (n: string) => unknown } }).chaosUtils;
+    if (!utils || !utils.instance) {
+      throw new Error('[chaos-maker] no chaos instance on page — call injectChaos first');
+    }
+    utils.disableGroup?.(n);
+  }, { n: name });
+}
+
+/**
  * Retrieve the PRNG seed from a Playwright page.
  * Log this value on test failure to replay exact chaos decisions.
  */
@@ -216,5 +242,7 @@ export {
   removeSWChaos,
   getSWChaosLog,
   getSWChaosLogFromSW,
+  enableSWGroup,
+  disableSWGroup,
 } from './sw';
 export type { SWChaosOptions, InjectSWChaosResult } from './sw';

--- a/packages/playwright/src/sw.ts
+++ b/packages/playwright/src/sw.ts
@@ -113,7 +113,10 @@ export async function removeSWChaos(page: Page, opts: SWChaosOptions = {}): Prom
  * acks. Engine state and request counters are preserved (no restart).
  */
 export async function enableSWGroup(page: Page, name: string, opts: SWChaosOptions = {}): Promise<void> {
-  const nameNorm = String(name).trim();
+  if (typeof name !== 'string') {
+    throw new Error('[chaos-maker] group name must be a string');
+  }
+  const nameNorm = name.trim();
   if (!nameNorm) {
     throw new Error('[chaos-maker] group name cannot be empty');
   }
@@ -122,7 +125,10 @@ export async function enableSWGroup(page: Page, name: string, opts: SWChaosOptio
 
 /** Disable a rule group inside the active SW chaos engine. */
 export async function disableSWGroup(page: Page, name: string, opts: SWChaosOptions = {}): Promise<void> {
-  const nameNorm = String(name).trim();
+  if (typeof name !== 'string') {
+    throw new Error('[chaos-maker] group name must be a string');
+  }
+  const nameNorm = name.trim();
   if (!nameNorm) {
     throw new Error('[chaos-maker] group name cannot be empty');
   }

--- a/packages/playwright/src/sw.ts
+++ b/packages/playwright/src/sw.ts
@@ -22,6 +22,8 @@ export interface InjectSWChaosResult {
 
 const BRIDGE_INIT_KEY = Symbol.for('chaos-maker.playwright.sw.bridgeInit');
 
+const DEFAULT_SW_TOGGLE_TIMEOUT = 2_000;
+
 async function ensurePageBridge(page: Page): Promise<void> {
   // `addInitScript` is additive — call it at most once per Page to prevent
   // listener stacking across re-inject calls. The flag inside the script also
@@ -111,16 +113,24 @@ export async function removeSWChaos(page: Page, opts: SWChaosOptions = {}): Prom
  * acks. Engine state and request counters are preserved (no restart).
  */
 export async function enableSWGroup(page: Page, name: string, opts: SWChaosOptions = {}): Promise<void> {
-  await toggleSWGroup(page, name, true, opts);
+  const nameNorm = String(name).trim();
+  if (!nameNorm) {
+    throw new Error('[chaos-maker] group name cannot be empty');
+  }
+  await toggleSWGroup(page, nameNorm, true, opts);
 }
 
 /** Disable a rule group inside the active SW chaos engine. */
 export async function disableSWGroup(page: Page, name: string, opts: SWChaosOptions = {}): Promise<void> {
-  await toggleSWGroup(page, name, false, opts);
+  const nameNorm = String(name).trim();
+  if (!nameNorm) {
+    throw new Error('[chaos-maker] group name cannot be empty');
+  }
+  await toggleSWGroup(page, nameNorm, false, opts);
 }
 
 async function toggleSWGroup(page: Page, name: string, enabled: boolean, opts: SWChaosOptions): Promise<void> {
-  const timeoutMs = opts.timeoutMs ?? 2_000;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_SW_TOGGLE_TIMEOUT;
   await ensurePageBridge(page);
   await page.evaluate(
     async ({ n, e, t }: { n: string; e: boolean; t: number }) => {

--- a/packages/playwright/src/sw.ts
+++ b/packages/playwright/src/sw.ts
@@ -106,6 +106,37 @@ export async function removeSWChaos(page: Page, opts: SWChaosOptions = {}): Prom
 }
 
 /**
+ * Enable a rule group inside the active SW chaos engine. Posts
+ * `__chaosMakerToggleGroup` over MessageChannel and resolves only after the SW
+ * acks. Engine state and request counters are preserved (no restart).
+ */
+export async function enableSWGroup(page: Page, name: string, opts: SWChaosOptions = {}): Promise<void> {
+  await toggleSWGroup(page, name, true, opts);
+}
+
+/** Disable a rule group inside the active SW chaos engine. */
+export async function disableSWGroup(page: Page, name: string, opts: SWChaosOptions = {}): Promise<void> {
+  await toggleSWGroup(page, name, false, opts);
+}
+
+async function toggleSWGroup(page: Page, name: string, enabled: boolean, opts: SWChaosOptions): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? 2_000;
+  await ensurePageBridge(page);
+  await page.evaluate(
+    async ({ n, e, t }: { n: string; e: boolean; t: number }) => {
+      const bridge = (globalThis as unknown as {
+        __chaosMakerSWBridge?: {
+          toggleGroup: (name: string, enabled: boolean, t: number) => Promise<unknown>;
+        };
+      }).__chaosMakerSWBridge;
+      if (!bridge) throw new Error('[chaos-maker] SW bridge missing — ensurePageBridge failed');
+      await bridge.toggleGroup(n, e, t);
+    },
+    { n: name, e: enabled, t: timeoutMs },
+  );
+}
+
+/**
  * Read the chaos event log buffered on the page side. Every event emitted by
  * the SW is broadcast to all controlled clients and captured here.
  */

--- a/packages/puppeteer/src/index.ts
+++ b/packages/puppeteer/src/index.ts
@@ -159,7 +159,10 @@ export async function getChaosLog(page: ChaosPage): Promise<ChaosEvent[]> {
  * before triggering an action that depends on the group being live.
  */
 export async function enableGroup(page: ChaosPage, name: string): Promise<void> {
-  const nameNorm = String(name).trim();
+  if (typeof name !== 'string') {
+    throw new Error('[chaos-maker] group name must be a string');
+  }
+  const nameNorm = name.trim();
   if (!nameNorm) {
     throw new Error('[chaos-maker] group name cannot be empty');
   }
@@ -185,7 +188,10 @@ export async function enableGroup(page: ChaosPage, name: string): Promise<void> 
 
 /** Disable a rule group at runtime in the page-side chaos engine. */
 export async function disableGroup(page: ChaosPage, name: string): Promise<void> {
-  const nameNorm = String(name).trim();
+  if (typeof name !== 'string') {
+    throw new Error('[chaos-maker] group name must be a string');
+  }
+  const nameNorm = name.trim();
   if (!nameNorm) {
     throw new Error('[chaos-maker] group name cannot be empty');
   }

--- a/packages/puppeteer/src/index.ts
+++ b/packages/puppeteer/src/index.ts
@@ -159,28 +159,54 @@ export async function getChaosLog(page: ChaosPage): Promise<ChaosEvent[]> {
  * before triggering an action that depends on the group being live.
  */
 export async function enableGroup(page: ChaosPage, name: string): Promise<void> {
+  const nameNorm = String(name).trim();
+  if (!nameNorm) {
+    throw new Error('[chaos-maker] group name cannot be empty');
+  }
   await page.evaluate((n: unknown) => {
     const utils = (globalThis as unknown as {
-      chaosUtils?: { instance: unknown; enableGroup?: (n: string) => unknown };
+      chaosUtils?: {
+        instance: unknown;
+        enableGroup?: (n: string) => { success: boolean; message: string };
+      };
     }).chaosUtils;
     if (!utils || !utils.instance) {
       throw new Error('[chaos-maker] no chaos instance on page — call injectChaos first');
     }
-    utils.enableGroup?.(n as string);
-  }, name as unknown);
+    if (typeof utils.enableGroup !== 'function') {
+      throw new Error('[chaos-maker] enableGroup API unavailable');
+    }
+    const result = utils.enableGroup(n as string);
+    if (result && result.success === false) {
+      throw new Error(`[chaos-maker] enableGroup('${n as string}') failed: ${result.message}`);
+    }
+  }, nameNorm as unknown);
 }
 
 /** Disable a rule group at runtime in the page-side chaos engine. */
 export async function disableGroup(page: ChaosPage, name: string): Promise<void> {
+  const nameNorm = String(name).trim();
+  if (!nameNorm) {
+    throw new Error('[chaos-maker] group name cannot be empty');
+  }
   await page.evaluate((n: unknown) => {
     const utils = (globalThis as unknown as {
-      chaosUtils?: { instance: unknown; disableGroup?: (n: string) => unknown };
+      chaosUtils?: {
+        instance: unknown;
+        disableGroup?: (n: string) => { success: boolean; message: string };
+      };
     }).chaosUtils;
     if (!utils || !utils.instance) {
       throw new Error('[chaos-maker] no chaos instance on page — call injectChaos first');
     }
-    utils.disableGroup?.(n as string);
-  }, name as unknown);
+    if (typeof utils.disableGroup !== 'function') {
+      throw new Error('[chaos-maker] disableGroup API unavailable');
+    }
+    const result = utils.disableGroup(n as string);
+    if (result && result.success === false) {
+      throw new Error(`[chaos-maker] disableGroup('${n as string}') failed: ${result.message}`);
+    }
+  }, nameNorm as unknown);
 }
 
 /**

--- a/packages/puppeteer/src/index.ts
+++ b/packages/puppeteer/src/index.ts
@@ -154,6 +154,36 @@ export async function getChaosLog(page: ChaosPage): Promise<ChaosEvent[]> {
 }
 
 /**
+ * Enable a rule group at runtime in the page-side chaos engine.
+ * Resolves once `page.evaluate` round-trips so the call is safe to await
+ * before triggering an action that depends on the group being live.
+ */
+export async function enableGroup(page: ChaosPage, name: string): Promise<void> {
+  await page.evaluate((n: unknown) => {
+    const utils = (globalThis as unknown as {
+      chaosUtils?: { instance: unknown; enableGroup?: (n: string) => unknown };
+    }).chaosUtils;
+    if (!utils || !utils.instance) {
+      throw new Error('[chaos-maker] no chaos instance on page — call injectChaos first');
+    }
+    utils.enableGroup?.(n as string);
+  }, name as unknown);
+}
+
+/** Disable a rule group at runtime in the page-side chaos engine. */
+export async function disableGroup(page: ChaosPage, name: string): Promise<void> {
+  await page.evaluate((n: unknown) => {
+    const utils = (globalThis as unknown as {
+      chaosUtils?: { instance: unknown; disableGroup?: (n: string) => unknown };
+    }).chaosUtils;
+    if (!utils || !utils.instance) {
+      throw new Error('[chaos-maker] no chaos instance on page — call injectChaos first');
+    }
+    utils.disableGroup?.(n as string);
+  }, name as unknown);
+}
+
+/**
  * Read the PRNG seed used by the active chaos instance. Log this on test
  * failure to replay the exact sequence of chaos decisions with the same seed.
  */
@@ -226,5 +256,7 @@ export {
   getSWChaosLog,
   getSWChaosLogFromSW,
   useSWChaos,
+  enableSWGroup,
+  disableSWGroup,
 } from './sw';
 export type { SWChaosOptions, InjectSWChaosResult } from './sw';

--- a/packages/puppeteer/src/sw.ts
+++ b/packages/puppeteer/src/sw.ts
@@ -113,7 +113,10 @@ export async function enableSWGroup(
   name: string,
   opts: SWChaosOptions = {},
 ): Promise<void> {
-  const nameNorm = String(name).trim();
+  if (typeof name !== 'string') {
+    throw new Error('[chaos-maker] group name must be a string');
+  }
+  const nameNorm = name.trim();
   if (!nameNorm) {
     throw new Error('[chaos-maker] group name cannot be empty');
   }
@@ -126,7 +129,10 @@ export async function disableSWGroup(
   name: string,
   opts: SWChaosOptions = {},
 ): Promise<void> {
-  const nameNorm = String(name).trim();
+  if (typeof name !== 'string') {
+    throw new Error('[chaos-maker] group name must be a string');
+  }
+  const nameNorm = name.trim();
   if (!nameNorm) {
     throw new Error('[chaos-maker] group name cannot be empty');
   }

--- a/packages/puppeteer/src/sw.ts
+++ b/packages/puppeteer/src/sw.ts
@@ -16,6 +16,8 @@ export interface InjectSWChaosResult {
 
 const BRIDGE_INIT_KEY = Symbol.for('chaos-maker.puppeteer.sw.bridgeInit');
 
+const DEFAULT_SW_TOGGLE_TIMEOUT = 2_000;
+
 // Puppeteer messages raised when no document is committed / context is torn
 // down. These are the only conditions under which we want `page.evaluate`
 // to be a no-op here; anything else (CSP, syntax error, destroyed target
@@ -111,7 +113,11 @@ export async function enableSWGroup(
   name: string,
   opts: SWChaosOptions = {},
 ): Promise<void> {
-  await toggleSWGroup(page, name, true, opts);
+  const nameNorm = String(name).trim();
+  if (!nameNorm) {
+    throw new Error('[chaos-maker] group name cannot be empty');
+  }
+  await toggleSWGroup(page, nameNorm, true, opts);
 }
 
 /** Disable a rule group inside the active SW chaos engine. */
@@ -120,7 +126,11 @@ export async function disableSWGroup(
   name: string,
   opts: SWChaosOptions = {},
 ): Promise<void> {
-  await toggleSWGroup(page, name, false, opts);
+  const nameNorm = String(name).trim();
+  if (!nameNorm) {
+    throw new Error('[chaos-maker] group name cannot be empty');
+  }
+  await toggleSWGroup(page, nameNorm, false, opts);
 }
 
 async function toggleSWGroup(
@@ -129,7 +139,7 @@ async function toggleSWGroup(
   enabled: boolean,
   opts: SWChaosOptions,
 ): Promise<void> {
-  const timeoutMs = opts.timeoutMs ?? 2_000;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_SW_TOGGLE_TIMEOUT;
   await ensurePageBridge(page);
   await page.evaluate(
     async (n: unknown, e: unknown, t: unknown) => {

--- a/packages/puppeteer/src/sw.ts
+++ b/packages/puppeteer/src/sw.ts
@@ -101,6 +101,52 @@ export async function removeSWChaos(page: ChaosPage, opts: SWChaosOptions = {}):
   }
 }
 
+/**
+ * Enable a rule group inside the active SW chaos engine. Posts
+ * `__chaosMakerToggleGroup` over MessageChannel and resolves only after the SW
+ * acks. Engine state and request counters are preserved (no restart).
+ */
+export async function enableSWGroup(
+  page: ChaosPage,
+  name: string,
+  opts: SWChaosOptions = {},
+): Promise<void> {
+  await toggleSWGroup(page, name, true, opts);
+}
+
+/** Disable a rule group inside the active SW chaos engine. */
+export async function disableSWGroup(
+  page: ChaosPage,
+  name: string,
+  opts: SWChaosOptions = {},
+): Promise<void> {
+  await toggleSWGroup(page, name, false, opts);
+}
+
+async function toggleSWGroup(
+  page: ChaosPage,
+  name: string,
+  enabled: boolean,
+  opts: SWChaosOptions,
+): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? 2_000;
+  await ensurePageBridge(page);
+  await page.evaluate(
+    async (n: unknown, e: unknown, t: unknown) => {
+      const bridge = (globalThis as unknown as {
+        __chaosMakerSWBridge?: {
+          toggleGroup: (n: string, e: boolean, t: number) => Promise<unknown>;
+        };
+      }).__chaosMakerSWBridge;
+      if (!bridge) throw new Error('[chaos-maker] SW bridge missing — ensurePageBridge failed');
+      await bridge.toggleGroup(n as string, e as boolean, t as number);
+    },
+    name as unknown,
+    enabled as unknown,
+    timeoutMs as unknown,
+  );
+}
+
 /** Read SW chaos events buffered on the page side. */
 export async function getSWChaosLog(page: ChaosPage): Promise<ChaosEvent[]> {
   return page.evaluate(() => {

--- a/packages/webdriverio/README.md
+++ b/packages/webdriverio/README.md
@@ -26,7 +26,7 @@ export const config: WebdriverIO.Config = {
 };
 ```
 
-That's it. Every spec now has `browser.injectChaos`, `browser.removeChaos`, `browser.getChaosLog`, `browser.getChaosSeed`, and the Service Worker helpers.
+That's it. Every spec now has `browser.injectChaos`, `browser.removeChaos`, `browser.getChaosLog`, `browser.getChaosSeed`, `browser.enableGroup`, `browser.disableGroup`, and the Service Worker helpers.
 
 ## Usage
 
@@ -96,7 +96,7 @@ await $('#refresh').click();
 
 ### `registerChaosCommands(browser)`
 
-Attach the `injectChaos`, `removeChaos`, `getChaosLog`, and `getChaosSeed` methods as custom commands on the given `browser` object. Call once in `wdio.conf.ts`' `before` hook.
+Attach the `injectChaos`, `removeChaos`, `getChaosLog`, `getChaosSeed`, `enableGroup`, and `disableGroup` methods as custom commands on the given `browser` object. Call once in `wdio.conf.ts`' `before` hook.
 
 ### `injectChaos(browser, config)`
 

--- a/packages/webdriverio/README.md
+++ b/packages/webdriverio/README.md
@@ -26,7 +26,12 @@ export const config: WebdriverIO.Config = {
 };
 ```
 
-That's it. Every spec now has `browser.injectChaos`, `browser.removeChaos`, `browser.getChaosLog`, `browser.getChaosSeed`, `browser.enableGroup`, `browser.disableGroup`, and the Service Worker helpers.
+That's it. Every spec now has `browser.injectChaos`, `browser.removeChaos`, `browser.getChaosLog`, `browser.getChaosSeed`, `browser.enableGroup`, `browser.disableGroup`, and the Service Worker group helpers:
+
+- `browser.enableSWGroup(name)`
+- `browser.disableSWGroup(name)`
+
+These mirror browser-side `browser.enableGroup(name)` and `browser.disableGroup(name)` but operate in the Service Worker context.
 
 ## Usage
 
@@ -96,7 +101,27 @@ await $('#refresh').click();
 
 ### `registerChaosCommands(browser)`
 
-Attach the `injectChaos`, `removeChaos`, `getChaosLog`, `getChaosSeed`, `enableGroup`, and `disableGroup` methods as custom commands on the given `browser` object. Call once in `wdio.conf.ts`' `before` hook.
+Attach browser-side custom commands on the given `browser` object. Call once in `wdio.conf.ts`' `before` hook.
+
+Registers:
+
+- `browser.injectChaos(config)`
+- `browser.removeChaos()`
+- `browser.getChaosLog()`
+- `browser.getChaosSeed()`
+- `browser.enableGroup(name)`
+- `browser.disableGroup(name)`
+
+Service Worker commands are registered separately with `registerSWChaosCommands(browser)`.
+
+### `registerSWChaosCommands(browser)`
+
+Attach Service Worker-specific commands on the given `browser` object. This includes the Service Worker group helpers:
+
+- `browser.enableSWGroup(name)`
+- `browser.disableSWGroup(name)`
+
+These mirror browser-side `browser.enableGroup(name)` and `browser.disableGroup(name)` but operate in the Service Worker context.
 
 ### `injectChaos(browser, config)`
 

--- a/packages/webdriverio/README.md
+++ b/packages/webdriverio/README.md
@@ -28,10 +28,11 @@ export const config: WebdriverIO.Config = {
 
 That's it. Every spec now has `browser.injectChaos`, `browser.removeChaos`, `browser.getChaosLog`, `browser.getChaosSeed`, `browser.enableGroup`, `browser.disableGroup`, and the Service Worker group helpers:
 
-- `browser.enableSWGroup(name)`
-- `browser.disableSWGroup(name)`
+- `browser.enableSWGroup(name, opts?: SWChaosOptions)`
+- `browser.disableSWGroup(name, opts?: SWChaosOptions)`
 
 These mirror browser-side `browser.enableGroup(name)` and `browser.disableGroup(name)` but operate in the Service Worker context.
+Pass `opts.timeoutMs` to override how long the command waits for the Service Worker acknowledgement.
 
 ## Usage
 
@@ -118,10 +119,11 @@ Service Worker commands are registered separately with `registerSWChaosCommands(
 
 Attach Service Worker-specific commands on the given `browser` object. This includes the Service Worker group helpers:
 
-- `browser.enableSWGroup(name)`
-- `browser.disableSWGroup(name)`
+- `browser.enableSWGroup(name, opts?: SWChaosOptions)`
+- `browser.disableSWGroup(name, opts?: SWChaosOptions)`
 
 These mirror browser-side `browser.enableGroup(name)` and `browser.disableGroup(name)` but operate in the Service Worker context.
+Pass `opts.timeoutMs` to override how long the command waits for the Service Worker acknowledgement.
 
 ### `injectChaos(browser, config)`
 

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -211,7 +211,8 @@ export async function getChaosSeed(browser: ChaosBrowser): Promise<number | null
  * Register chaos-maker's custom WDIO commands on a browser object. After
  * calling this once (typically in `before` hook of `wdio.conf.ts`), tests can
  * call `browser.injectChaos(config)`, `browser.removeChaos()`,
- * `browser.getChaosLog()`, and `browser.getChaosSeed()` directly.
+ * `browser.getChaosLog()`, `browser.getChaosSeed()`,
+ * `browser.enableGroup(name)`, and `browser.disableGroup(name)` directly.
  */
 export function registerChaosCommands(browser: ChaosBrowser): void {
   if (!browser.addCommand) {

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -135,28 +135,54 @@ export async function getChaosLog(browser: ChaosBrowser): Promise<ChaosEvent[]> 
  * before the next action that depends on the group being live.
  */
 export async function enableGroup(browser: ChaosBrowser, name: string): Promise<void> {
+  const nameNorm = String(name).trim();
+  if (!nameNorm) {
+    throw new Error('[chaos-maker] group name cannot be empty');
+  }
   await browser.execute((n: string) => {
     const w = window as unknown as {
-      chaosUtils?: { instance: unknown; enableGroup?: (n: string) => unknown };
+      chaosUtils?: {
+        instance: unknown;
+        enableGroup?: (n: string) => { success: boolean; message: string };
+      };
     };
     if (!w.chaosUtils || !w.chaosUtils.instance) {
       throw new Error('[chaos-maker] no chaos instance on page — call injectChaos first');
     }
-    w.chaosUtils.enableGroup?.(n);
-  }, name);
+    if (typeof w.chaosUtils.enableGroup !== 'function') {
+      throw new Error('[chaos-maker] enableGroup API unavailable');
+    }
+    const result = w.chaosUtils.enableGroup(n);
+    if (result && result.success === false) {
+      throw new Error(`[chaos-maker] enableGroup('${n}') failed: ${result.message}`);
+    }
+  }, nameNorm);
 }
 
 /** Disable a rule group at runtime in the page-side chaos engine. */
 export async function disableGroup(browser: ChaosBrowser, name: string): Promise<void> {
+  const nameNorm = String(name).trim();
+  if (!nameNorm) {
+    throw new Error('[chaos-maker] group name cannot be empty');
+  }
   await browser.execute((n: string) => {
     const w = window as unknown as {
-      chaosUtils?: { instance: unknown; disableGroup?: (n: string) => unknown };
+      chaosUtils?: {
+        instance: unknown;
+        disableGroup?: (n: string) => { success: boolean; message: string };
+      };
     };
     if (!w.chaosUtils || !w.chaosUtils.instance) {
       throw new Error('[chaos-maker] no chaos instance on page — call injectChaos first');
     }
-    w.chaosUtils.disableGroup?.(n);
-  }, name);
+    if (typeof w.chaosUtils.disableGroup !== 'function') {
+      throw new Error('[chaos-maker] disableGroup API unavailable');
+    }
+    const result = w.chaosUtils.disableGroup(n);
+    if (result && result.success === false) {
+      throw new Error(`[chaos-maker] disableGroup('${n}') failed: ${result.message}`);
+    }
+  }, nameNorm);
 }
 
 /**

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -135,7 +135,10 @@ export async function getChaosLog(browser: ChaosBrowser): Promise<ChaosEvent[]> 
  * before the next action that depends on the group being live.
  */
 export async function enableGroup(browser: ChaosBrowser, name: string): Promise<void> {
-  const nameNorm = String(name).trim();
+  if (typeof name !== 'string') {
+    throw new Error('[chaos-maker] group name must be a string');
+  }
+  const nameNorm = name.trim();
   if (!nameNorm) {
     throw new Error('[chaos-maker] group name cannot be empty');
   }
@@ -161,7 +164,10 @@ export async function enableGroup(browser: ChaosBrowser, name: string): Promise<
 
 /** Disable a rule group at runtime in the page-side chaos engine. */
 export async function disableGroup(browser: ChaosBrowser, name: string): Promise<void> {
-  const nameNorm = String(name).trim();
+  if (typeof name !== 'string') {
+    throw new Error('[chaos-maker] group name must be a string');
+  }
+  const nameNorm = name.trim();
   if (!nameNorm) {
     throw new Error('[chaos-maker] group name cannot be empty');
   }

--- a/packages/webdriverio/src/index.ts
+++ b/packages/webdriverio/src/index.ts
@@ -130,6 +130,36 @@ export async function getChaosLog(browser: ChaosBrowser): Promise<ChaosEvent[]> 
 }
 
 /**
+ * Enable a rule group at runtime in the page-side chaos engine.
+ * Resolves once `browser.execute` round-trips so the call is safe to await
+ * before the next action that depends on the group being live.
+ */
+export async function enableGroup(browser: ChaosBrowser, name: string): Promise<void> {
+  await browser.execute((n: string) => {
+    const w = window as unknown as {
+      chaosUtils?: { instance: unknown; enableGroup?: (n: string) => unknown };
+    };
+    if (!w.chaosUtils || !w.chaosUtils.instance) {
+      throw new Error('[chaos-maker] no chaos instance on page — call injectChaos first');
+    }
+    w.chaosUtils.enableGroup?.(n);
+  }, name);
+}
+
+/** Disable a rule group at runtime in the page-side chaos engine. */
+export async function disableGroup(browser: ChaosBrowser, name: string): Promise<void> {
+  await browser.execute((n: string) => {
+    const w = window as unknown as {
+      chaosUtils?: { instance: unknown; disableGroup?: (n: string) => unknown };
+    };
+    if (!w.chaosUtils || !w.chaosUtils.instance) {
+      throw new Error('[chaos-maker] no chaos instance on page — call injectChaos first');
+    }
+    w.chaosUtils.disableGroup?.(n);
+  }, name);
+}
+
+/**
  * Read the PRNG seed used by the active chaos instance. Log this on test
  * failure to replay the exact sequence of chaos decisions with a fixed seed.
  */
@@ -168,6 +198,12 @@ export function registerChaosCommands(browser: ChaosBrowser): void {
   });
   browser.addCommand('getChaosSeed', async function (this: ChaosBrowser) {
     return getChaosSeed(this);
+  });
+  browser.addCommand('enableGroup', async function (this: ChaosBrowser, ...args: unknown[]) {
+    await enableGroup(this, args[0] as string);
+  });
+  browser.addCommand('disableGroup', async function (this: ChaosBrowser, ...args: unknown[]) {
+    await disableGroup(this, args[0] as string);
   });
 }
 
@@ -208,5 +244,7 @@ export {
   getSWChaosLog,
   getSWChaosLogFromSW,
   registerSWChaosCommands,
+  enableSWGroup,
+  disableSWGroup,
 } from './sw';
 export type { SWChaosOptions, InjectSWChaosResult } from './sw';

--- a/packages/webdriverio/src/sw.ts
+++ b/packages/webdriverio/src/sw.ts
@@ -14,6 +14,8 @@ export interface InjectSWChaosResult {
   seed: number | null;
 }
 
+const DEFAULT_SW_TOGGLE_TIMEOUT = 2_000;
+
 /**
  * Inject chaos into the active page's Service Worker.
  *
@@ -96,7 +98,11 @@ export async function enableSWGroup(
   name: string,
   opts: SWChaosOptions = {},
 ): Promise<void> {
-  await toggleSWGroup(browser, name, true, opts);
+  const nameNorm = String(name).trim();
+  if (!nameNorm) {
+    throw new Error('[chaos-maker] group name cannot be empty');
+  }
+  await toggleSWGroup(browser, nameNorm, true, opts);
 }
 
 /** Disable a rule group inside the active SW chaos engine. */
@@ -105,7 +111,11 @@ export async function disableSWGroup(
   name: string,
   opts: SWChaosOptions = {},
 ): Promise<void> {
-  await toggleSWGroup(browser, name, false, opts);
+  const nameNorm = String(name).trim();
+  if (!nameNorm) {
+    throw new Error('[chaos-maker] group name cannot be empty');
+  }
+  await toggleSWGroup(browser, nameNorm, false, opts);
 }
 
 async function toggleSWGroup(
@@ -114,7 +124,7 @@ async function toggleSWGroup(
   enabled: boolean,
   opts: SWChaosOptions,
 ): Promise<void> {
-  const timeoutMs = opts.timeoutMs ?? 2_000;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_SW_TOGGLE_TIMEOUT;
   await browser.execute((src: string) => {
     const w = window as unknown as { __chaosMakerSWBridgeInstalled?: boolean };
     if (w.__chaosMakerSWBridgeInstalled) return;

--- a/packages/webdriverio/src/sw.ts
+++ b/packages/webdriverio/src/sw.ts
@@ -98,7 +98,10 @@ export async function enableSWGroup(
   name: string,
   opts: SWChaosOptions = {},
 ): Promise<void> {
-  const nameNorm = String(name).trim();
+  if (typeof name !== 'string') {
+    throw new Error('[chaos-maker] group name must be a string');
+  }
+  const nameNorm = name.trim();
   if (!nameNorm) {
     throw new Error('[chaos-maker] group name cannot be empty');
   }
@@ -111,7 +114,10 @@ export async function disableSWGroup(
   name: string,
   opts: SWChaosOptions = {},
 ): Promise<void> {
-  const nameNorm = String(name).trim();
+  if (typeof name !== 'string') {
+    throw new Error('[chaos-maker] group name must be a string');
+  }
+  const nameNorm = name.trim();
   if (!nameNorm) {
     throw new Error('[chaos-maker] group name cannot be empty');
   }

--- a/packages/webdriverio/src/sw.ts
+++ b/packages/webdriverio/src/sw.ts
@@ -86,6 +86,60 @@ export async function removeSWChaos(browser: ChaosBrowser, opts: SWChaosOptions 
   }
 }
 
+/**
+ * Enable a rule group inside the active SW chaos engine. Posts
+ * `__chaosMakerToggleGroup` over MessageChannel and resolves only after the SW
+ * acks. Engine state and request counters are preserved (no restart).
+ */
+export async function enableSWGroup(
+  browser: ChaosBrowser,
+  name: string,
+  opts: SWChaosOptions = {},
+): Promise<void> {
+  await toggleSWGroup(browser, name, true, opts);
+}
+
+/** Disable a rule group inside the active SW chaos engine. */
+export async function disableSWGroup(
+  browser: ChaosBrowser,
+  name: string,
+  opts: SWChaosOptions = {},
+): Promise<void> {
+  await toggleSWGroup(browser, name, false, opts);
+}
+
+async function toggleSWGroup(
+  browser: ChaosBrowser,
+  name: string,
+  enabled: boolean,
+  opts: SWChaosOptions,
+): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? 2_000;
+  await browser.execute((src: string) => {
+    const w = window as unknown as { __chaosMakerSWBridgeInstalled?: boolean };
+    if (w.__chaosMakerSWBridgeInstalled) return;
+    const script = document.createElement('script');
+    script.textContent = src;
+    (document.head || document.documentElement).appendChild(script);
+    script.remove();
+  }, SW_BRIDGE_SOURCE);
+
+  await browser.execute(
+    async (n: string, e: boolean, t: number) => {
+      const bridge = (window as unknown as {
+        __chaosMakerSWBridge?: {
+          toggleGroup: (n: string, e: boolean, t: number) => Promise<unknown>;
+        };
+      }).__chaosMakerSWBridge;
+      if (!bridge) throw new Error('[chaos-maker] SW bridge missing — install failed');
+      await bridge.toggleGroup(n, e, t);
+    },
+    name,
+    enabled,
+    timeoutMs,
+  );
+}
+
 /** Read SW chaos events buffered on the page side. */
 export async function getSWChaosLog(browser: ChaosBrowser): Promise<ChaosEvent[]> {
   return browser.execute(() => {
@@ -134,5 +188,11 @@ export function registerSWChaosCommands(browser: ChaosBrowser): void {
   });
   browser.addCommand('getSWChaosLogFromSW', async function (this: ChaosBrowser, ...args: unknown[]) {
     return getSWChaosLogFromSW(this, args[0] as SWChaosOptions | undefined);
+  });
+  browser.addCommand('enableSWGroup', async function (this: ChaosBrowser, ...args: unknown[]) {
+    await enableSWGroup(this, args[0] as string, args[1] as SWChaosOptions | undefined);
+  });
+  browser.addCommand('disableSWGroup', async function (this: ChaosBrowser, ...args: unknown[]) {
+    await disableSWGroup(this, args[0] as string, args[1] as SWChaosOptions | undefined);
   });
 }

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -13,6 +13,10 @@ declare global {
       removeSWChaos(options?: SWChaosOptions): Promise<void>;
       getSWChaosLog(): Promise<ChaosEvent[]>;
       getSWChaosLogFromSW(options?: SWChaosOptions): Promise<ChaosEvent[]>;
+      enableGroup(name: string): Promise<void>;
+      disableGroup(name: string): Promise<void>;
+      enableSWGroup(name: string, options?: SWChaosOptions): Promise<void>;
+      disableSWGroup(name: string, options?: SWChaosOptions): Promise<void>;
     }
   }
 }


### PR DESCRIPTION
## Summary

Phase B of RFC-001 (Rule Groups). Plan: [can-you-take-a-cozy-hopper.md](https://github.com/chaos-maker-dev/chaos-maker/issues/45).

- core: `chaosUtils` gains `enableGroup` / `disableGroup` / `createGroup` / `getGroupState` proxies; SW bridge gains `toggleGroup(name, enabled, timeoutMs)` posting `__chaosMakerToggleGroup` with awaited MessageChannel ack.
- All four adapters expose paired page-side and SW-side toggle helpers, all returning `Promise<void>` and resolving only after their respective ack:
  - playwright: `enableGroup` / `disableGroup` / `enableSWGroup` / `disableSWGroup`, plus matching fixture surface.
  - cypress: `cy.enableGroup` / `cy.disableGroup` / `cy.enableSWGroup` / `cy.disableSWGroup`, with Chainable type augmentation.
  - puppeteer: `enableGroup` / `disableGroup` / `enableSWGroup` / `disableSWGroup`.
  - webdriverio: standalone helpers + `browser.enableGroup` / `disableGroup` / `enableSWGroup` / `disableSWGroup` commands and ambient typings.
- SW handler reuses Phase A's `state.groups.setEnabled(...)` path; engine state and request counters survive a toggle (no `startEngine` / `stopEngine`).
- Adapter helpers default the SW ack `timeoutMs` to `2000` (override via `SWChaosOptions`).

## Test plan

- [x] `pnpm lint`
- [x] `pnpm -r build`
- [x] `pnpm test` (354 unit tests pass)
- [x] `pnpm --filter e2e-tests-playwright test --project=chromium` (81/81 pass; existing specs unaffected)
- [ ] Phase C will add `rule-groups.spec.ts` to every adapter, exercising the toggle round-trip end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic group management: create, enable, disable, and query named rule groups at runtime from pages, tests, and service workers.
  * Page↔Service-Worker group toggles with acknowledgement and configurable timeout.
  * New test helpers/commands across Cypress, Playwright, Puppeteer, and WebdriverIO to control groups from tests.

* **Documentation**
  * WebdriverIO docs updated to include the new enable/disable group commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->