### PR TITLE
[v0.5.0] Rule Groups Tests + Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - Unreleased
+
+### Added
+
+- Rule Groups adapter coverage: Playwright, Puppeteer, WebdriverIO, and Cypress now have matching package-level tests for browser-side toggles, default-group behavior, multiple groups, Service Worker group toggles, invalid names, and adapter parity.
+- Rule Groups documentation: the root README and adapter READMEs now cover creating groups, runtime toggles, Service Worker toggles, multiple-group examples, and troubleshooting.
+
 ## [0.4.0] - 2026-04-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ test('shows error state when payment API fails', async ({ page }) => {
 | Service Worker fetch | Yes | Yes | Yes | Yes |
 | Server-Sent Events | Yes | Yes | Yes | Yes |
 | GraphQL operation matcher | Yes | Yes | Yes | Yes |
+| Rule Groups | Yes | Yes | Yes | Yes |
 
 ## Service Worker chaos
 
@@ -63,6 +64,72 @@ importScripts('/chaos-maker-sw.js');
 ```
 
 Page-side: `injectSWChaos` / `removeSWChaos` / `getSWChaosLog` in each adapter. See adapter READMEs.
+
+## Rule Groups
+
+Group related rules so a test can turn a whole failure scenario on or off at runtime without restarting chaos.
+
+### Creating Groups
+
+```ts
+import { ChaosConfigBuilder } from '@chaos-maker/core';
+
+const chaos = new ChaosConfigBuilder()
+  .inGroup("payments")
+  .failRequests("/api/pay", 503, 1)
+  .build();
+```
+
+Rules without `.inGroup()` stay in the default group and continue to work as before.
+
+### Runtime Toggle
+
+The examples below use `page` as a generic adapter handle. See each adapter README for exact syntax.
+
+```ts
+await page.enableGroup("payments");
+await page.disableGroup("payments");
+```
+
+Browser-side toggles affect rules injected into the page with `injectChaos`.
+
+### Service Worker Toggle
+
+```ts
+await page.enableSWGroup("payments");
+await page.disableSWGroup("payments");
+```
+
+Service Worker toggles affect rules injected into the active Service Worker with `injectSWChaos`. Browser-side and SW-side toggles are separate because they run in different JavaScript contexts. If a group has rules in both places, toggle both explicitly.
+
+### Multiple Groups Example
+
+```ts
+import { ChaosConfigBuilder } from '@chaos-maker/core';
+
+const chaos = new ChaosConfigBuilder()
+  .inGroup("payments")
+  .failRequests("/api/pay", 503, 1)
+  .inGroup("auth")
+  .failRequests("/api/session", 401, 1)
+  .inGroup("analytics")
+  .addLatency("/api/events", 750, 1)
+  .build();
+
+await injectChaos(page, chaos);
+
+await page.disableGroup("payments");
+await page.enableGroup("auth");
+await page.enableGroup("analytics");
+```
+
+In this state, payment failures are skipped, auth failures run, and analytics latency runs.
+
+### Troubleshooting
+
+- Group not working: confirm the rule was created with `.inGroup("name")` or `group: "name"`, and confirm you awaited the toggle before triggering the request.
+- Group name errors: group names must be strings after trimming. Empty strings, whitespace-only strings, and `null` throw.
+- SW toggling issues: call `injectSWChaos` after the page has an active Service Worker controller, and use `enableSWGroup` or `disableSWGroup` for SW rules. Page-side `enableGroup` does not toggle SW rules.
 
 ## SSE and GraphQL
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,7 +48,7 @@ export default [
   },
   {
     // Configuration for test files
-    files: ["**/*.test.ts"],
+    files: ["**/*.test.ts", "packages/*/test/**/*.spec.ts"],
     plugins: {
       vitest,
     },

--- a/packages/cypress/README.md
+++ b/packages/cypress/README.md
@@ -34,7 +34,7 @@ Register the custom commands in `cypress/support/e2e.ts`:
 import '@chaos-maker/cypress/support';
 ```
 
-That's it. Every spec now has `cy.injectChaos`, `cy.removeChaos`, `cy.getChaosLog`, `cy.getChaosSeed`, and the Service Worker helpers.
+That's it. Every spec now has `cy.injectChaos`, `cy.removeChaos`, `cy.getChaosLog`, `cy.getChaosSeed`, `cy.enableGroup`, `cy.disableGroup`, and the Service Worker helpers including `cy.enableSWGroup` and `cy.disableSWGroup`.
 
 ## Usage
 
@@ -84,6 +84,37 @@ it('checkout handles combined chaos', () => {
   cy.visit('/checkout');
 });
 ```
+
+### Rule Groups
+
+Use Rule Groups to switch related chaos rules on or off during a test.
+
+```ts
+import { ChaosConfigBuilder } from '@chaos-maker/core';
+
+it('toggles payment chaos', () => {
+  const config = new ChaosConfigBuilder()
+    .defineGroup('payments', { enabled: false })
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .build();
+
+  cy.injectChaos(config);
+  cy.visit('/checkout');
+
+  cy.enableGroup('payments');
+  cy.disableGroup('payments');
+});
+```
+
+For Service Worker rules, use the SW commands after `cy.injectSWChaos`:
+
+```ts
+cy.enableSWGroup('payments');
+cy.disableSWGroup('payments');
+```
+
+Browser-side `cy.enableGroup` and `cy.disableGroup` affect page rules from `cy.injectChaos`. `cy.enableSWGroup` and `cy.disableSWGroup` affect Service Worker rules from `cy.injectSWChaos`.
 
 ### Reproducing failures with a seed
 
@@ -145,6 +176,14 @@ Resolve to the chaos event log — every chaos check since injection, with `appl
 
 Resolve to the PRNG seed used by the current chaos instance, or `null` when chaos is not active. Log this on failure to replay the exact sequence of chaos decisions deterministically.
 
+### `cy.enableGroup(name)` / `cy.disableGroup(name)`
+
+Toggle a browser-side Rule Group at runtime.
+
+### `cy.enableSWGroup(name, options?)` / `cy.disableSWGroup(name, options?)`
+
+Toggle a Service Worker Rule Group at runtime. Pass `options.timeoutMs` to override the Service Worker acknowledgement timeout.
+
 ## How it works
 
 - The plugin-side `chaos:getUmdSource` task (registered by `registerChaosTasks`) reads the `@chaos-maker/core` UMD bundle from disk via `require.resolve`. It runs once per spec; the result is cached in the Node process.
@@ -182,13 +221,18 @@ it('SW fetch fails', () => {
     expect(win.navigator.serviceWorker.controller).to.not.be.null;
   });
   cy.injectSWChaos({
-    network: { failures: [{ urlPattern: '/api/data', statusCode: 503, probability: 1 }] },
+    groups: [{ name: 'payments', enabled: false }],
+    network: {
+      failures: [{ urlPattern: '/api/data', statusCode: 503, probability: 1, group: 'payments' }],
+    },
     seed: 1,
   });
+  cy.enableSWGroup('payments');
   cy.get('#trigger').click();
   cy.getSWChaosLog().should((log) => {
     expect(log.some((e) => e.type === 'network:failure' && e.applied)).to.be.true;
   });
+  cy.disableSWGroup('payments');
   cy.removeSWChaos();
 });
 ```

--- a/packages/cypress/test/rule-groups.spec.ts
+++ b/packages/cypress/test/rule-groups.spec.ts
@@ -23,8 +23,23 @@ type CommandMap = Record<string, (...args: unknown[]) => unknown>;
 const cleanups: Array<() => void> = [];
 
 afterEach(() => {
+  const errors: unknown[] = [];
+
   while (cleanups.length > 0) {
-    cleanups.pop()?.();
+    const cleanup = cleanups.pop();
+    try {
+      cleanup?.();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+
+  if (errors.length > 1) {
+    throw new AggregateError(errors, 'Cleanup failures');
   }
 });
 

--- a/packages/cypress/test/rule-groups.spec.ts
+++ b/packages/cypress/test/rule-groups.spec.ts
@@ -1,0 +1,251 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ChaosConfigBuilder, ChaosMaker } from '@chaos-maker/core';
+import type { ChaosConfig, ChaosEvent } from '@chaos-maker/core';
+import { registerChaosCommands } from '../src/commands';
+import { registerSWChaosCommands } from '../src/sw';
+
+type ChaosUtilsHarness = {
+  instance: ChaosMaker;
+  getLog: () => ChaosEvent[];
+  enableGroup: (name: string) => { success: boolean; message: string };
+  disableGroup: (name: string) => { success: boolean; message: string };
+};
+
+type Runtime = {
+  request: (url: string) => Promise<Response>;
+  log: () => ChaosEvent[];
+  cleanup: () => void;
+};
+
+type CommandMap = Record<string, (...args: unknown[]) => unknown>;
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) {
+    cleanups.pop()?.();
+  }
+});
+
+function configWithPaymentGroupInitiallyDisabled(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .defineGroup('payments', { enabled: false })
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .withSeed(1)
+    .build();
+}
+
+function configWithPaymentGroup(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .withSeed(1)
+    .build();
+}
+
+function configWithoutGroup(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .failRequests('/api/pay', 503, 1)
+    .withSeed(1)
+    .build();
+}
+
+function configWithMultipleGroups(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .inGroup('auth')
+    .failRequests('/api/auth', 401, 1)
+    .withSeed(1)
+    .build();
+}
+
+function makeUtils(instance: ChaosMaker): ChaosUtilsHarness {
+  return {
+    instance,
+    getLog: () => instance.getLog(),
+    enableGroup(name) {
+      try {
+        instance.enableGroup(name);
+        return { success: true, message: 'enabled' };
+      } catch (error) {
+        return { success: false, message: error instanceof Error ? error.message : String(error) };
+      }
+    },
+    disableGroup(name) {
+      try {
+        instance.disableGroup(name);
+        return { success: true, message: 'disabled' };
+      } catch (error) {
+        return { success: false, message: error instanceof Error ? error.message : String(error) };
+      }
+    },
+  };
+}
+
+function startRuntime(config: ChaosConfig): Runtime {
+  const previousChaosUtils = (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils;
+  const target = {
+    fetch: async () => new Response('ok', { status: 200 }),
+  } as unknown as typeof globalThis;
+  const instance = new ChaosMaker(config, { target });
+  instance.start();
+  (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils = makeUtils(instance);
+
+  return {
+    request: (url) => target.fetch(url),
+    log: () => instance.getLog(),
+    cleanup: () => {
+      instance.stop();
+      if (previousChaosUtils) {
+        (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils = previousChaosUtils;
+      } else {
+        delete (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils;
+      }
+    },
+  };
+}
+
+function startSWRuntime(config: ChaosConfig): Runtime {
+  const runtime = startRuntime(config);
+  const previousBridge = (globalThis as { __chaosMakerSWBridge?: unknown }).__chaosMakerSWBridge;
+  const utils = (globalThis as { chaosUtils: ChaosUtilsHarness }).chaosUtils;
+  (globalThis as {
+    __chaosMakerSWBridge?: { toggleGroup: (name: string, enabled: boolean, timeoutMs: number) => Promise<void> };
+  }).__chaosMakerSWBridge = {
+    async toggleGroup(name, enabled) {
+      if (enabled) {
+        utils.instance.enableGroup(name);
+      } else {
+        utils.instance.disableGroup(name);
+      }
+    },
+  };
+  cleanups.push(() => {
+    if (previousBridge) {
+      (globalThis as { __chaosMakerSWBridge?: unknown }).__chaosMakerSWBridge = previousBridge;
+    } else {
+      delete (globalThis as { __chaosMakerSWBridge?: unknown }).__chaosMakerSWBridge;
+    }
+  });
+  return runtime;
+}
+
+function track(runtime: Runtime): Runtime {
+  cleanups.push(runtime.cleanup);
+  return runtime;
+}
+
+function installCypressHarness(): CommandMap {
+  const commands: CommandMap = {};
+  const previousCypress = (globalThis as { Cypress?: unknown }).Cypress;
+  const previousCy = (globalThis as { cy?: unknown }).cy;
+  (globalThis as { Cypress?: unknown }).Cypress = {
+    Commands: {
+      add(name: string, fn: (...args: unknown[]) => unknown) {
+        commands[name] = fn;
+      },
+    },
+    Promise,
+    on: () => undefined,
+    off: () => undefined,
+  };
+  (globalThis as { cy?: unknown }).cy = {
+    task: () => ({ then: () => undefined }),
+    window: () => ({
+      then: (fn: (win: typeof globalThis) => unknown) => Promise.resolve(fn(globalThis)),
+    }),
+  };
+  cleanups.push(() => {
+    if (previousCypress) {
+      (globalThis as { Cypress?: unknown }).Cypress = previousCypress;
+    } else {
+      delete (globalThis as { Cypress?: unknown }).Cypress;
+    }
+    if (previousCy) {
+      (globalThis as { cy?: unknown }).cy = previousCy;
+    } else {
+      delete (globalThis as { cy?: unknown }).cy;
+    }
+  });
+  registerChaosCommands();
+  registerSWChaosCommands();
+  return commands;
+}
+
+function hasAppliedFailure(log: ChaosEvent[], statusCode: number): boolean {
+  return log.some(
+    (event) => event.type === 'network:failure' && event.applied && event.detail.statusCode === statusCode,
+  );
+}
+
+describe('@chaos-maker/cypress rule groups', () => {
+  it('enable group executes grouped rule', async () => {
+    const commands = installCypressHarness();
+    const runtime = track(startRuntime(configWithPaymentGroupInitiallyDisabled()));
+
+    commands.enableGroup('payments');
+    const response = await runtime.request('/api/pay');
+
+    expect(response.status).toBe(503);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+  });
+
+  it('disable group skips grouped rule', async () => {
+    const commands = installCypressHarness();
+    const runtime = track(startRuntime(configWithPaymentGroup()));
+
+    commands.disableGroup('payments');
+    const response = await runtime.request('/api/pay');
+
+    expect(response.status).toBe(200);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+  });
+
+  it('rules without inGroup still execute through the default group', async () => {
+    installCypressHarness();
+    const runtime = track(startRuntime(configWithoutGroup()));
+
+    const response = await runtime.request('/api/pay');
+
+    expect(response.status).toBe(503);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+  });
+
+  it('multiple groups only apply enabled groups', async () => {
+    const commands = installCypressHarness();
+    const runtime = track(startRuntime(configWithMultipleGroups()));
+
+    commands.disableGroup('payments');
+    const payments = await runtime.request('/api/pay');
+    const auth = await runtime.request('/api/auth');
+
+    expect(payments.status).toBe(200);
+    expect(auth.status).toBe(401);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+    expect(hasAppliedFailure(runtime.log(), 401)).toBe(true);
+  });
+
+  it('enableSWGroup enables grouped Service Worker chaos', async () => {
+    const commands = installCypressHarness();
+    const runtime = track(startSWRuntime(configWithPaymentGroupInitiallyDisabled()));
+
+    const before = await runtime.request('/api/pay');
+    await commands.enableSWGroup('payments');
+    const after = await runtime.request('/api/pay');
+
+    expect(before.status).toBe(200);
+    expect(after.status).toBe(503);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+  });
+
+  it('invalid group names throw errors before window access', async () => {
+    const commands = installCypressHarness();
+
+    expect(() => commands.enableGroup('')).toThrow('[chaos-maker] group name cannot be empty');
+    expect(() => commands.enableGroup(null as unknown as string)).toThrow(
+      '[chaos-maker] group name must be a string',
+    );
+  });
+});

--- a/packages/cypress/test/rule-groups.spec.ts
+++ b/packages/cypress/test/rule-groups.spec.ts
@@ -9,6 +9,7 @@ type ChaosUtilsHarness = {
   getLog: () => ChaosEvent[];
   enableGroup: (name: string) => { success: boolean; message: string };
   disableGroup: (name: string) => { success: boolean; message: string };
+  getGroupState: (name: string) => boolean | null;
 };
 
 type Runtime = {
@@ -61,6 +62,18 @@ function configWithMultipleGroups(): ChaosConfig {
     .build();
 }
 
+function configWithMixedGroupStates(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .defineGroup('payments', { enabled: false })
+    .defineGroup('auth', { enabled: true })
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .inGroup('auth')
+    .failRequests('/api/auth', 401, 1)
+    .withSeed(1)
+    .build();
+}
+
 function makeUtils(instance: ChaosMaker): ChaosUtilsHarness {
   return {
     instance,
@@ -81,6 +94,7 @@ function makeUtils(instance: ChaosMaker): ChaosUtilsHarness {
         return { success: false, message: error instanceof Error ? error.message : String(error) };
       }
     },
+    getGroupState: (name) => instance.getGroupState(name),
   };
 }
 
@@ -180,6 +194,20 @@ function hasAppliedFailure(log: ChaosEvent[], statusCode: number): boolean {
   );
 }
 
+function countAppliedFailures(log: ChaosEvent[], statusCode: number): number {
+  return log.filter(
+    (event) => event.type === 'network:failure' && event.applied && event.detail.statusCode === statusCode,
+  ).length;
+}
+
+function readGroupState(name: string): { hasGroup: boolean; enabled: boolean | null } {
+  const utils = (globalThis as { chaosUtils: ChaosUtilsHarness }).chaosUtils;
+  return {
+    hasGroup: utils.instance.hasGroup(name),
+    enabled: utils.getGroupState(name),
+  };
+}
+
 describe('@chaos-maker/cypress rule groups', () => {
   it('enable group executes grouped rule', async () => {
     const commands = installCypressHarness();
@@ -201,6 +229,20 @@ describe('@chaos-maker/cypress rule groups', () => {
 
     expect(response.status).toBe(200);
     expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+  });
+
+  it('enable then disable group changes real fetch behavior', async () => {
+    const commands = installCypressHarness();
+    const runtime = track(startRuntime(configWithPaymentGroupInitiallyDisabled()));
+
+    commands.enableGroup('payments');
+    const enabled = await runtime.request('/api/pay');
+    commands.disableGroup('payments');
+    const disabled = await runtime.request('/api/pay');
+
+    expect(enabled.status).toBe(503);
+    expect(disabled.status).toBe(200);
+    expect(countAppliedFailures(runtime.log(), 503)).toBe(1);
   });
 
   it('rules without inGroup still execute through the default group', async () => {
@@ -227,17 +269,47 @@ describe('@chaos-maker/cypress rule groups', () => {
     expect(hasAppliedFailure(runtime.log(), 401)).toBe(true);
   });
 
+  it('multiple groups can enable one group while disabling another', async () => {
+    const commands = installCypressHarness();
+    const runtime = track(startRuntime(configWithMixedGroupStates()));
+
+    commands.enableGroup('payments');
+    commands.disableGroup('auth');
+    const payments = await runtime.request('/api/pay');
+    const auth = await runtime.request('/api/auth');
+
+    expect(payments.status).toBe(503);
+    expect(auth.status).toBe(200);
+    expect(countAppliedFailures(runtime.log(), 503)).toBe(1);
+    expect(countAppliedFailures(runtime.log(), 401)).toBe(0);
+  });
+
+  it('enableGroup auto-registers a non-existent group as enabled', () => {
+    const commands = installCypressHarness();
+    track(startRuntime(configWithoutGroup()));
+
+    commands.enableGroup('non-existent-group');
+
+    expect(readGroupState('non-existent-group')).toEqual({
+      hasGroup: true,
+      enabled: true,
+    });
+  });
+
   it('enableSWGroup enables grouped Service Worker chaos', async () => {
     const commands = installCypressHarness();
     const runtime = track(startSWRuntime(configWithPaymentGroupInitiallyDisabled()));
 
     const before = await runtime.request('/api/pay');
     await commands.enableSWGroup('payments');
-    const after = await runtime.request('/api/pay');
+    const afterEnable = await runtime.request('/api/pay');
+    await commands.disableSWGroup('payments');
+    const afterDisable = await runtime.request('/api/pay');
 
     expect(before.status).toBe(200);
-    expect(after.status).toBe(503);
-    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+    expect(afterEnable.status).toBe(503);
+    expect(afterDisable.status).toBe(200);
+    expect(countAppliedFailures(runtime.log(), 503)).toBe(1);
   });
 
   it('invalid group names throw errors before window access', async () => {
@@ -245,6 +317,10 @@ describe('@chaos-maker/cypress rule groups', () => {
 
     expect(() => commands.enableGroup('')).toThrow('[chaos-maker] group name cannot be empty');
     expect(() => commands.enableGroup(null as unknown as string)).toThrow(
+      '[chaos-maker] group name must be a string',
+    );
+    expect(() => commands.disableGroup('')).toThrow('[chaos-maker] group name cannot be empty');
+    expect(() => commands.disableGroup(null as unknown as string)).toThrow(
       '[chaos-maker] group name must be a string',
     );
   });

--- a/packages/cypress/test/rule-groups.spec.ts
+++ b/packages/cypress/test/rule-groups.spec.ts
@@ -129,6 +129,7 @@ function startSWRuntime(config: ChaosConfig): Runtime {
     __chaosMakerSWBridge?: { toggleGroup: (name: string, enabled: boolean, timeoutMs: number) => Promise<void> };
   }).__chaosMakerSWBridge = {
     async toggleGroup(name, enabled) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
       if (enabled) {
         utils.instance.enableGroup(name);
       } else {
@@ -229,6 +230,7 @@ describe('@chaos-maker/cypress rule groups', () => {
 
     expect(response.status).toBe(200);
     expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+    expect(runtime.log().some((event) => event.type === 'rule-group:gated')).toBe(true);
   });
 
   it('enable then disable group changes real fetch behavior', async () => {
@@ -293,6 +295,18 @@ describe('@chaos-maker/cypress rule groups', () => {
     expect(readGroupState('non-existent-group')).toEqual({
       hasGroup: true,
       enabled: true,
+    });
+  });
+
+  it('disableGroup auto-registers a non-existent group as disabled', () => {
+    const commands = installCypressHarness();
+    track(startRuntime(configWithoutGroup()));
+
+    commands.disableGroup('ghost-group');
+
+    expect(readGroupState('ghost-group')).toEqual({
+      hasGroup: true,
+      enabled: false,
     });
   });
 

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -90,6 +90,49 @@ test('checkout handles combined chaos', async ({ page }) => {
 });
 ```
 
+### Rule Groups
+
+Use Rule Groups to toggle a set of rules during a test without reinjecting chaos.
+
+```ts
+import { test, expect } from '@playwright/test';
+import { ChaosConfigBuilder } from '@chaos-maker/core';
+import {
+  injectChaos,
+  enableGroup,
+  disableGroup,
+  enableSWGroup,
+  disableSWGroup,
+} from '@chaos-maker/playwright';
+
+test('toggles checkout chaos', async ({ page }) => {
+  const config = new ChaosConfigBuilder()
+    .defineGroup('payments', { enabled: false })
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .build();
+
+  await injectChaos(page, config);
+  await page.goto('/checkout');
+
+  await enableGroup(page, 'payments');
+  await expect(page.getByText('Try again')).toBeVisible();
+
+  await disableGroup(page, 'payments');
+});
+```
+
+With the fixture, the same helpers are available as `chaos.enableGroup(name)` and `chaos.disableGroup(name)`.
+
+For Service Worker rules, use the SW helpers after `injectSWChaos`:
+
+```ts
+await enableSWGroup(page, 'payments');
+await disableSWGroup(page, 'payments');
+```
+
+Browser-side `enableGroup` and `disableGroup` affect page rules from `injectChaos`. `enableSWGroup` and `disableSWGroup` affect Service Worker rules from `injectSWChaos`.
+
 ### SSE and GraphQL
 
 ```ts
@@ -133,6 +176,14 @@ Stop chaos and restore original `fetch`/`XHR`/DOM behavior.
 
 Retrieve the chaos event log from the page. Returns `ChaosEvent[]` — every chaos check emitted since injection, with `applied: true/false`.
 
+### `enableGroup(page, name)` / `disableGroup(page, name)`
+
+Toggle a browser-side Rule Group at runtime.
+
+### `enableSWGroup(page, name, opts?)` / `disableSWGroup(page, name, opts?)`
+
+Toggle a Service Worker Rule Group at runtime. Pass `opts.timeoutMs` to override the Service Worker acknowledgement timeout.
+
 ### Fixture: `chaos`
 
 Available when importing `test` from `@chaos-maker/playwright/fixture`:
@@ -140,6 +191,10 @@ Available when importing `test` from `@chaos-maker/playwright/fixture`:
 - `chaos.inject(config)` — same as `injectChaos(page, config)`
 - `chaos.remove()` — same as `removeChaos(page)` (also called automatically after each test)
 - `chaos.getLog()` — same as `getChaosLog(page)`
+- `chaos.enableGroup(name)` — same as `enableGroup(page, name)`
+- `chaos.disableGroup(name)` — same as `disableGroup(page, name)`
+- `chaos.enableSWGroup(name, opts?)` — same as `enableSWGroup(page, name, opts)`
+- `chaos.disableSWGroup(name, opts?)` — same as `disableSWGroup(page, name, opts)`
 
 ## Debugging with trace
 
@@ -199,18 +254,29 @@ importScripts('/chaos-maker-sw.js');
 ```
 
 ```ts
-import { injectSWChaos, removeSWChaos, getSWChaosLog } from '@chaos-maker/playwright';
+import {
+  injectSWChaos,
+  removeSWChaos,
+  getSWChaosLog,
+  enableSWGroup,
+  disableSWGroup,
+} from '@chaos-maker/playwright';
 
 test('SW-fetched /api returns 503', async ({ page }) => {
   await page.goto('/app-with-sw/');
   // wait for controller after your app's SW registration
   await injectSWChaos(page, {
-    network: { failures: [{ urlPattern: '/api/data', statusCode: 503, probability: 1 }] },
+    groups: [{ name: 'payments', enabled: false }],
+    network: {
+      failures: [{ urlPattern: '/api/data', statusCode: 503, probability: 1, group: 'payments' }],
+    },
     seed: 1,
   });
+  await enableSWGroup(page, 'payments');
   await page.click('#trigger');
   const log = await getSWChaosLog(page);
   expect(log.some(e => e.type === 'network:failure' && e.applied)).toBe(true);
+  await disableSWGroup(page, 'payments');
   await removeSWChaos(page);
 });
 ```

--- a/packages/playwright/test/rule-groups.spec.ts
+++ b/packages/playwright/test/rule-groups.spec.ts
@@ -120,6 +120,7 @@ function startSWRuntime(config: ChaosConfig): Runtime {
     __chaosMakerSWBridge?: { toggleGroup: (name: string, enabled: boolean, timeoutMs: number) => Promise<void> };
   }).__chaosMakerSWBridge = {
     async toggleGroup(name, enabled) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
       if (enabled) {
         utils.instance.enableGroup(name);
       } else {
@@ -197,6 +198,7 @@ describe('@chaos-maker/playwright rule groups', () => {
 
     expect(response.status).toBe(200);
     expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+    expect(runtime.log().some((event) => event.type === 'rule-group:gated')).toBe(true);
   });
 
   it('enable then disable group changes real fetch behavior', async () => {
@@ -245,6 +247,18 @@ describe('@chaos-maker/playwright rule groups', () => {
     expect(await readPageGroupState(page, 'non-existent-group')).toEqual({
       hasGroup: true,
       enabled: true,
+    });
+  });
+
+  it('disableGroup auto-registers a non-existent group as disabled', async () => {
+    const page = makePage();
+    track(startRuntime(configWithoutGroup()));
+
+    await disableGroup(page, 'ghost-group');
+
+    expect(await readPageGroupState(page, 'ghost-group')).toEqual({
+      hasGroup: true,
+      enabled: false,
     });
   });
 

--- a/packages/playwright/test/rule-groups.spec.ts
+++ b/packages/playwright/test/rule-groups.spec.ts
@@ -26,8 +26,23 @@ type Runtime = {
 const cleanups: Array<() => void> = [];
 
 afterEach(() => {
+  const errors: unknown[] = [];
+
   while (cleanups.length > 0) {
-    cleanups.pop()?.();
+    const cleanup = cleanups.pop();
+    try {
+      cleanup?.();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+
+  if (errors.length > 1) {
+    throw new AggregateError(errors, 'Cleanup failures');
   }
 });
 

--- a/packages/playwright/test/rule-groups.spec.ts
+++ b/packages/playwright/test/rule-groups.spec.ts
@@ -1,0 +1,227 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ChaosConfigBuilder, ChaosMaker } from '@chaos-maker/core';
+import type { ChaosConfig, ChaosEvent } from '@chaos-maker/core';
+import type { Page } from '@playwright/test';
+import {
+  enableGroup,
+  disableGroup,
+  enableSWGroup,
+} from '../src/index';
+
+type ChaosUtilsHarness = {
+  instance: ChaosMaker;
+  getLog: () => ChaosEvent[];
+  enableGroup: (name: string) => { success: boolean; message: string };
+  disableGroup: (name: string) => { success: boolean; message: string };
+};
+
+type Runtime = {
+  request: (url: string) => Promise<Response>;
+  log: () => ChaosEvent[];
+  cleanup: () => void;
+};
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) {
+    cleanups.pop()?.();
+  }
+});
+
+function configWithPaymentGroupInitiallyDisabled(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .defineGroup('payments', { enabled: false })
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .withSeed(1)
+    .build();
+}
+
+function configWithPaymentGroup(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .withSeed(1)
+    .build();
+}
+
+function configWithoutGroup(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .failRequests('/api/pay', 503, 1)
+    .withSeed(1)
+    .build();
+}
+
+function configWithMultipleGroups(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .inGroup('auth')
+    .failRequests('/api/auth', 401, 1)
+    .withSeed(1)
+    .build();
+}
+
+function makeUtils(instance: ChaosMaker): ChaosUtilsHarness {
+  return {
+    instance,
+    getLog: () => instance.getLog(),
+    enableGroup(name) {
+      try {
+        instance.enableGroup(name);
+        return { success: true, message: 'enabled' };
+      } catch (error) {
+        return { success: false, message: error instanceof Error ? error.message : String(error) };
+      }
+    },
+    disableGroup(name) {
+      try {
+        instance.disableGroup(name);
+        return { success: true, message: 'disabled' };
+      } catch (error) {
+        return { success: false, message: error instanceof Error ? error.message : String(error) };
+      }
+    },
+  };
+}
+
+function startRuntime(config: ChaosConfig): Runtime {
+  const previousChaosUtils = (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils;
+  const target = {
+    fetch: async () => new Response('ok', { status: 200 }),
+  } as unknown as typeof globalThis;
+  const instance = new ChaosMaker(config, { target });
+  instance.start();
+  (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils = makeUtils(instance);
+
+  return {
+    request: (url) => target.fetch(url),
+    log: () => instance.getLog(),
+    cleanup: () => {
+      instance.stop();
+      if (previousChaosUtils) {
+        (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils = previousChaosUtils;
+      } else {
+        delete (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils;
+      }
+    },
+  };
+}
+
+function startSWRuntime(config: ChaosConfig): Runtime {
+  const runtime = startRuntime(config);
+  const previousBridge = (globalThis as { __chaosMakerSWBridge?: unknown }).__chaosMakerSWBridge;
+  const utils = (globalThis as { chaosUtils: ChaosUtilsHarness }).chaosUtils;
+  (globalThis as {
+    __chaosMakerSWBridge?: { toggleGroup: (name: string, enabled: boolean, timeoutMs: number) => Promise<void> };
+  }).__chaosMakerSWBridge = {
+    async toggleGroup(name, enabled) {
+      if (enabled) {
+        utils.instance.enableGroup(name);
+      } else {
+        utils.instance.disableGroup(name);
+      }
+    },
+  };
+  cleanups.push(() => {
+    if (previousBridge) {
+      (globalThis as { __chaosMakerSWBridge?: unknown }).__chaosMakerSWBridge = previousBridge;
+    } else {
+      delete (globalThis as { __chaosMakerSWBridge?: unknown }).__chaosMakerSWBridge;
+    }
+  });
+  return runtime;
+}
+
+function track(runtime: Runtime): Runtime {
+  cleanups.push(runtime.cleanup);
+  return runtime;
+}
+
+function makePage(): Page {
+  return {
+    addInitScript: async () => undefined,
+    evaluate: async (fn: unknown, arg?: unknown) => {
+      if (typeof fn === 'function') {
+        return (fn as (arg?: unknown) => unknown)(arg) as never;
+      }
+      return undefined as never;
+    },
+  } as unknown as Page;
+}
+
+function hasAppliedFailure(log: ChaosEvent[], statusCode: number): boolean {
+  return log.some(
+    (event) => event.type === 'network:failure' && event.applied && event.detail.statusCode === statusCode,
+  );
+}
+
+describe('@chaos-maker/playwright rule groups', () => {
+  it('enable group executes grouped rule', async () => {
+    const page = makePage();
+    const runtime = track(startRuntime(configWithPaymentGroupInitiallyDisabled()));
+
+    await enableGroup(page, 'payments');
+    const response = await runtime.request('/api/pay');
+
+    expect(response.status).toBe(503);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+  });
+
+  it('disable group skips grouped rule', async () => {
+    const page = makePage();
+    const runtime = track(startRuntime(configWithPaymentGroup()));
+
+    await disableGroup(page, 'payments');
+    const response = await runtime.request('/api/pay');
+
+    expect(response.status).toBe(200);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+  });
+
+  it('rules without inGroup still execute through the default group', async () => {
+    const runtime = track(startRuntime(configWithoutGroup()));
+
+    const response = await runtime.request('/api/pay');
+
+    expect(response.status).toBe(503);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+  });
+
+  it('multiple groups only apply enabled groups', async () => {
+    const page = makePage();
+    const runtime = track(startRuntime(configWithMultipleGroups()));
+
+    await disableGroup(page, 'payments');
+    const payments = await runtime.request('/api/pay');
+    const auth = await runtime.request('/api/auth');
+
+    expect(payments.status).toBe(200);
+    expect(auth.status).toBe(401);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+    expect(hasAppliedFailure(runtime.log(), 401)).toBe(true);
+  });
+
+  it('enableSWGroup enables grouped Service Worker chaos', async () => {
+    const page = makePage();
+    const runtime = track(startSWRuntime(configWithPaymentGroupInitiallyDisabled()));
+
+    const before = await runtime.request('/api/pay');
+    await enableSWGroup(page, 'payments');
+    const after = await runtime.request('/api/pay');
+
+    expect(before.status).toBe(200);
+    expect(after.status).toBe(503);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+  });
+
+  it('invalid group names throw errors before page evaluation', async () => {
+    const page = makePage();
+
+    await expect(enableGroup(page, '')).rejects.toThrow('[chaos-maker] group name cannot be empty');
+    await expect(enableGroup(page, null as unknown as string)).rejects.toThrow(
+      '[chaos-maker] group name must be a string',
+    );
+  });
+});

--- a/packages/playwright/test/rule-groups.spec.ts
+++ b/packages/playwright/test/rule-groups.spec.ts
@@ -6,6 +6,7 @@ import {
   enableGroup,
   disableGroup,
   enableSWGroup,
+  disableSWGroup,
 } from '../src/index';
 
 type ChaosUtilsHarness = {
@@ -13,6 +14,7 @@ type ChaosUtilsHarness = {
   getLog: () => ChaosEvent[];
   enableGroup: (name: string) => { success: boolean; message: string };
   disableGroup: (name: string) => { success: boolean; message: string };
+  getGroupState: (name: string) => boolean | null;
 };
 
 type Runtime = {
@@ -83,6 +85,7 @@ function makeUtils(instance: ChaosMaker): ChaosUtilsHarness {
         return { success: false, message: error instanceof Error ? error.message : String(error) };
       }
     },
+    getGroupState: (name) => instance.getGroupState(name),
   };
 }
 
@@ -157,6 +160,22 @@ function hasAppliedFailure(log: ChaosEvent[], statusCode: number): boolean {
   );
 }
 
+function countAppliedFailures(log: ChaosEvent[], statusCode: number): number {
+  return log.filter(
+    (event) => event.type === 'network:failure' && event.applied && event.detail.statusCode === statusCode,
+  ).length;
+}
+
+async function readPageGroupState(page: Page, name: string): Promise<{ hasGroup: boolean; enabled: boolean | null }> {
+  return page.evaluate(({ n }: { n: string }) => {
+    const utils = (globalThis as unknown as { chaosUtils?: ChaosUtilsHarness }).chaosUtils;
+    return {
+      hasGroup: utils?.instance.hasGroup(n) ?? false,
+      enabled: utils?.getGroupState(n) ?? null,
+    };
+  }, { n: name });
+}
+
 describe('@chaos-maker/playwright rule groups', () => {
   it('enable group executes grouped rule', async () => {
     const page = makePage();
@@ -178,6 +197,20 @@ describe('@chaos-maker/playwright rule groups', () => {
 
     expect(response.status).toBe(200);
     expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+  });
+
+  it('enable then disable group changes real fetch behavior', async () => {
+    const page = makePage();
+    const runtime = track(startRuntime(configWithPaymentGroupInitiallyDisabled()));
+
+    await enableGroup(page, 'payments');
+    const enabled = await runtime.request('/api/pay');
+    await disableGroup(page, 'payments');
+    const disabled = await runtime.request('/api/pay');
+
+    expect(enabled.status).toBe(503);
+    expect(disabled.status).toBe(200);
+    expect(countAppliedFailures(runtime.log(), 503)).toBe(1);
   });
 
   it('rules without inGroup still execute through the default group', async () => {
@@ -203,17 +236,43 @@ describe('@chaos-maker/playwright rule groups', () => {
     expect(hasAppliedFailure(runtime.log(), 401)).toBe(true);
   });
 
+  it('enableGroup auto-registers a non-existent group as enabled', async () => {
+    const page = makePage();
+    track(startRuntime(configWithoutGroup()));
+
+    await enableGroup(page, 'non-existent-group');
+
+    expect(await readPageGroupState(page, 'non-existent-group')).toEqual({
+      hasGroup: true,
+      enabled: true,
+    });
+  });
+
+  it('reflects group state through the page realm chaosUtils contract', async () => {
+    const page = makePage();
+    track(startRuntime(configWithPaymentGroupInitiallyDisabled()));
+
+    await enableGroup(page, 'payments');
+    expect((await readPageGroupState(page, 'payments')).enabled).toBe(true);
+
+    await disableGroup(page, 'payments');
+    expect((await readPageGroupState(page, 'payments')).enabled).toBe(false);
+  });
+
   it('enableSWGroup enables grouped Service Worker chaos', async () => {
     const page = makePage();
     const runtime = track(startSWRuntime(configWithPaymentGroupInitiallyDisabled()));
 
     const before = await runtime.request('/api/pay');
     await enableSWGroup(page, 'payments');
-    const after = await runtime.request('/api/pay');
+    const afterEnable = await runtime.request('/api/pay');
+    await disableSWGroup(page, 'payments');
+    const afterDisable = await runtime.request('/api/pay');
 
     expect(before.status).toBe(200);
-    expect(after.status).toBe(503);
-    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+    expect(afterEnable.status).toBe(503);
+    expect(afterDisable.status).toBe(200);
+    expect(countAppliedFailures(runtime.log(), 503)).toBe(1);
   });
 
   it('invalid group names throw errors before page evaluation', async () => {

--- a/packages/playwright/vitest.config.ts
+++ b/packages/playwright/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    include: ['test/**/*.test.ts'],
+    include: ['test/**/*.test.ts', 'test/**/*.spec.ts'],
   },
 });

--- a/packages/puppeteer/README.md
+++ b/packages/puppeteer/README.md
@@ -52,6 +52,27 @@ Returns the full event log (applied + skipped decisions) since `injectChaos` was
 
 Returns the PRNG seed used by the active chaos instance. Log this on test failure to replay the exact sequence.
 
+### `enableGroup(page, name)` / `disableGroup(page, name)`
+
+Enable or disable a browser-side Rule Group at runtime. The promise resolves after the page evaluates the toggle.
+
+```ts
+import { ChaosConfigBuilder } from '@chaos-maker/core';
+import { injectChaos, enableGroup, disableGroup } from '@chaos-maker/puppeteer';
+
+const config = new ChaosConfigBuilder()
+  .defineGroup('payments', { enabled: false })
+  .inGroup('payments')
+  .failRequests('/api/pay', 503, 1)
+  .build();
+
+await injectChaos(page, config);
+await page.goto('http://localhost:3000/checkout');
+
+await enableGroup(page, 'payments');
+await disableGroup(page, 'payments');
+```
+
 ### `useChaos(page, config)`
 
 Convenience helper for `afterEach`-style cleanup — injects chaos and returns an async teardown:
@@ -67,20 +88,33 @@ afterEach(() => teardown());
 ## Service Worker chaos
 
 ```ts
-import { injectSWChaos, removeSWChaos, getSWChaosLog } from '@chaos-maker/puppeteer';
+import {
+  injectSWChaos,
+  removeSWChaos,
+  getSWChaosLog,
+  enableSWGroup,
+  disableSWGroup,
+} from '@chaos-maker/puppeteer';
 
 await page.goto('http://localhost:3000/app-with-sw/');
 await page.waitForFunction(() => !!navigator.serviceWorker.controller);
 await injectSWChaos(page, {
-  network: { failures: [{ urlPattern: '/api/data', statusCode: 503, probability: 1 }] },
+  groups: [{ name: 'payments', enabled: false }],
+  network: {
+    failures: [{ urlPattern: '/api/data', statusCode: 503, probability: 1, group: 'payments' }],
+  },
   seed: 1,
 });
+await enableSWGroup(page, 'payments');
 // ...interact...
 const log = await getSWChaosLog(page);
+await disableSWGroup(page, 'payments');
 await removeSWChaos(page);
 ```
 
 User's SW must `importScripts('/chaos-maker-sw.js')` (classic) or `import { installChaosSW } from '@chaos-maker/core/sw'` (module).
+
+Browser-side `enableGroup` and `disableGroup` affect page rules from `injectChaos`. `enableSWGroup` and `disableSWGroup` affect Service Worker rules from `injectSWChaos`.
 
 ## SSE and GraphQL
 

--- a/packages/puppeteer/test/rule-groups.spec.ts
+++ b/packages/puppeteer/test/rule-groups.spec.ts
@@ -120,6 +120,7 @@ function startSWRuntime(config: ChaosConfig): Runtime {
     __chaosMakerSWBridge?: { toggleGroup: (name: string, enabled: boolean, timeoutMs: number) => Promise<void> };
   }).__chaosMakerSWBridge = {
     async toggleGroup(name, enabled) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
       if (enabled) {
         utils.instance.enableGroup(name);
       } else {
@@ -199,6 +200,7 @@ describe('@chaos-maker/puppeteer rule groups', () => {
 
     expect(response.status).toBe(200);
     expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+    expect(runtime.log().some((event) => event.type === 'rule-group:gated')).toBe(true);
   });
 
   it('enable then disable group changes real fetch behavior', async () => {
@@ -247,6 +249,18 @@ describe('@chaos-maker/puppeteer rule groups', () => {
     expect(await readPageGroupState(page, 'non-existent-group')).toEqual({
       hasGroup: true,
       enabled: true,
+    });
+  });
+
+  it('disableGroup auto-registers a non-existent group as disabled', async () => {
+    const page = makePage();
+    track(startRuntime(configWithoutGroup()));
+
+    await disableGroup(page, 'ghost-group');
+
+    expect(await readPageGroupState(page, 'ghost-group')).toEqual({
+      hasGroup: true,
+      enabled: false,
     });
   });
 

--- a/packages/puppeteer/test/rule-groups.spec.ts
+++ b/packages/puppeteer/test/rule-groups.spec.ts
@@ -5,6 +5,7 @@ import {
   enableGroup,
   disableGroup,
   enableSWGroup,
+  disableSWGroup,
   type ChaosPage,
 } from '../src/index';
 
@@ -13,6 +14,7 @@ type ChaosUtilsHarness = {
   getLog: () => ChaosEvent[];
   enableGroup: (name: string) => { success: boolean; message: string };
   disableGroup: (name: string) => { success: boolean; message: string };
+  getGroupState: (name: string) => boolean | null;
 };
 
 type Runtime = {
@@ -83,6 +85,7 @@ function makeUtils(instance: ChaosMaker): ChaosUtilsHarness {
         return { success: false, message: error instanceof Error ? error.message : String(error) };
       }
     },
+    getGroupState: (name) => instance.getGroupState(name),
   };
 }
 
@@ -158,6 +161,23 @@ function hasAppliedFailure(log: ChaosEvent[], statusCode: number): boolean {
   );
 }
 
+function countAppliedFailures(log: ChaosEvent[], statusCode: number): number {
+  return log.filter(
+    (event) => event.type === 'network:failure' && event.applied && event.detail.statusCode === statusCode,
+  ).length;
+}
+
+async function readPageGroupState(page: ChaosPage, name: string): Promise<{ hasGroup: boolean; enabled: boolean | null }> {
+  return page.evaluate((n: unknown) => {
+    const groupName = n as string;
+    const utils = (globalThis as unknown as { chaosUtils?: ChaosUtilsHarness }).chaosUtils;
+    return {
+      hasGroup: utils?.instance.hasGroup(groupName) ?? false,
+      enabled: utils?.getGroupState(groupName) ?? null,
+    };
+  }, name as unknown);
+}
+
 describe('@chaos-maker/puppeteer rule groups', () => {
   it('enable group executes grouped rule', async () => {
     const page = makePage();
@@ -179,6 +199,20 @@ describe('@chaos-maker/puppeteer rule groups', () => {
 
     expect(response.status).toBe(200);
     expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+  });
+
+  it('enable then disable group changes real fetch behavior', async () => {
+    const page = makePage();
+    const runtime = track(startRuntime(configWithPaymentGroupInitiallyDisabled()));
+
+    await enableGroup(page, 'payments');
+    const enabled = await runtime.request('/api/pay');
+    await disableGroup(page, 'payments');
+    const disabled = await runtime.request('/api/pay');
+
+    expect(enabled.status).toBe(503);
+    expect(disabled.status).toBe(200);
+    expect(countAppliedFailures(runtime.log(), 503)).toBe(1);
   });
 
   it('rules without inGroup still execute through the default group', async () => {
@@ -204,17 +238,32 @@ describe('@chaos-maker/puppeteer rule groups', () => {
     expect(hasAppliedFailure(runtime.log(), 401)).toBe(true);
   });
 
+  it('enableGroup auto-registers a non-existent group as enabled', async () => {
+    const page = makePage();
+    track(startRuntime(configWithoutGroup()));
+
+    await enableGroup(page, 'non-existent-group');
+
+    expect(await readPageGroupState(page, 'non-existent-group')).toEqual({
+      hasGroup: true,
+      enabled: true,
+    });
+  });
+
   it('enableSWGroup enables grouped Service Worker chaos', async () => {
     const page = makePage();
     const runtime = track(startSWRuntime(configWithPaymentGroupInitiallyDisabled()));
 
     const before = await runtime.request('/api/pay');
     await enableSWGroup(page, 'payments');
-    const after = await runtime.request('/api/pay');
+    const afterEnable = await runtime.request('/api/pay');
+    await disableSWGroup(page, 'payments');
+    const afterDisable = await runtime.request('/api/pay');
 
     expect(before.status).toBe(200);
-    expect(after.status).toBe(503);
-    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+    expect(afterEnable.status).toBe(503);
+    expect(afterDisable.status).toBe(200);
+    expect(countAppliedFailures(runtime.log(), 503)).toBe(1);
   });
 
   it('invalid group names throw errors before page evaluation', async () => {

--- a/packages/puppeteer/test/rule-groups.spec.ts
+++ b/packages/puppeteer/test/rule-groups.spec.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ChaosConfigBuilder, ChaosMaker } from '@chaos-maker/core';
+import type { ChaosConfig, ChaosEvent } from '@chaos-maker/core';
+import {
+  enableGroup,
+  disableGroup,
+  enableSWGroup,
+  type ChaosPage,
+} from '../src/index';
+
+type ChaosUtilsHarness = {
+  instance: ChaosMaker;
+  getLog: () => ChaosEvent[];
+  enableGroup: (name: string) => { success: boolean; message: string };
+  disableGroup: (name: string) => { success: boolean; message: string };
+};
+
+type Runtime = {
+  request: (url: string) => Promise<Response>;
+  log: () => ChaosEvent[];
+  cleanup: () => void;
+};
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) {
+    cleanups.pop()?.();
+  }
+});
+
+function configWithPaymentGroupInitiallyDisabled(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .defineGroup('payments', { enabled: false })
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .withSeed(1)
+    .build();
+}
+
+function configWithPaymentGroup(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .withSeed(1)
+    .build();
+}
+
+function configWithoutGroup(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .failRequests('/api/pay', 503, 1)
+    .withSeed(1)
+    .build();
+}
+
+function configWithMultipleGroups(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .inGroup('auth')
+    .failRequests('/api/auth', 401, 1)
+    .withSeed(1)
+    .build();
+}
+
+function makeUtils(instance: ChaosMaker): ChaosUtilsHarness {
+  return {
+    instance,
+    getLog: () => instance.getLog(),
+    enableGroup(name) {
+      try {
+        instance.enableGroup(name);
+        return { success: true, message: 'enabled' };
+      } catch (error) {
+        return { success: false, message: error instanceof Error ? error.message : String(error) };
+      }
+    },
+    disableGroup(name) {
+      try {
+        instance.disableGroup(name);
+        return { success: true, message: 'disabled' };
+      } catch (error) {
+        return { success: false, message: error instanceof Error ? error.message : String(error) };
+      }
+    },
+  };
+}
+
+function startRuntime(config: ChaosConfig): Runtime {
+  const previousChaosUtils = (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils;
+  const target = {
+    fetch: async () => new Response('ok', { status: 200 }),
+  } as unknown as typeof globalThis;
+  const instance = new ChaosMaker(config, { target });
+  instance.start();
+  (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils = makeUtils(instance);
+
+  return {
+    request: (url) => target.fetch(url),
+    log: () => instance.getLog(),
+    cleanup: () => {
+      instance.stop();
+      if (previousChaosUtils) {
+        (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils = previousChaosUtils;
+      } else {
+        delete (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils;
+      }
+    },
+  };
+}
+
+function startSWRuntime(config: ChaosConfig): Runtime {
+  const runtime = startRuntime(config);
+  const previousBridge = (globalThis as { __chaosMakerSWBridge?: unknown }).__chaosMakerSWBridge;
+  const utils = (globalThis as { chaosUtils: ChaosUtilsHarness }).chaosUtils;
+  (globalThis as {
+    __chaosMakerSWBridge?: { toggleGroup: (name: string, enabled: boolean, timeoutMs: number) => Promise<void> };
+  }).__chaosMakerSWBridge = {
+    async toggleGroup(name, enabled) {
+      if (enabled) {
+        utils.instance.enableGroup(name);
+      } else {
+        utils.instance.disableGroup(name);
+      }
+    },
+  };
+  cleanups.push(() => {
+    if (previousBridge) {
+      (globalThis as { __chaosMakerSWBridge?: unknown }).__chaosMakerSWBridge = previousBridge;
+    } else {
+      delete (globalThis as { __chaosMakerSWBridge?: unknown }).__chaosMakerSWBridge;
+    }
+  });
+  return runtime;
+}
+
+function track(runtime: Runtime): Runtime {
+  cleanups.push(runtime.cleanup);
+  return runtime;
+}
+
+function makePage(): ChaosPage {
+  return {
+    evaluateOnNewDocument: async () => undefined,
+    evaluate: async (fn: unknown, ...args: unknown[]) => {
+      if (typeof fn === 'function') {
+        return (fn as (...args: unknown[]) => unknown)(...args) as never;
+      }
+      return undefined as never;
+    },
+    goto: async () => undefined,
+  };
+}
+
+function hasAppliedFailure(log: ChaosEvent[], statusCode: number): boolean {
+  return log.some(
+    (event) => event.type === 'network:failure' && event.applied && event.detail.statusCode === statusCode,
+  );
+}
+
+describe('@chaos-maker/puppeteer rule groups', () => {
+  it('enable group executes grouped rule', async () => {
+    const page = makePage();
+    const runtime = track(startRuntime(configWithPaymentGroupInitiallyDisabled()));
+
+    await enableGroup(page, 'payments');
+    const response = await runtime.request('/api/pay');
+
+    expect(response.status).toBe(503);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+  });
+
+  it('disable group skips grouped rule', async () => {
+    const page = makePage();
+    const runtime = track(startRuntime(configWithPaymentGroup()));
+
+    await disableGroup(page, 'payments');
+    const response = await runtime.request('/api/pay');
+
+    expect(response.status).toBe(200);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+  });
+
+  it('rules without inGroup still execute through the default group', async () => {
+    const runtime = track(startRuntime(configWithoutGroup()));
+
+    const response = await runtime.request('/api/pay');
+
+    expect(response.status).toBe(503);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+  });
+
+  it('multiple groups only apply enabled groups', async () => {
+    const page = makePage();
+    const runtime = track(startRuntime(configWithMultipleGroups()));
+
+    await disableGroup(page, 'payments');
+    const payments = await runtime.request('/api/pay');
+    const auth = await runtime.request('/api/auth');
+
+    expect(payments.status).toBe(200);
+    expect(auth.status).toBe(401);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+    expect(hasAppliedFailure(runtime.log(), 401)).toBe(true);
+  });
+
+  it('enableSWGroup enables grouped Service Worker chaos', async () => {
+    const page = makePage();
+    const runtime = track(startSWRuntime(configWithPaymentGroupInitiallyDisabled()));
+
+    const before = await runtime.request('/api/pay');
+    await enableSWGroup(page, 'payments');
+    const after = await runtime.request('/api/pay');
+
+    expect(before.status).toBe(200);
+    expect(after.status).toBe(503);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+  });
+
+  it('invalid group names throw errors before page evaluation', async () => {
+    const page = makePage();
+
+    await expect(enableGroup(page, '')).rejects.toThrow('[chaos-maker] group name cannot be empty');
+    await expect(enableGroup(page, null as unknown as string)).rejects.toThrow(
+      '[chaos-maker] group name must be a string',
+    );
+  });
+});

--- a/packages/puppeteer/vitest.config.ts
+++ b/packages/puppeteer/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['test/**/*.test.ts'],
+    include: ['test/**/*.test.ts', 'test/**/*.spec.ts'],
   },
 });

--- a/packages/webdriverio/README.md
+++ b/packages/webdriverio/README.md
@@ -63,6 +63,37 @@ await injectChaos(browser, { /* config */ });
 const log = await getChaosLog(browser);
 ```
 
+## Rule Groups
+
+Group rules by scenario and toggle them at runtime.
+
+```ts
+import { ChaosConfigBuilder } from '@chaos-maker/core';
+
+const config = new ChaosConfigBuilder()
+  .defineGroup('payments', { enabled: false })
+  .inGroup('payments')
+  .failRequests('/api/pay', 503, 1)
+  .inGroup('auth')
+  .failRequests('/api/session', 401, 1)
+  .build();
+
+await browser.url('/checkout');
+await browser.injectChaos(config);
+
+await browser.enableGroup('payments');
+await browser.disableGroup('payments');
+```
+
+For Service Worker rules, use the SW commands after `browser.injectSWChaos`:
+
+```ts
+await browser.enableSWGroup('payments');
+await browser.disableSWGroup('payments');
+```
+
+Browser-side `browser.enableGroup` and `browser.disableGroup` affect page rules from `browser.injectChaos`. `browser.enableSWGroup` and `browser.disableSWGroup` affect Service Worker rules from `browser.injectSWChaos`.
+
 ## Important: inject after navigation
 
 WebDriver has no cross-browser pre-navigation hook, so `@chaos-maker/webdriverio` injects chaos **after** `browser.url(...)` completes. Requests issued during the initial page load are not intercepted.
@@ -141,6 +172,14 @@ Read every chaos decision emitted since `injectChaos` was called — applied or 
 
 Read the PRNG seed used by the active chaos instance. Log this on test failure to replay the exact sequence of chaos decisions with a fixed seed.
 
+### `browser.enableGroup(name)` / `browser.disableGroup(name)`
+
+Toggle a browser-side Rule Group. Requires `registerChaosCommands(browser)`.
+
+### `browser.enableSWGroup(name, opts?)` / `browser.disableSWGroup(name, opts?)`
+
+Toggle a Service Worker Rule Group. Requires `registerSWChaosCommands(browser)`. Pass `opts.timeoutMs` to override the Service Worker acknowledgement timeout.
+
 ## Service Worker chaos
 
 Register the SW commands in `wdio.conf.ts`:
@@ -162,11 +201,16 @@ await browser.waitUntil(() =>
   browser.execute(() => !!navigator.serviceWorker.controller),
 );
 await browser.injectSWChaos({
-  network: { failures: [{ urlPattern: '/api/data', statusCode: 503, probability: 1 }] },
+  groups: [{ name: 'payments', enabled: false }],
+  network: {
+    failures: [{ urlPattern: '/api/data', statusCode: 503, probability: 1, group: 'payments' }],
+  },
   seed: 1,
 });
+await browser.enableSWGroup('payments');
 // ...interact...
 const log = await browser.getSWChaosLog();
+await browser.disableSWGroup('payments');
 await browser.removeSWChaos();
 ```
 

--- a/packages/webdriverio/test/index.test.ts
+++ b/packages/webdriverio/test/index.test.ts
@@ -101,10 +101,17 @@ describe('@chaos-maker/webdriverio', () => {
   });
 
   describe('registerChaosCommands', () => {
-    it('registers all four commands on the browser', () => {
+    it('registers all browser-side commands on the browser', () => {
       registerChaosCommands(fake.browser);
       const names = fake.addCommandCalls.map((c) => c.name);
-      expect(names).toEqual(['injectChaos', 'removeChaos', 'getChaosLog', 'getChaosSeed']);
+      expect(names).toEqual([
+        'injectChaos',
+        'removeChaos',
+        'getChaosLog',
+        'getChaosSeed',
+        'enableGroup',
+        'disableGroup',
+      ]);
     });
 
     it('throws when addCommand is missing', () => {

--- a/packages/webdriverio/test/rule-groups.spec.ts
+++ b/packages/webdriverio/test/rule-groups.spec.ts
@@ -146,6 +146,7 @@ function startSWRuntime(config: ChaosConfig): Runtime {
     __chaosMakerSWBridge?: { toggleGroup: (name: string, enabled: boolean, timeoutMs: number) => Promise<void> };
   }).__chaosMakerSWBridge = {
     async toggleGroup(name, enabled) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
       if (enabled) {
         utils.instance.enableGroup(name);
       } else {
@@ -232,6 +233,7 @@ describe('@chaos-maker/webdriverio rule groups', () => {
 
     expect(response.status).toBe(200);
     expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+    expect(runtime.log().some((event) => event.type === 'rule-group:gated')).toBe(true);
   });
 
   it('enable then disable group changes real fetch behavior', async () => {
@@ -284,6 +286,19 @@ describe('@chaos-maker/webdriverio rule groups', () => {
     expect(await readBrowserGroupState(browser, 'non-existent-group')).toEqual({
       hasGroup: true,
       enabled: true,
+    });
+  });
+
+  it('disableGroup auto-registers a non-existent group as disabled', async () => {
+    installBrowserGlobals();
+    const browser = makeBrowser();
+    track(startRuntime(configWithoutGroup()));
+
+    await disableGroup(browser, 'ghost-group');
+
+    expect(await readBrowserGroupState(browser, 'ghost-group')).toEqual({
+      hasGroup: true,
+      enabled: false,
     });
   });
 

--- a/packages/webdriverio/test/rule-groups.spec.ts
+++ b/packages/webdriverio/test/rule-groups.spec.ts
@@ -13,6 +13,7 @@ type ChaosUtilsHarness = {
   getLog: () => ChaosEvent[];
   enableGroup: (name: string) => { success: boolean; message: string };
   disableGroup: (name: string) => { success: boolean; message: string };
+  getGroupState: (name: string) => boolean | null;
 };
 
 type Runtime = {
@@ -87,6 +88,7 @@ function makeUtils(instance: ChaosMaker): ChaosUtilsHarness {
         return { success: false, message: error instanceof Error ? error.message : String(error) };
       }
     },
+    getGroupState: (name) => instance.getGroupState(name),
   };
 }
 
@@ -188,6 +190,25 @@ function hasAppliedFailure(log: ChaosEvent[], statusCode: number): boolean {
   );
 }
 
+function countAppliedFailures(log: ChaosEvent[], statusCode: number): number {
+  return log.filter(
+    (event) => event.type === 'network:failure' && event.applied && event.detail.statusCode === statusCode,
+  ).length;
+}
+
+async function readBrowserGroupState(
+  browser: ChaosBrowser,
+  name: string,
+): Promise<{ hasGroup: boolean; enabled: boolean | null }> {
+  return browser.execute((n: string) => {
+    const utils = (window as unknown as { chaosUtils?: ChaosUtilsHarness }).chaosUtils;
+    return {
+      hasGroup: utils?.instance.hasGroup(n) ?? false,
+      enabled: utils?.getGroupState(n) ?? null,
+    };
+  }, name);
+}
+
 describe('@chaos-maker/webdriverio rule groups', () => {
   it('enable group executes grouped rule', async () => {
     installBrowserGlobals();
@@ -211,6 +232,21 @@ describe('@chaos-maker/webdriverio rule groups', () => {
 
     expect(response.status).toBe(200);
     expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+  });
+
+  it('enable then disable group changes real fetch behavior', async () => {
+    installBrowserGlobals();
+    const browser = makeBrowser();
+    const runtime = track(startRuntime(configWithPaymentGroupInitiallyDisabled()));
+
+    await enableGroup(browser, 'payments');
+    const enabled = await runtime.request('/api/pay');
+    await disableGroup(browser, 'payments');
+    const disabled = await runtime.request('/api/pay');
+
+    expect(enabled.status).toBe(503);
+    expect(disabled.status).toBe(200);
+    expect(countAppliedFailures(runtime.log(), 503)).toBe(1);
   });
 
   it('rules without inGroup still execute through the default group', async () => {
@@ -238,6 +274,19 @@ describe('@chaos-maker/webdriverio rule groups', () => {
     expect(hasAppliedFailure(runtime.log(), 401)).toBe(true);
   });
 
+  it('enableGroup auto-registers a non-existent group as enabled', async () => {
+    installBrowserGlobals();
+    const browser = makeBrowser();
+    track(startRuntime(configWithoutGroup()));
+
+    await enableGroup(browser, 'non-existent-group');
+
+    expect(await readBrowserGroupState(browser, 'non-existent-group')).toEqual({
+      hasGroup: true,
+      enabled: true,
+    });
+  });
+
   it('enableSWGroup enables grouped Service Worker chaos', async () => {
     installBrowserGlobals();
     const browser = makeBrowser();
@@ -246,11 +295,14 @@ describe('@chaos-maker/webdriverio rule groups', () => {
 
     const before = await runtime.request('/api/pay');
     await browser.commandCalls.enableSWGroup('payments');
-    const after = await runtime.request('/api/pay');
+    const afterEnable = await runtime.request('/api/pay');
+    await browser.commandCalls.disableSWGroup('payments');
+    const afterDisable = await runtime.request('/api/pay');
 
     expect(before.status).toBe(200);
-    expect(after.status).toBe(503);
-    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+    expect(afterEnable.status).toBe(503);
+    expect(afterDisable.status).toBe(200);
+    expect(countAppliedFailures(runtime.log(), 503)).toBe(1);
   });
 
   it('invalid group names throw errors before browser execution', async () => {

--- a/packages/webdriverio/test/rule-groups.spec.ts
+++ b/packages/webdriverio/test/rule-groups.spec.ts
@@ -29,8 +29,23 @@ type FakeBrowser = ChaosBrowser & {
 const cleanups: Array<() => void> = [];
 
 afterEach(() => {
+  const errors: unknown[] = [];
+
   while (cleanups.length > 0) {
-    cleanups.pop()?.();
+    const cleanup = cleanups.pop();
+    try {
+      cleanup?.();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+
+  if (errors.length > 1) {
+    throw new AggregateError(errors, 'Cleanup failures');
   }
 });
 

--- a/packages/webdriverio/test/rule-groups.spec.ts
+++ b/packages/webdriverio/test/rule-groups.spec.ts
@@ -1,0 +1,265 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ChaosConfigBuilder, ChaosMaker } from '@chaos-maker/core';
+import type { ChaosConfig, ChaosEvent } from '@chaos-maker/core';
+import {
+  enableGroup,
+  disableGroup,
+  registerSWChaosCommands,
+  type ChaosBrowser,
+} from '../src/index';
+
+type ChaosUtilsHarness = {
+  instance: ChaosMaker;
+  getLog: () => ChaosEvent[];
+  enableGroup: (name: string) => { success: boolean; message: string };
+  disableGroup: (name: string) => { success: boolean; message: string };
+};
+
+type Runtime = {
+  request: (url: string) => Promise<Response>;
+  log: () => ChaosEvent[];
+  cleanup: () => void;
+};
+
+type FakeBrowser = ChaosBrowser & {
+  commandCalls: Record<string, (...args: unknown[]) => unknown>;
+};
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) {
+    cleanups.pop()?.();
+  }
+});
+
+function configWithPaymentGroupInitiallyDisabled(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .defineGroup('payments', { enabled: false })
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .withSeed(1)
+    .build();
+}
+
+function configWithPaymentGroup(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .withSeed(1)
+    .build();
+}
+
+function configWithoutGroup(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .failRequests('/api/pay', 503, 1)
+    .withSeed(1)
+    .build();
+}
+
+function configWithMultipleGroups(): ChaosConfig {
+  return new ChaosConfigBuilder()
+    .inGroup('payments')
+    .failRequests('/api/pay', 503, 1)
+    .inGroup('auth')
+    .failRequests('/api/auth', 401, 1)
+    .withSeed(1)
+    .build();
+}
+
+function makeUtils(instance: ChaosMaker): ChaosUtilsHarness {
+  return {
+    instance,
+    getLog: () => instance.getLog(),
+    enableGroup(name) {
+      try {
+        instance.enableGroup(name);
+        return { success: true, message: 'enabled' };
+      } catch (error) {
+        return { success: false, message: error instanceof Error ? error.message : String(error) };
+      }
+    },
+    disableGroup(name) {
+      try {
+        instance.disableGroup(name);
+        return { success: true, message: 'disabled' };
+      } catch (error) {
+        return { success: false, message: error instanceof Error ? error.message : String(error) };
+      }
+    },
+  };
+}
+
+function installBrowserGlobals(): void {
+  const previousWindow = (globalThis as { window?: unknown }).window;
+  const previousDocument = (globalThis as { document?: unknown }).document;
+  (globalThis as { window?: typeof globalThis }).window = globalThis;
+  (globalThis as { document?: unknown }).document = {
+    createElement: () => ({ textContent: '', remove: () => undefined }),
+    head: { appendChild: () => undefined },
+    documentElement: { appendChild: () => undefined },
+  };
+  cleanups.push(() => {
+    if (previousWindow) {
+      (globalThis as { window?: unknown }).window = previousWindow;
+    } else {
+      delete (globalThis as { window?: unknown }).window;
+    }
+    if (previousDocument) {
+      (globalThis as { document?: unknown }).document = previousDocument;
+    } else {
+      delete (globalThis as { document?: unknown }).document;
+    }
+  });
+}
+
+function startRuntime(config: ChaosConfig): Runtime {
+  const previousChaosUtils = (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils;
+  const target = {
+    fetch: async () => new Response('ok', { status: 200 }),
+  } as unknown as typeof globalThis;
+  const instance = new ChaosMaker(config, { target });
+  instance.start();
+  (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils = makeUtils(instance);
+
+  return {
+    request: (url) => target.fetch(url),
+    log: () => instance.getLog(),
+    cleanup: () => {
+      instance.stop();
+      if (previousChaosUtils) {
+        (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils = previousChaosUtils;
+      } else {
+        delete (globalThis as { chaosUtils?: ChaosUtilsHarness }).chaosUtils;
+      }
+    },
+  };
+}
+
+function startSWRuntime(config: ChaosConfig): Runtime {
+  const runtime = startRuntime(config);
+  const previousBridge = (globalThis as { __chaosMakerSWBridge?: unknown }).__chaosMakerSWBridge;
+  const utils = (globalThis as { chaosUtils: ChaosUtilsHarness }).chaosUtils;
+  (globalThis as {
+    __chaosMakerSWBridge?: { toggleGroup: (name: string, enabled: boolean, timeoutMs: number) => Promise<void> };
+  }).__chaosMakerSWBridge = {
+    async toggleGroup(name, enabled) {
+      if (enabled) {
+        utils.instance.enableGroup(name);
+      } else {
+        utils.instance.disableGroup(name);
+      }
+    },
+  };
+  cleanups.push(() => {
+    if (previousBridge) {
+      (globalThis as { __chaosMakerSWBridge?: unknown }).__chaosMakerSWBridge = previousBridge;
+    } else {
+      delete (globalThis as { __chaosMakerSWBridge?: unknown }).__chaosMakerSWBridge;
+    }
+  });
+  return runtime;
+}
+
+function track(runtime: Runtime): Runtime {
+  cleanups.push(runtime.cleanup);
+  return runtime;
+}
+
+function makeBrowser(): FakeBrowser {
+  const commandCalls: Record<string, (...args: unknown[]) => unknown> = {};
+  return {
+    commandCalls,
+    execute: async (fn: unknown, ...args: unknown[]) => {
+      if (typeof fn === 'function') {
+        return (fn as (...args: unknown[]) => unknown)(...args) as never;
+      }
+      return undefined as never;
+    },
+    addCommand(name, fn) {
+      commandCalls[name] = (...args: unknown[]) => fn.apply(this, args);
+    },
+  } as FakeBrowser;
+}
+
+function hasAppliedFailure(log: ChaosEvent[], statusCode: number): boolean {
+  return log.some(
+    (event) => event.type === 'network:failure' && event.applied && event.detail.statusCode === statusCode,
+  );
+}
+
+describe('@chaos-maker/webdriverio rule groups', () => {
+  it('enable group executes grouped rule', async () => {
+    installBrowserGlobals();
+    const browser = makeBrowser();
+    const runtime = track(startRuntime(configWithPaymentGroupInitiallyDisabled()));
+
+    await enableGroup(browser, 'payments');
+    const response = await runtime.request('/api/pay');
+
+    expect(response.status).toBe(503);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+  });
+
+  it('disable group skips grouped rule', async () => {
+    installBrowserGlobals();
+    const browser = makeBrowser();
+    const runtime = track(startRuntime(configWithPaymentGroup()));
+
+    await disableGroup(browser, 'payments');
+    const response = await runtime.request('/api/pay');
+
+    expect(response.status).toBe(200);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+  });
+
+  it('rules without inGroup still execute through the default group', async () => {
+    installBrowserGlobals();
+    const runtime = track(startRuntime(configWithoutGroup()));
+
+    const response = await runtime.request('/api/pay');
+
+    expect(response.status).toBe(503);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+  });
+
+  it('multiple groups only apply enabled groups', async () => {
+    installBrowserGlobals();
+    const browser = makeBrowser();
+    const runtime = track(startRuntime(configWithMultipleGroups()));
+
+    await disableGroup(browser, 'payments');
+    const payments = await runtime.request('/api/pay');
+    const auth = await runtime.request('/api/auth');
+
+    expect(payments.status).toBe(200);
+    expect(auth.status).toBe(401);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(false);
+    expect(hasAppliedFailure(runtime.log(), 401)).toBe(true);
+  });
+
+  it('enableSWGroup enables grouped Service Worker chaos', async () => {
+    installBrowserGlobals();
+    const browser = makeBrowser();
+    registerSWChaosCommands(browser);
+    const runtime = track(startSWRuntime(configWithPaymentGroupInitiallyDisabled()));
+
+    const before = await runtime.request('/api/pay');
+    await browser.commandCalls.enableSWGroup('payments');
+    const after = await runtime.request('/api/pay');
+
+    expect(before.status).toBe(200);
+    expect(after.status).toBe(503);
+    expect(hasAppliedFailure(runtime.log(), 503)).toBe(true);
+  });
+
+  it('invalid group names throw errors before browser execution', async () => {
+    installBrowserGlobals();
+    const browser = makeBrowser();
+
+    await expect(enableGroup(browser, '')).rejects.toThrow('[chaos-maker] group name cannot be empty');
+    await expect(enableGroup(browser, null as unknown as string)).rejects.toThrow(
+      '[chaos-maker] group name must be a string',
+    );
+  });
+});

--- a/packages/webdriverio/vitest.config.ts
+++ b/packages/webdriverio/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['test/**/*.test.ts'],
+    include: ['test/**/*.test.ts', 'test/**/*.spec.ts'],
   },
 });


### PR DESCRIPTION
Implements Issues #46 and #47.

Adds adapter-level validation tests and completes documentation for Rule Groups usage across all supported adapters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rule Groups: runtime toggling of chaos rule groups via enableGroup/disableGroup across adapters (Cypress, Playwright, Puppeteer, WebdriverIO).
  * Service Worker group toggles via enableSWGroup/disableSWGroup.

* **Documentation**
  * Expanded Rule Groups docs and examples in root and adapter READMEs; added CHANGELOG entry.
  * Puppeteer docs now mention retrieving the chaos PRNG seed.

* **Tests**
  * Added end-to-end/spec tests covering Rule Groups, SW toggles, validation, and gated-event behavior across adapters.

* **Chores**
  * Test discovery broadened to include .spec.ts files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->