### PR TITLE
chore(build): run sync-sw-fixtures with bun runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
           path: packages
 
       - name: Sync SW bundle into fixtures
-        run: node scripts/sync-sw-fixtures.mjs
+        run: bun scripts/sync-sw-fixtures.mjs
 
       - name: Cache Playwright Browsers
         id: playwright-cache
@@ -263,7 +263,7 @@ jobs:
           path: packages
 
       - name: Sync SW bundle into fixtures
-        run: node scripts/sync-sw-fixtures.mjs
+        run: bun scripts/sync-sw-fixtures.mjs
 
       - name: Run Cypress E2E Tests (${{ matrix.browser }})
         working-directory: e2e-tests/cypress
@@ -300,7 +300,7 @@ jobs:
           path: packages
 
       - name: Sync SW bundle into fixtures
-        run: node scripts/sync-sw-fixtures.mjs
+        run: bun scripts/sync-sw-fixtures.mjs
 
       - name: Run WebdriverIO E2E Tests (${{ matrix.browser }})
         env:
@@ -335,7 +335,7 @@ jobs:
           path: packages
 
       - name: Sync SW bundle into fixtures
-        run: node scripts/sync-sw-fixtures.mjs
+        run: bun scripts/sync-sw-fixtures.mjs
 
       - name: Install Puppeteer Chrome
         if: steps.puppeteer-cache.outputs.cache-hit != 'true'

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "build:core": "bun --filter @chaos-maker/core build && node scripts/sync-sw-fixtures.mjs",
+    "build:core": "bun --filter @chaos-maker/core build && bun scripts/sync-sw-fixtures.mjs",
     "build:playwright": "bun --filter @chaos-maker/playwright build",
     "build:cypress": "bun --filter @chaos-maker/cypress build",
     "build:webdriverio": "bun --filter @chaos-maker/webdriverio build",


### PR DESCRIPTION
## Summary

- Swap `node scripts/sync-sw-fixtures.mjs` for `bun scripts/sync-sw-fixtures.mjs` in the root `build:core` script.
- First step of the Bun runtime adoption pass for our `.mjs` build/docs scripts.

## Why this is safe

The script uses only `node:fs/promises` (`copyFile`, `mkdir`), `node:path`, and `node:url` (`fileURLToPath`). All three modules are at full parity in Bun (100% of Node's own path tests, 92% of fs tests; `node:url` fully implemented). No `child_process`, no `worker_threads`, no native modules.

Output verified byte-identical:

```
3244cf70…  packages/core/dist/sw.js
3244cf70…  e2e-tests/fixtures/sw-app/chaos-maker-sw.js
9b67eda7…  packages/core/dist/sw.mjs
9b67eda7…  e2e-tests/fixtures/sw-app/chaos-maker-sw.mjs
```

## Test plan

- [x] `bun run build:core` succeeds end-to-end
- [x] sha256 of copied fixture files matches the corresponding `packages/core/dist/sw.*`
- [ ] CI green on existing build/E2E suites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the runtime used by core build and CI sync scripts from Node to Bun to streamline local build and end-to-end test setup across workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaos-maker-dev/chaos-maker/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->