### PR TITLE
ci: deploy docs only on tag push to avoid Pages SHA dedupe

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,13 @@
 name: Docs
 
 on:
+  # Production deploys only fire on release tag pushes. Main pushes used to
+  # trigger a redeploy too, but that collided with tag-triggered deploys at
+  # the same SHA: GitHub Pages dedupes by `pages_build_version` (= commit
+  # SHA), so the second deploy was reported successful but never published.
+  # `workflow_dispatch` covers ad-hoc redeploys for infra/theme/script
+  # changes that ship between tags.
   push:
-    branches: [main]
     tags: ['v*.*.*']
   pull_request:
     branches: [main]
@@ -46,7 +51,7 @@ jobs:
 
       # PRs validate the branch's working-tree docs alongside tag archives so
       # that broken mdx/frontmatter/imports fail review. The published site is
-      # tag-only, so non-PR builds (push to main / tag) skip the `--dev`
+      # tag-only, so tag-push and workflow_dispatch builds skip the `--dev`
       # overlay and never include `/main/` in the deployable artifact.
       - name: Build Docs (PR preview, working tree + tags)
         if: github.event_name == 'pull_request'
@@ -64,14 +69,14 @@ jobs:
           path: docs/dist
 
       - name: Upload Pages Artifact
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch'
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/dist
 
   deploy:
     name: Docs Deploy
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Remove `branches: [main]` from `docs.yml` push trigger
- Restrict `Upload Pages Artifact` and `Docs Deploy` to tag pushes and `workflow_dispatch`
- Update inline comments to match the new flow

## Why

GitHub Pages dedupes deploys by `pages_build_version` (= commit SHA). When a release-PR merge produces commit `X` and the same `X` is then tagged, two Docs runs land on `X` back-to-back. The first run publishes (with whatever generator state existed at the time), the second run is reported as success but never publishes because Pages treats it as a duplicate. This bit v0.5.0: the main-merge run built `/latest/` from v0.4.0 (tag did not exist yet), and the v0.5.0 tag run that should have flipped `/latest/` to v0.5.0 was silently dropped.

Restricting deploys to tag pushes makes each release a unique commit SHA from Pages' perspective and removes the race entirely. PR validation (`build:dev`) still runs on every PR via this workflow, and `ci.yml`'s `docs-build` job continues to validate working-tree docs on main pushes. `workflow_dispatch` is the escape hatch for infra/theme/script changes that ship between tags.

## Follow-up after merge

Run `gh workflow run docs.yml --ref main` to publish v0.5.0 docs (the tag-triggered deploy from earlier was the silent no-op). The dispatched run produces a fresh commit SHA on `main`, sees the v0.5.0 tag, and publishes correctly.

## Test plan

- [ ] CI green on PR
- [ ] After merge: dispatch the workflow on `main`, verify `/v0-5-0/` returns 200 and `/latest/` banner shows v0.5.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation deployment workflow to trigger only on version tag releases and manual triggers, removing automatic deployments on main branch pushes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaos-maker-dev/chaos-maker/pull/69)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->