### PR TITLE
chore(release): prep v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Security
-
-- Bump transitive `qs` to 6.15.2 and `uuid` to 11.1.1 via workspace overrides to clear Dependabot alerts #67 and #66. Also bump transitive `brace-expansion` to 5.0.6 so `bun audit` stays clean. These dependencies are used through developer tooling, so published package runtime surfaces are unchanged.
+## [0.8.0] - 2026-05-28
 
 ### Added
 
@@ -18,9 +16,15 @@ All notable changes to this project will be documented in this file.
 
 - **Package Manager Migration**: Migrated the workspace from pnpm to Bun as the package manager and script runner. Workspaces and dependency resolutions are now managed through Bun, using the isolated linker (`linker = "isolated"` in `bunfig.toml`) to maintain strict dependency isolation. Scripts in CI/CD workflows, developer commands in `README.md` and `CONTRIBUTING.md`, and local setup guides have been updated to `bun` / `bunx` equivalents. E2E tests and publishing still run on Node/npm for compatibility with browsers and OIDC Trusted Publishing.
 
+- **Bundler migration to Bun build**: the Service Worker bundle for `@chaos-maker/core` and the four adapter bundles (`@chaos-maker/playwright`, `@chaos-maker/cypress`, `@chaos-maker/webdriverio`, `@chaos-maker/puppeteer`) now build with `bun build` instead of Vite (SW) and tsup (adapters). `tsc --emitDeclarationOnly` still generates the `.d.ts` outputs so adapter type surfaces are unchanged. No published package shape, runtime behavior, or export map changes.
+
 - WebSocket and SSE rule types (`WebSocketDropConfig`, `WebSocketDelayConfig`, `WebSocketCorruptConfig`, `WebSocketCloseConfig`, `SSEDropConfig`, `SSEDelayConfig`, `SSECorruptConfig`, `SSECloseConfig`) are now `type` aliases over a discriminated union (`TransportRuleMatchers` intersection) rather than `interface extends`. A rule either declares one or more inline matcher fields (`urlPattern`, `hostname`, `queryParams`) or declares `matcher: 'name'`, never both; the inline-versus-named split is mutually exclusive at both the TypeScript level and at validation. `urlPattern` is optional as long as `hostname` or `queryParams` is present, matching the network rule surface. Existing configs that supplied `urlPattern` continue to validate and run unchanged. Consumers who previously did `interface MyRule extends WebSocketDropConfig` should switch to `type MyRule = WebSocketDropConfig & { ... }`.
 
 - **Cross-adapter matcher parity coverage**: matcher E2E coverage across Playwright, Cypress, WebdriverIO, and Puppeteer is now driven by a single declarative scenario catalog under `e2e-tests/fixtures/parity/`. Each adapter ships a thin interpreter that walks the scenario step list (`click`, `waitForText`, `waitForCount`, `expectText`, `request` for in-page fetch/XHR, `settle`) and a one-file spec that loops the catalog so every adapter reports the same ~20 test titles and runs identical chaos configs against the shared fixture. Coverage area: hostname, query-parameter, header (case-insensitive), resource-type (`fetch` vs `xhr`), built-in (`apiRequests`, `graphql`, `authRequests`, user-override), WebSocket (named matcher hostname, queryParams fires / skips, debug `matchedBy` attribution), SSE (named matcher hostname, queryParams fires / skips). Negative network cases vary the matcher rule rather than the request hostname so every request stays same-origin and observable. Replaces the three previous per-adapter spec files (`matchers.*`, `built-in-matchers.*`, `matchers-cross-transport.*`) on all four adapters, removing roughly 1,000 lines of duplicated test code without dropping any covered scenario. No public API change; the chaos-maker package surface is identical.
+
+### Security
+
+- Bump transitive `qs` to 6.15.2 and `uuid` to 11.1.1 via workspace overrides to clear Dependabot alerts #67 and #66. Also bump transitive `brace-expansion` to 5.0.6 so `bun audit` stays clean. These dependencies are used through developer tooling, so published package runtime surfaces are unchanged.
 
 ## [0.7.1] - 2026-05-19
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,11 @@ Thanks for your interest in contributing. This guide gets you from fork to merge
 
 ```text
 packages/
-  core/              # @chaos-maker/core, the framework-agnostic chaos engine (Vite, ESM + CJS + UMD + SW bundles)
-  playwright/        # @chaos-maker/playwright adapter (tsup)
-  cypress/           # @chaos-maker/cypress adapter (tsup)
-  webdriverio/       # @chaos-maker/webdriverio adapter (tsup)
-  puppeteer/         # @chaos-maker/puppeteer adapter (tsup)
+  core/              # @chaos-maker/core, the framework-agnostic chaos engine (Vite for ESM/CJS/UMD, Bun build for SW)
+  playwright/        # @chaos-maker/playwright adapter (Bun build)
+  cypress/           # @chaos-maker/cypress adapter (Bun build)
+  webdriverio/       # @chaos-maker/webdriverio adapter (Bun build)
+  puppeteer/         # @chaos-maker/puppeteer adapter (Bun build)
 
 e2e-tests/
   fixtures/          # Shared HTTP / WS / SSE / GraphQL fixture servers, SW app

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 Inject controlled chaos into web applications to test frontend resilience. Works with Playwright, Cypress, WebdriverIO, and Puppeteer with no backend changes.
 
-## What's new in v0.7.0
+## What's new in v0.8.0
 
-- **Scenario profiles and runtime overrides**: bundle several presets and rules behind one name with `profile`, register inline with `customProfiles`, and tune one parameter per call site via `profileOverrides`. [Profiles concept](https://chaos-maker-dev.github.io/chaos-maker/concepts/profiles/).
-- **Advanced matchers and named registry**: every network rule now accepts `hostname`, `queryParams`, `requestHeaders`, and `resourceTypes` filters alongside `urlPattern`. A top-level `matchers` registry holds reusable named matchers so several rules can share one targeting definition. [Matchers concept](https://chaos-maker-dev.github.io/chaos-maker/concepts/matchers/).
-- **Chaos timeline and reporting**: turn a chaos event log into a deterministic `ChaosReport` with `buildChaosReport`, then serialize it as JSON, Markdown, or a self-contained HTML timeline for PR comments and CI artifacts. [Timeline and reporting concept](https://chaos-maker-dev.github.io/chaos-maker/concepts/timeline-and-reporting/).
+- **Cross-transport matchers**: every WebSocket and SSE rule now accepts the same matcher targeting surface as network rules. Use inline `hostname`, `queryParams`, or a `matcher: 'name'` reference into the existing top-level `matchers` registry so one matcher can target network, WebSocket, and SSE without per-transport duplication. [WebSocket chaos concept](https://chaos-maker-dev.github.io/chaos-maker/concepts/websocket-chaos/) and [Matchers concept](https://chaos-maker-dev.github.io/chaos-maker/concepts/matchers/).
+- **Built-in matchers**: `graphql`, `apiRequests`, and `authRequests` ship preregistered so the most common targets need no `matchers` entry. A user `matchers` entry of the same name overrides one. [Built-in matchers](https://chaos-maker-dev.github.io/chaos-maker/concepts/matchers/#built-in-matchers).
+- **Cross-adapter matcher parity coverage**: matcher E2E coverage across Playwright, Cypress, WebdriverIO, and Puppeteer is now driven by a single declarative scenario catalog under `e2e-tests/fixtures/parity/`. No public API change; published package surface is identical.
 
 Full release notes in [CHANGELOG.md](CHANGELOG.md).
 
@@ -58,7 +58,7 @@ See the [Scenario profiles concept](https://chaos-maker-dev.github.io/chaos-make
 
 ## Advanced matchers
 
-Every network rule now accepts hostname, query parameter, request header, and resource-type matchers alongside `urlPattern` and `methods`. A separate `matchers` registry holds reusable named matchers so several rules can share one targeting definition.
+Every network, WebSocket, and SSE rule accepts hostname, query parameter, and (network-only) request header / resource-type matchers alongside `urlPattern` and `methods`. A separate `matchers` registry holds reusable named matchers so one matcher can target network, WebSocket, and SSE without per-transport duplication.
 
 ```typescript
 await injectChaos(page, {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -154,6 +154,50 @@ const config = new ChaosConfigBuilder()
 | SSE | `sse.*` | Drop, delay, corrupt, or close EventSource events |
 | GraphQL | `graphqlOperation` | Target one operation on a shared endpoint |
 
+## Matchers
+
+Every network, WebSocket, and SSE rule accepts targeting matchers alongside `urlPattern` and `methods`:
+
+- `hostname` (string or RegExp, case-insensitive on strings)
+- `queryParams` (record of `string | RegExp | boolean`)
+- `requestHeaders` (network only; case-insensitive keys)
+- `resourceTypes` (network only; `['fetch' | 'xhr']`)
+
+A top-level `matchers` registry holds reusable named matchers so one matcher can target network, WebSocket, and SSE without per-transport duplication:
+
+```ts
+new ChaosMaker({
+  matchers: {
+    customers: { hostname: 'api.example.com', urlPattern: '/api/customers' },
+  },
+  network: {
+    failures: [{ matcher: 'customers', statusCode: 503, probability: 1 }],
+  },
+});
+```
+
+A rule supplies either inline matcher fields OR `matcher: 'name'`, never both. Mixing surfaces `matcher_inline_conflict` at validation time.
+
+### Built-in matchers
+
+Three matchers ship preregistered and resolve by name without any `matchers` entry:
+
+- `graphql` (`urlPattern: '/graphql'`)
+- `apiRequests` (`urlPattern: '/api'`)
+- `authRequests` (`requestHeaders: { authorization: true }`)
+
+```ts
+new ChaosMaker({
+  network: {
+    latencies: [{ matcher: 'graphql', delayMs: 1200, probability: 1 }],
+  },
+});
+```
+
+`BUILT_IN_MATCHERS` is exported from `@chaos-maker/core` and every adapter. A user `matchers` entry of the same name transparently overrides a built-in. `authRequests` is meaningful on network rules only - WebSocket and SSE rules cannot target request headers, so a stream rule referencing it matches every connection.
+
+See the [Matchers concept](https://chaos-maker-dev.github.io/chaos-maker/concepts/matchers/) for the full surface, validation codes, and debug attribution.
+
 ## Configuration Reference
 
 ### NetworkFailureConfig

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/core",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "type": "module",
   "description": "A lightweight, framework-agnostic toolkit for injecting chaos into web applications to test frontend resilience",
   "keywords": [

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/cypress",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "type": "module",
   "description": "Cypress adapter for @chaos-maker/core - custom commands for one-line chaos injection",
   "keywords": [

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/playwright",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "type": "module",
   "description": "Playwright adapter for @chaos-maker/core - one-line chaos injection in E2E tests",
   "keywords": [

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/puppeteer",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "type": "module",
   "description": "Puppeteer adapter for @chaos-maker/core - one-line chaos injection in Puppeteer tests",
   "keywords": [

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chaos-maker/webdriverio",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "type": "module",
   "description": "WebdriverIO adapter for @chaos-maker/core - one-line chaos injection in WDIO tests",
   "keywords": [


### PR DESCRIPTION
## Summary

Release-readiness pass for v0.8.0. Forty-five commits have landed on `main` since v0.7.1; this PR rolls them up into a tagged release.

### Public surface changes (full detail in `CHANGELOG.md`)

**Added**
- Cross-transport matchers: every WebSocket and SSE rule accepts inline `hostname` / `queryParams` and `matcher: 'name'` references. New `TransportRuleMatchers` type re-exported from core and every adapter.
- Built-in matchers: `graphql`, `apiRequests`, and `authRequests` ship preregistered. New `BUILT_IN_MATCHERS` value export from core and every adapter.

**Changed**
- Package manager migrated from pnpm to Bun (workspaces, scripts, CI).
- SW + adapter bundles migrated from Vite/tsup to `bun build`.
- WS/SSE rule types switched from `interface extends` to `type` aliases (soft typing break - consumers using `interface X extends WebSocketDropConfig` switch to `type X = WebSocketDropConfig & { ... }`).
- Matcher E2E coverage across all four adapters now runs from a single shared parity catalog under `e2e-tests/fixtures/parity/`.

**Security**
- Workspace overrides bump transitive `qs` to 6.15.2, `uuid` to 11.1.1, and `brace-expansion` to 5.0.6 (Dependabot alerts `#67`, `#66`; `bun audit` clean).

### What this PR changes

- Bump all five published packages (`@chaos-maker/core`, `@chaos-maker/playwright`, `@chaos-maker/cypress`, `@chaos-maker/webdriverio`, `@chaos-maker/puppeteer`) from `0.7.1` → `0.8.0`.
- Stamp `CHANGELOG.md` `[Unreleased]` → `[0.8.0] - 2026-05-28`. Bundler migration entry added under Changed.
- Refresh root `README.md` "What's new" block for v0.8.0; expand the Advanced matchers intro to cover the cross-transport surface.
- Refresh `packages/core/README.md` with a Matchers section (registry, inline fields, built-in catalog) so the npm landing reflects the v0.7/v0.8 public surface.
- Fix `CONTRIBUTING.md` project-structure block: adapter bundlers are now `bun build`, not `tsup`; core notes Vite (ESM/CJS/UMD) + Bun build (SW).

## Test plan

- [x] CI green (lint, unit, build, docs, e2e × four adapters).
- [x] Confirm `0.8.0` appears in all five `packages/*/package.json` files on the rendered diff.
- [ ] After merge, tag `v0.8.0` and let `release.yml` publish the five packages via OIDC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes for v0.8.0 with enhanced matcher support for WebSocket and SSE rules.
  * Added matcher registry documentation with built-in options (graphql, apiRequests, authRequests).
  * Documented expanded cross-transport matcher capabilities.
  * Updated build tooling references in project documentation.

* **Chores**
  * Version bumped to 0.8.0 across all packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chaos-maker-dev/chaos-maker/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->