### PR TITLE
fix(deps): bump devalue to 5.8.1 (GHSA-77vg-94rm-hx3p)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
       "fast-xml-parser@<5.7.0": "5.7.0",
       "fast-xml-builder@<1.1.7": "1.1.7",
       "basic-ftp@<5.3.1": "5.3.1",
-      "ip-address@<10.1.1": "10.1.1"
+      "ip-address@<10.1.1": "10.1.1",
+      "devalue@>=5.6.3 <5.8.1": "5.8.1"
     }
   },
   "packageManager": "pnpm@10.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,7 @@ overrides:
   fast-xml-builder@<1.1.7: 1.1.7
   basic-ftp@<5.3.1: 5.3.1
   ip-address@<10.1.1: 10.1.1
+  devalue@>=5.6.3 <5.8.1: 5.8.1
 
 importers:
 
@@ -2179,8 +2180,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  devalue@5.8.0:
-    resolution: {integrity: sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==}
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -6703,7 +6704,7 @@ snapshots:
       clsx: 2.1.1
       common-ancestor-path: 2.0.0
       cookie: 1.1.1
-      devalue: 5.8.0
+      devalue: 5.8.1
       diff: 8.0.4
       dset: 3.1.4
       es-module-lexer: 2.1.0
@@ -7337,7 +7338,7 @@ snapshots:
   detect-libc@2.1.2:
     optional: true
 
-  devalue@5.8.0: {}
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Pin transitive `devalue` via pnpm override to >=5.8.1, patching high-severity DoS (CVE-2026-42570, GHSA-77vg-94rm-hx3p) in sparse-array deserialization.
- Resolves Dependabot alert #63.

## Test plan
- [x] CI green
- [ ] `pnpm install` clean