### PR TITLE
chore: run remaining build/docs scripts with bun runtime

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,8 +15,8 @@
     "prebuild:dev": "bun run generate:versions:dev",
     "build:dev": "ASTRO_TELEMETRY_DISABLED=1 astro build",
     "preview": "ASTRO_TELEMETRY_DISABLED=1 astro preview",
-    "test:versions": "node scripts/test-versioning.mjs",
-    "test:versions:full": "bun run build:dev && node scripts/test-versioning.mjs"
+    "test:versions": "bun scripts/test-versioning.mjs",
+    "test:versions:full": "bun run build:dev && bun scripts/test-versioning.mjs"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.38.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,8 +6,8 @@
     "node": ">=22.12.0"
   },
   "scripts": {
-    "generate:versions": "node scripts/build-versioned-docs.mjs",
-    "generate:versions:dev": "node scripts/build-versioned-docs.mjs --dev",
+    "generate:versions": "bun scripts/build-versioned-docs.mjs",
+    "generate:versions:dev": "bun scripts/build-versioned-docs.mjs --dev",
     "predev": "bun run generate:versions:dev",
     "dev": "ASTRO_TELEMETRY_DISABLED=1 astro dev",
     "prebuild": "bun run generate:versions",

--- a/docs/scripts/build-versioned-docs.mjs
+++ b/docs/scripts/build-versioned-docs.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 /**
  * Generate versioned docs into docs/src/content/docs/ from git tags.
  *

--- a/docs/scripts/test-versioning.mjs
+++ b/docs/scripts/test-versioning.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 /**
  * Validates the docs versioning pipeline end-to-end.
  *

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "dev": "vite build --watch",
     "build": "vite build && vite build -c vite.config.sw.ts && tsc -p tsconfig.build.json && bun run build:schema",
-    "build:schema": "node scripts/build-schema.mjs",
+    "build:schema": "bun scripts/build-schema.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/core/scripts/build-schema.mjs
+++ b/packages/core/scripts/build-schema.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/scripts/sync-sw-fixtures.mjs
+++ b/scripts/sync-sw-fixtures.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 /**
  * Copies the built core SW bundles into the e2e fixture directory so the
  * static file server (python http.server / http-server on CI) can serve them


### PR DESCRIPTION
## Summary

- Continue the bun runtime adoption pass for our `.mjs` build/docs scripts.
- Stacked on top of #94. Targets `chore/bun-runtime-sync-sw-fixtures` as base; will rebase onto `main` once #94 lands.
- Swaps `node` → `bun` for the remaining three scripts:
  - `packages/core/scripts/build-schema.mjs` (invoked by `build:schema` in `@chaos-maker/core`)
  - `docs/scripts/test-versioning.mjs` (invoked by `test:versions` and `test:versions:full` in `chaos-maker-docs`)
  - `docs/scripts/build-versioned-docs.mjs` (invoked by `generate:versions` and `generate:versions:dev` in `chaos-maker-docs`)

## Why this is safe

All three scripts use only Node APIs that Bun implements at full or non-blocking-partial parity:

| Script | Node APIs used | Bun status |
|--------|----------------|-----------|
| `build-schema.mjs` | `node:fs` sync, `node:path`, `node:url`, dynamic import of compiled core, `zod-to-json-schema` | full |
| `test-versioning.mjs` | `node:child_process` (`execFileSync`), `node:fs`, `node:path`, `node:url` | `execFileSync` partial (missing `proc.gid`/`proc.uid`, no socket-handle IPC); we use stdout capture only |
| `build-versioned-docs.mjs` | `execFileSync` (git tag enumeration), `node:fs` (`cpSync`, `mkdtempSync`, etc), `node:os` `tmpdir`, `node:path`, `node:url` | same — full + non-blocking partial |

## Local validation

- `bun --filter @chaos-maker/core build:schema` → wrote both schema artifacts; sha256 byte-identical to `node`-produced output.
- `bun --filter chaos-maker-docs build:dev` → 285 pages built end-to-end (build-versioned-docs ran under bun).
- `bun --filter chaos-maker-docs test:versions:full` → PASS, all 8 versions green.

## Test plan

- [x] core schema artifacts hash-identical between bun and node
- [x] docs build:dev succeeds under bun (285 pages)
- [x] docs test:versions PASS under bun
- [x] CI green on existing build/E2E suites

## After #94 merges

Rebase this branch onto `main` and re-target the PR base to `main`.